### PR TITLE
Updated docker compose templates

### DIFF
--- a/src/main/paradox/docs/getting-started/running-nexus/docker-compose/docker-compose.yaml
+++ b/src/main/paradox/docs/getting-started/running-nexus/docker-compose/docker-compose.yaml
@@ -1,45 +1,42 @@
 version: "2"
 services:
   kg:
-    image: bluebrain/nexus-kg:1.1
+    image: bluebrain/nexus-kg:1.2
     entrypoint: ["wait-for-it.sh", "-s", "-t", "0", "admin:8080", "--", "./bin/kg"]
     environment:
       CASSANDRA_CONTACT_POINT1: "cassandra:9042"
       BIND_INTERFACE: "0.0.0.0"
       PUBLIC_URI: "http://localhost"
-      SERVICE_DESCRIPTION_URI: "http://localhost"
-      IAM_INTERNAL_IRI: "http://iam:8080/v1"
-      IAM_PUBLIC_IRI: "http://localhost/v1"
-      ADMIN_INTERNAL_IRI: "http://admin:8080/v1"
-      ADMIN_PUBLIC_IRI: "http://localhost/v1"
+      IAM_INTERNAL_IRI: "http://iam:8080"
+      IAM_PUBLIC_IRI: "http://localhost"
+      ADMIN_INTERNAL_IRI: "http://admin:8080"
+      ADMIN_PUBLIC_IRI: "http://localhost"
       SPARQL_BASE_URI: "http://blazegraph:9999/blazegraph"
       ELASTIC_SEARCH_BASE_URI: "http://elasticsearch:9200"
       JAVA_OPTS: "-XX:+UseStringDeduplication -Xms512m -Xmx2G"
 
   iam:
-    image: bluebrain/nexus-iam:1.1
+    image: bluebrain/nexus-iam:1.2
     entrypoint: ["wait-for-it.sh", "-s", "-t", "0", "cassandra:9042", "--", "./bin/iam"]
     environment:
       CASSANDRA_CONTACT_POINT1: "cassandra:9042"
       BIND_INTERFACE: "0.0.0.0"
       PUBLIC_URI: "http://localhost"
-      SERVICE_DESCRIPTION_URI: "http://localhost/iam"
       JAVA_OPTS: "-Xms512m -Xmx1G"
 
   admin:
-    image: bluebrain/nexus-admin:1.1
+    image: bluebrain/nexus-admin:1.2
     entrypoint: ["wait-for-it.sh", "-s", "-t", "0", "iam:8080", "--", "./bin/admin"]
     environment:
       CASSANDRA_CONTACT_POINT1: "cassandra:9042"
       BIND_INTERFACE: "0.0.0.0"
       PUBLIC_URI: "http://localhost"
-      SERVICE_DESCRIPTION_URI: "http://localhost/admin"
-      IAM_INTERNAL_IRI: "http://iam:8080/v1"
-      IAM_PUBLIC_IRI: "http://localhost/v1"
+      IAM_INTERNAL_IRI: "http://iam:8080"
+      IAM_PUBLIC_IRI: "http://localhost"
       JAVA_OPTS: "-Xms512m -Xmx512m"
 
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.2.0"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:7.4.0"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
@@ -53,16 +50,18 @@ services:
       CASSANDRA_BROADCAST_ADDRESS: cassandra
 
   blazegraph:
-    image: "nawer/blazegraph:2.1.5"
+    image: bluebrain/blazegraph-nexus:2.1.5
 
   web:
-    image: "bluebrain/nexus-web:1.1.1"
+    image: bluebrain/nexus-web:1.1.1
     environment:
       BASE_PATH: "/"
       HOST_NAME: "http://localhost"
       API_ENDPOINT: "http://localhost/v1"
 
   router:
-    image: "bluebrain/nexus-router:1.0"
+    image: nginx:stable
     ports:
       - 80:80
+    volumes:
+      - ${PWD}/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/src/main/paradox/docs/getting-started/running-nexus/docker-swarm/docker-compose.yaml
+++ b/src/main/paradox/docs/getting-started/running-nexus/docker-swarm/docker-compose.yaml
@@ -1,23 +1,22 @@
 version: "3.3"
 services:
   kg:
-    image: bluebrain/nexus-kg:1.1
+    image: bluebrain/nexus-kg:1.2
     entrypoint: ["wait-for-it.sh", "-s", "-t", "0", "admin:8080", "--", "./bin/kg"]
     environment:
       CASSANDRA_CONTACT_POINT1: "cassandra:9042"
       BIND_INTERFACE: "0.0.0.0"
       PUBLIC_URI: "http://localhost"
-      SERVICE_DESCRIPTION_URI: "http://localhost"
-      IAM_INTERNAL_IRI: "http://iam:8080/v1"
-      IAM_PUBLIC_IRI: "http://localhost/v1"
-      ADMIN_INTERNAL_IRI: "http://admin:8080/v1"
-      ADMIN_PUBLIC_IRI: "http://localhost/v1"
+      IAM_INTERNAL_IRI: "http://iam:8080"
+      IAM_PUBLIC_IRI: "http://localhost"
+      ADMIN_INTERNAL_IRI: "http://admin:8080"
+      ADMIN_PUBLIC_IRI: "http://localhost"
       SPARQL_BASE_URI: "http://blazegraph:9999/blazegraph"
       ELASTIC_SEARCH_BASE_URI: "http://elasticsearch:9200"
       JAVA_OPTS: "-XX:+UseStringDeduplication -Xms2G -Xmx4G"
 
   iam:
-    image: bluebrain/nexus-iam:1.1
+    image: bluebrain/nexus-iam:1.2
     entrypoint: ["wait-for-it.sh", "-s", "-t", "0", "cassandra:9042", "--", "./bin/iam"]
     environment:
       CASSANDRA_CONTACT_POINT1: "cassandra:9042"
@@ -27,19 +26,18 @@ services:
       JAVA_OPTS: "-Xms1G -Xmx2G"
 
   admin:
-    image: bluebrain/nexus-admin:1.1
+    image: bluebrain/nexus-admin:1.2
     entrypoint: ["wait-for-it.sh", "-s", "-t", "0", "iam:8080", "--", "./bin/admin"]
     environment:
       CASSANDRA_CONTACT_POINT1: "cassandra:9042"
       BIND_INTERFACE: "0.0.0.0"
       PUBLIC_URI: "http://localhost"
-      SERVICE_DESCRIPTION_URI: "http://localhost/admin"
-      IAM_INTERNAL_IRI: "http://iam:8080/v1"
-      IAM_PUBLIC_IRI: "http://localhost/v1"
+      IAM_INTERNAL_IRI: "http://iam:8080"
+      IAM_PUBLIC_IRI: "http://localhost"
       JAVA_OPTS: "-Xms1G -Xmx1G"
 
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.2.0"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:7.4.0"
     environment:
       ES_JAVA_OPTS: "-Xms4G -Xmx4G"
       discovery.type: "single-node"
@@ -53,20 +51,22 @@ services:
       CASSANDRA_BROADCAST_ADDRESS: cassandra
 
   blazegraph:
-    image: "nawer/blazegraph:2.1.5"
+    image: bluebrain/blazegraph-nexus:2.1.5
 
   web:
-    image: "bluebrain/nexus-web:1.1.1"
+    image: bluebrain/nexus-web:1.1.1
     environment:
       BASE_PATH: "/"
       HOST_NAME: "http://localhost"
       API_ENDPOINT: "http://localhost/v1"
 
   router:
-    image: "bluebrain/nexus-router:1.0"
+    image: nginx:stable
     ports:
       - target: 80
         published: 80
         mode: host
     deploy:
-        mode: global
+      mode: global
+    volumes:
+      - ${PWD}/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/src/main/paradox/docs/getting-started/running-nexus/docker-swarm/nginx.conf
+++ b/src/main/paradox/docs/getting-started/running-nexus/docker-swarm/nginx.conf
@@ -6,6 +6,12 @@ server {
     location / {
         proxy_pass http://web:8000;
     }
+    location /version {
+        proxy_pass http://kg:8080;
+    }
+    location /status {
+        proxy_pass http://kg:8080;
+    }
     location /v1 {
         proxy_pass http://kg:8080;
     }

--- a/src/main/paradox/docs/getting-started/running-nexus/index.md
+++ b/src/main/paradox/docs/getting-started/running-nexus/index.md
@@ -175,7 +175,12 @@ deployment. If you'd like help with creating persistent volumes, feel free to co
 
 While not recommended, we provide a [Docker Compose template](./docker-compose/docker-compose.yaml)
 in the old *version 2* format. It comes with lower memory settings and it's a convenient way to quickly try
-out Nexus on your own computer. Download the file into a directory of your choice, for instance `~/docker/nexus/`.
+out Nexus on your own computer.
+
+Download the file into a directory of your choice, for instance `~/docker/nexus/`.
+
+Download the [http proxy configuration](./docker-swarm/nginx.conf) to the same directory.
+
 You can then simply run `docker-compose up` within this directory:
 
 Command
@@ -205,7 +210,7 @@ Attaching to nexus_iam_1, nexus_kg_1, nexus_blazegraph_1, nexus_cassandra_1, nex
 
 ### Endpoints
 
-The provided reverse proxy (the `nexus-router` image) exposes several endpoints:
+The provided reverse proxy (the `nginx` image) exposes several endpoints:
 
 * [root](http://localhost): Nexus web interface
 * [v1](http://localhost/v1): API root
@@ -215,8 +220,8 @@ The provided reverse proxy (the `nexus-router` image) exposes several endpoints:
 * [elasticsearch](http://localhost/elasticsearch): Elasticsearch endpoint
 * [blazegraph](http://localhost/blazegraph): Blazegraph web interface
 
-If you'd like to customize the listening port or remove unnecessary endpoints, you can build your own
-Nginx based Docker image. See the [reference configuration](./docker-swarm/nginx.conf).
+If you'd like to customize the listening port or remove unnecessary endpoints, you can simply modify the `nginx.conf`
+file.
 
 ## Run Nexus locally with Minikube
 


### PR DESCRIPTION
The templates no longer uses the custom nginx router
image, but rather just mounts the nginx conf directly
into the nginx container.