### PR TITLE
Add EPFL logo to the header

### DIFF
--- a/src/main/paradox/index.html
+++ b/src/main/paradox/index.html
@@ -32,6 +32,9 @@
 					<span>GitHub</span>
 					<i class="fab fa-github"></i>
 				</a>
+				<a href="https://www.epfl.ch/" target="_blank">
+					<img src="assets/img/logo_EPFL.accea7ac.png" alt="EPFL" style="background-color: white; padding: 3px; height: 3em; width: auto; margin: 0;">
+				</a>
 			</nav>
 		</header>
 		<section class="hero">


### PR DESCRIPTION
Adds an EPFL link with the logo there in the top right

![screenshot 2019-02-15 at 12 08 05](https://user-images.githubusercontent.com/5485824/52853218-2ff56480-311b-11e9-88cc-09b13f597617.png)
