### PR TITLE
Added successCondition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,18 +24,18 @@ scalafmt: {
 }
  */
 
-val catsVersion       = "2.1.0"
-val catsEffectVersion = "2.0.0"
+val catsVersion       = "2.1.1"
+val catsEffectVersion = "2.1.2"
 val catsRetryVersion  = "0.3.2"
 val circeVersion      = "0.13.0"
 val declineVersion    = "1.0.0"
-val fs2Version        = "2.2.1"
+val fs2Version        = "2.2.2"
 val http4sVersion     = "0.21.1"
 val log4catsVersion   = "1.0.1"
 val logbackVersion    = "1.2.3"
 val monixVersion      = "3.1.0"
-val pureconfigVersion = "0.12.1"
-val scalaTestVersion  = "3.1.0"
+val pureconfigVersion = "0.12.3"
+val scalaTestVersion  = "3.1.1"
 
 lazy val catsCore        = "org.typelevel"         %% "cats-core"              % catsVersion
 lazy val catsEffect      = "org.typelevel"         %% "cats-effect"            % catsEffectVersion

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/ClientRetryCondition.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/ClientRetryCondition.scala
@@ -26,6 +26,25 @@ trait ClientRetryCondition {
       case Left(err) => apply(err)
       case _         => false
     }
+
+  /**
+    * Decide whether it is worth to avoid retrying or not depending on the passed [[ClientError]].
+    * The actual retry will depend on the [[ch.epfl.bluebrain.nexus.cli.config.RetryStrategyConfig]].
+
+    * @param error the client error
+    * @return true = do not retry; false = retry
+    */
+  def notRetry(error: ClientError): Boolean = !apply(error)
+
+  /**
+    * Decide whether it is worth to avoid retrying or not depending on the passed either of [[ClientError]].
+    * The actual retry will depend on the [[ch.epfl.bluebrain.nexus.cli.config.RetryStrategyConfig]].
+    *
+    * @param either an [[Either]] where the Left is a [[ClientError]]
+    * @return true = do not retry; false = retry
+    */
+  def notRetryFromEither[A](either: ClientErrOr[A]): Boolean = !fromEither(either)
+
 }
 
 // $COVERAGE-OFF$

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/ProjectClient.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/ProjectClient.scala
@@ -63,7 +63,7 @@ object ProjectClient {
     new ProjectClient[F] {
 
       private val endpoints                            = NexusEndpoints(config)
-      private val retryCondition                       = config.retry.retryCondition.fromEither[ProjectLabelRef] _
+      private val successCondition                     = config.retry.retryCondition.notRetryFromEither[ProjectLabelRef] _
       private implicit val retryPolicy: RetryPolicy[F] = config.retry.retryPolicy
       private implicit val logOnError: (ClientErrOr[ProjectLabelRef], RetryDetails) => F[Unit] =
         (eitherErr, details) => Logger[F].info(s"Client error '$eitherErr'. Retry details: '$details'")
@@ -83,7 +83,7 @@ object ProjectClient {
                     F.pure(Right((orgLabel, projectLabel)))
               }
             })
-            resp.retryingM(retryCondition)
+            resp.retryingM(successCondition)
         }
       }
     }


### PR DESCRIPTION
Fixed `retryingM`. I was passing was a `retryCondition` not a `successCondition`. From the docs:

```scala
def retryingM[M[_]: Monad, A](policy: RetryPolicy[M],
                              wasSuccessful: A => Boolean,
                              onFailure: (A, RetryDetails) => M[Unit])
                             (action: => M[A]): M[A]
```
I think It still makes sense to keep the app.conf and the model as a `ClientRetryCondition`, since it reads better:

```conf
{
   retry {
      strategy: "once",
      condition: "onServerError"
   }
}
```