### PR TITLE
Add link to comprehensive example as tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The overall documentation of the platform is available [here](https://bbp-nexus.
 Please check out our tutorials:
  - [Nexus KG Schema Format](https://bbp-nexus.epfl.ch/staging/schema-documentation/documentation/shacl-schemas.html#nexus-kg-schemas)
  - [Jupyter notebook with basic operations using Nexus](https://github.com/BlueBrain/nexus/blob/master/tutorial/basic_operations_nexus_v0.ipynb)
+ - Comprehensive example (real use case): [workflow (IPython notebook)](https://github.com/BlueBrain/nat/blob/master/kg/Literature%20Annotation%20-%20Knowledge%20Graph.ipynb) and [productivity toolkit (Python modules)](https://github.com/BlueBrain/nat/blob/master/kg/README.md).
 
 ## Technical Introduction
 


### PR DESCRIPTION
Hi,

I suggest to add links to the IPython notebook I created for the Literature Annotation domain and to the **productivity toolkit** I designed to support this **common workflow** of users of Nexus wanting to publish their data in a Knowledge Graph backed by it.

I think it would be of great help for users to see **all in one place**:
- the SHACL schemas (Neuroshapes),
- the original data (NeuroCurator / NAT),
- the transformed data (samples in the notebook),
- the transformation logic to make source data correspond to the schemas,
- the general workflow to follow to achieve **from 0 to Nexus**,
- the common issues a user have to face and how to solve them with the productivity toolkit.

To the best of my knowledge, there is indeed no **public resource** achieving this **unique view** on all these axes yet. Adding this reference in the 'Tutorials' section will **guide new users** and will make **existing users more productive**. It will also **decrease the need of support** for common mistakes and operations.