### PR TITLE
doc: remove all "TBC" pages, keep only real doc.

### DIFF
--- a/src/main/paradox/docs/additional-info/faq.md
+++ b/src/main/paradox/docs/additional-info/faq.md
@@ -1,3 +1,2 @@
 # Frequently asked questions
 
-TBC.

--- a/src/main/paradox/docs/additional-info/incremental-domain-definition.md
+++ b/src/main/paradox/docs/additional-info/incremental-domain-definition.md
@@ -1,3 +1,0 @@
-# Incremental domain definition
-
-TBC.

--- a/src/main/paradox/docs/additional-info/index.md
+++ b/src/main/paradox/docs/additional-info/index.md
@@ -1,6 +1,5 @@
 @@@ index
 
-* [Incremental domain definition](incremental-domain-definition.md)
 * [Web applications development best practices](web-applications-standards.md)
 * [Frequently asked questions](faq.md)
 

--- a/src/main/paradox/docs/architecture/index.md
+++ b/src/main/paradox/docs/architecture/index.md
@@ -11,5 +11,3 @@
 The architecture section is to provide a comprehensive architectural overview of the Nexus platform. It presents a
 number of architectural views to depict various aspects of the system. It is intended to convey the significant
 architectural decisions which have been made on the system.
-
-TBC.

--- a/src/main/paradox/docs/getting-started/example.md
+++ b/src/main/paradox/docs/getting-started/example.md
@@ -1,3 +1,0 @@
-# Data management example
-
-TBC.

--- a/src/main/paradox/docs/getting-started/shacl.md
+++ b/src/main/paradox/docs/getting-started/shacl.md
@@ -1,3 +1,0 @@
-# Data validation with SHACL
-
-TBC.


### PR DESCRIPTION
Exception: the FAQ page which is about to get some content.

There is no valid reason to keep unfinished pages in the documentation of a released public product.