### PR TITLE
Update to fix Documentation link

### DIFF
--- a/src/main/paradox/index.html
+++ b/src/main/paradox/index.html
@@ -25,7 +25,7 @@
 				<h1 id="instance-name">Blue Brain Nexus</h1>
 			</div>
 			<nav class="menu-block">
-				<a href="https://github.com/BlueBrain/nexus" target="_blank">
+				<a href="https://bluebrain.github.io/nexus/docs/" target="_blank">
 					<span>Documentation</span>
 				</a>
         <a href="https://github.com/BlueBrain/nexus" target="_blank">


### PR DESCRIPTION
Updated Documentation link at the top of the page to point to https://bluebrain.github.io/nexus/docs/