### PR TITLE
Ported RDF library Iri

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,12 +31,16 @@ val circeVersion      = "0.13.0"
 val declineVersion    = "1.0.0"
 val fs2Version        = "2.2.2"
 val http4sVersion     = "0.21.1"
+val jenaVersion       = "3.14.0"
 val log4catsVersion   = "1.0.1"
 val logbackVersion    = "1.2.3"
+val magnoliaVersion   = "0.12.6"
 val monixVersion      = "3.1.0"
+val parboiledVersion  = "2.2.0"
 val pureconfigVersion = "0.12.3"
 val scalaTestVersion  = "3.1.1"
 
+lazy val alleycatsCore   = "org.typelevel"         %% "alleycats-core"         % catsVersion
 lazy val catsCore        = "org.typelevel"         %% "cats-core"              % catsVersion
 lazy val catsEffect      = "org.typelevel"         %% "cats-effect"            % catsEffectVersion
 lazy val catsRetry       = "com.github.cb372"      %% "cats-retry-core"        % catsRetryVersion
@@ -49,10 +53,13 @@ lazy val decline         = "com.monovore"          %% "decline"                %
 lazy val fs2             = "co.fs2"                %% "fs2-core"               % fs2Version
 lazy val http4sCirce     = "org.http4s"            %% "http4s-circe"           % http4sVersion
 lazy val http4sClient    = "org.http4s"            %% "http4s-blaze-client"    % http4sVersion
+lazy val jenaArq         = "org.apache.jena"       % "jena-arq"                % jenaVersion
 lazy val log4cats        = "io.chrisdavenport"     %% "log4cats-core"          % log4catsVersion
 lazy val log4catsSlf4j   = "io.chrisdavenport"     %% "log4cats-slf4j"         % log4catsVersion
 lazy val logback         = "ch.qos.logback"        % "logback-classic"         % logbackVersion
+lazy val magnolia        = "com.propensive"        %% "magnolia"               % magnoliaVersion
 lazy val monixEval       = "io.monix"              %% "monix-eval"             % monixVersion
+lazy val parboiled2      = "org.parboiled"         %% "parboiled"              % parboiledVersion
 lazy val pureconfig      = "com.github.pureconfig" %% "pureconfig"             % pureconfigVersion
 lazy val scalaTest       = "org.scalatest"         %% "scalatest"              % scalaTestVersion
 
@@ -88,6 +95,23 @@ lazy val docs = project
     git.remoteRepo  := "git@github.com:BlueBrain/nexus.git",
     ghpagesNoJekyll := true,
     ghpagesBranch   := "gh-pages"
+  )
+
+lazy val rdf = project
+  .in(file("rdf"))
+  .settings(name := "rdf", moduleName := "rdf")
+  .settings(noPublish)
+  .settings(
+    libraryDependencies ++= Seq(
+      alleycatsCore,
+      catsCore,
+      parboiled2,
+      circeCore    % Test,
+      circeParser  % Test,
+      circeLiteral % Test,
+      jenaArq      % Test,
+      scalaTest    % Test
+    )
   )
 
 lazy val cliShared = project
@@ -132,7 +156,7 @@ lazy val root = project
   .in(file("."))
   .settings(name := "nexus", moduleName := "nexus")
   .settings(noPublish)
-  .aggregate(docs, cli)
+  .aggregate(docs, cli, rdf)
 
 lazy val noPublish = Seq(publishLocal := {}, publish := {}, publishArtifact := false)
 

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/PctString.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/PctString.scala
@@ -1,0 +1,28 @@
+package ch.epfl.bluebrain.nexus.rdf
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.parboiled2.CharPredicate
+
+object PctString {
+
+  private val UTF8 = UTF_8.displayName()
+  private[rdf] def uriStringIgnore(s: String, toIgnore: CharPredicate): String = {
+    val (_, encoded) = s.foldLeft((0, new StringBuilder())) {
+      case ((forceIgnore, sb), b) if forceIgnore > 0       => (forceIgnore - 1, sb.append(b))
+      case ((_, sb), b) if toIgnore.matchesAny(b.toString) => (0, sb.append(b))
+      case ((_, sb), b) if b == '%'                        => (2, sb.append(b))
+      case ((_, sb), b)                                    => (0, pctEncode(sb, b))
+    }
+    encoded.toString()
+  }
+
+  private def pctEncode(sb: StringBuilder, char: Char): StringBuilder =
+    if (char == ' ') sb.append("%20")
+    else sb.append(URLEncoder.encode(char.toString, UTF8))
+
+  implicit final class StringEncodingOpts(private val value: String) extends AnyVal {
+    def pctEncodeIgnore(toIgnore: CharPredicate): String = uriStringIgnore(value, toIgnore)
+  }
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Vocabulary.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Vocabulary.scala
@@ -1,0 +1,91 @@
+package ch.epfl.bluebrain.nexus.rdf
+
+import ch.epfl.bluebrain.nexus.rdf.syntax.iri._
+
+// $COVERAGE-OFF$
+object Vocabulary {
+
+  /**
+    * RDF vocabulary from W3C
+    */
+  object rdf {
+    val base       = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    val first      = url"${base}first"
+    val rest       = url"${base}rest"
+    val nil        = url"${base}nil"
+    val tpe        = url"${base}type"
+    val langString = url"${base}langString"
+    val value      = url"${base}value"
+  }
+
+  /**
+    * OWL vocabulary from W3C
+    */
+  object owl {
+    val base     = "http://www.w3.org/2002/07/owl#"
+    val imports  = url"${base}imports"
+    val sameAs   = url"${base}sameAs"
+    val hasValue = url"${base}hasValue"
+    val oneOf    = url"${base}oneOf"
+    val Ontology = url"${base}Ontology"
+    val Class    = url"${base}Class"
+  }
+
+  /**
+    * XSD vocabulary from W3C
+    */
+  object xsd {
+    val base               = "http://www.w3.org/2001/XMLSchema#"
+    val dateTime           = url"${base}dateTime"
+    val date               = url"${base}date"
+    val time               = url"${base}time"
+    val string             = url"${base}string"
+    val boolean            = url"${base}boolean"
+    val byte               = url"${base}byte"
+    val short              = url"${base}short"
+    val int                = url"${base}int"
+    val integer            = url"${base}integer"
+    val long               = url"${base}long"
+    val decimal            = url"${base}decimal"
+    val double             = url"${base}double"
+    val float              = url"${base}float"
+    val negativeInteger    = url"${base}negativeInteger"
+    val nonNegativeInteger = url"${base}nonNegativeInteger"
+    val nonPositiveInteger = url"${base}nonPositiveInteger"
+    val positiveInteger    = url"${base}positiveInteger"
+    val unsignedByte       = url"${base}unsignedByte"
+    val unsignedShort      = url"${base}unsignedShort"
+    val unsignedInt        = url"${base}unsignedInt"
+    val unsignedLong       = url"${base}unsignedLong"
+  }
+
+  /**
+    * XMLSchema vocabulary
+    */
+  object xml {
+    val base = "http://www.w3.org/2001/XMLSchema#"
+    val int  = url"${base}int"
+  }
+
+  /**
+    * Schema.org vocabulary
+    */
+  object schema {
+    val base              = "http://schema.org/"
+    val age               = url"${base}age"
+    val description       = url"${base}description"
+    val name              = url"${base}name"
+    val unitText          = url"${base}unitText"
+    val value             = url"${base}value"
+    val Person            = url"${base}Person"
+    val QuantitativeValue = url"${base}QuantitativeValue"
+  }
+
+  /**
+    * Nexus vocabulary
+    */
+  object nxv {
+    val base = url"https://bluebrain.github.io/nexus/vocabulary/"
+  }
+}
+// $COVERAGE-ON$

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Authority.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Authority.scala
@@ -1,0 +1,365 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.implicits._
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.PctString._
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority.Host._
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+
+import scala.collection.immutable.ArraySeq
+import scala.collection.{immutable, View}
+
+/**
+  * The Authority part of an IRI as defined by RFC 3987.
+  *
+  * @param userInfo the optional user info part
+  * @param host     the host part
+  * @param port     the optional port part
+  */
+final case class Authority(userInfo: Option[UserInfo], host: Host, port: Option[Port]) {
+
+  /**
+    * @return the string representation for the Authority segment compatible with the rfc3987
+    *         (using percent-encoding only for delimiters)
+    */
+  lazy val iriString: String = {
+    val ui = userInfo.map(_.iriString + "@").getOrElse("")
+    val p  = port.map(":" + _.value.toString).getOrElse("")
+    s"$ui${host.iriString}$p"
+  }
+
+  /**
+    * @return the string representation using percent-encoding for the Authority segment
+    *         when necessary according to rfc3986
+    */
+  lazy val uriString: String = {
+    {
+      val ui = userInfo.map(_.uriString + "@").getOrElse("")
+      val p  = port.map(":" + _.value.toString).getOrElse("")
+      s"$ui${host.uriString}$p"
+    }
+  }
+}
+
+object Authority {
+
+  final implicit val authorityShow: Show[Authority] = Show.show(_.iriString)
+
+  final implicit val authorityEq: Eq[Authority] = Eq.fromUniversalEquals
+
+  /**
+    * A user info representation as specified by RFC 3987.
+    *
+    * @param value the underlying string representation
+    */
+  final case class UserInfo private[iri] (value: String) {
+
+    /**
+      * As per the specification the user info is case sensitive.  This method allows comparing two user info values
+      * disregarding the character casing.
+      *
+      * @param that the user info to compare to
+      * @return true if the underlying values are equal (diregarding their case), false otherwise
+      */
+    def equalsIgnoreCase(that: UserInfo): Boolean =
+      this.value equalsIgnoreCase that.value
+
+    /**
+      * @return the string representation for the Userinfo segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
+      */
+    lazy val iriString: String = value.pctEncodeIgnore(`iuser_info_allowed`)
+
+    /**
+      * @return the string representation using percent-encoding for the Userinfo segment
+      *         when necessary according to rfc3986
+      */
+    lazy val uriString: String = value.pctEncodeIgnore(`user_info_allowed`)
+  }
+
+  object UserInfo {
+
+    /**
+      * Attempt to construct a new UserInfo from the argument validating the character encodings as per RFC 3987.
+      *
+      * @param string the string to parse as a user info.
+      * @return Right(UserInfo(value)) if the string conforms to specification, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, UserInfo] =
+      new IriParser(string).parseUserInfo
+
+    final implicit val userInfoShow: Show[UserInfo] = Show.show(_.iriString)
+    final implicit val userInfoEq: Eq[UserInfo]     = Eq.fromUniversalEquals
+  }
+
+  /**
+    * Host part of an Iri as defined in RFC 3987.
+    */
+  sealed abstract class Host extends Product with Serializable {
+
+    /**
+      * @return true if the host is an IPv4 address, false otherwise
+      */
+    def isIPv4: Boolean = false
+
+    /**
+      * @return true if the host is an IPv6 address, false otherwise
+      */
+    def isIPv6: Boolean = false
+
+    /**
+      * @return true if the host is a named host, false otherwise
+      */
+    def isNamed: Boolean = false
+
+    /**
+      * @return Some(this) if this is an IPv4Host, None otherwise
+      */
+    def asIPv4: Option[IPv4Host] = None
+
+    /**
+      * @return Some(this) if this is an IPv6Host, None otherwise
+      */
+    def asIPv6: Option[IPv6Host] = None
+
+    /**
+      * @return Some(this) if this is a NamedHost, None otherwise
+      */
+    def asNamed: Option[NamedHost] = None
+
+    def value: String
+
+    /**
+      * @return the string representation using percent-encoding for the Host segment
+      *         when necessary according to rfc3986
+      */
+    def uriString: String
+
+    /**
+      * @return the string representation for the Host segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
+      */
+    def iriString: String
+  }
+
+  object Host {
+
+    /**
+      * Constructs a new IPv4Host from the argument bytes.
+      *
+      * @param byte1 the first byte of the address
+      * @param byte2 the second byte of the address
+      * @param byte3 the third byte of the address
+      * @param byte4 the fourth byte of the address
+      * @return the IPv4Host represented by these bytes
+      */
+    final def ipv4(byte1: Byte, byte2: Byte, byte3: Byte, byte4: Byte): IPv4Host =
+      IPv4Host(byte1, byte2, byte3, byte4)
+
+    /**
+      * Attempt to construct a new IPv4Host from its 32bit representation.
+      *
+      * @param bytes a 32bit IPv4 address
+      * @return Right(IPv4Host(bytes)) if the bytes is a 4byte array, Left(error) otherwise
+      */
+    final def ipv4(bytes: Array[Byte]): Either[String, IPv4Host] =
+      IPv4Host(bytes)
+
+    /**
+      * Attempt to construct a new IPv4Host from its string representation as specified by RFC 3987.
+      *
+      * @param string the string to parse as an IPv4 address.
+      * @return Right(IPv4Host(bytes)) if the string conforms to specification, Left(error) otherwise
+      */
+    final def ipv4(string: String): Either[String, IPv4Host] =
+      IPv4Host(string)
+
+    /**
+      * Attempt to construct a new IPv6Host from its 128bit representation.
+      *
+      * @param bytes a 128bit IPv6 address
+      * @return Right(IPv6Host(bytes)) if the bytes is a 16byte array, Left(error) otherwise
+      */
+    def ipv6(bytes: Array[Byte]): Either[String, IPv6Host] =
+      IPv6Host(bytes)
+
+    /**
+      * Attempt to construct a new NamedHost from the argument validating the character encodings as per RFC 3987.
+      *
+      * @param string the string to parse as a named host.
+      * @return Right(NamedHost(value)) if the string conforms to specification, Left(error) otherwise
+      */
+    def named(string: String): Either[String, NamedHost] =
+      NamedHost(string)
+
+    /**
+      * An IPv4 host representation as specified by RFC 3987.
+      *
+      * @param bytes the underlying bytes
+      */
+    final case class IPv4Host private[iri] (bytes: immutable.Seq[Byte]) extends Host {
+      override def isIPv4: Boolean          = true
+      override def asIPv4: Option[IPv4Host] = Some(this)
+      override lazy val value: String       = bytes.map(_ & 0xFF).mkString(".")
+      override lazy val uriString: String   = value
+      override lazy val iriString: String   = value
+    }
+
+    object IPv4Host {
+
+      /**
+        * Attempt to construct a new IPv4Host from its 32bit representation.
+        *
+        * @param bytes a 32bit IPv4 address
+        * @return Right(IPv4Host(bytes)) if the bytes is a 4byte array, Left(error) otherwise
+        */
+      final def apply(bytes: Array[Byte]): Either[String, IPv4Host] =
+        Either
+          .catchNonFatal(fromBytes(bytes))
+          .leftMap(_ => "Illegal IPv4Host byte representation")
+
+      /**
+        * Attempt to construct a new IPv4Host from its string representation as specified by RFC 3987.
+        *
+        * @param string the string to parse as an IPv4 address.
+        * @return Right(IPv4Host(bytes)) if the string conforms to specification, Left(error) otherwise
+        */
+      final def apply(string: String): Either[String, IPv4Host] =
+        new IriParser(string).parseIPv4
+
+      /**
+        * Constructs a new IPv4Host from the argument bytes.
+        *
+        * @param byte1 the first byte of the address
+        * @param byte2 the second byte of the address
+        * @param byte3 the third byte of the address
+        * @param byte4 the fourth byte of the address
+        * @return the IPv4Host represented by these bytes
+        */
+      final def apply(byte1: Byte, byte2: Byte, byte3: Byte, byte4: Byte): IPv4Host =
+        new IPv4Host(ArraySeq.unsafeWrapArray(Array(byte1, byte2, byte3, byte4)))
+
+      private def fromBytes(bytes: Array[Byte]): IPv4Host = {
+        require(bytes.length == 4)
+        new IPv4Host(bytes.toIndexedSeq)
+      }
+
+      final implicit val ipv4HostShow: Show[IPv4Host] =
+        Show.show(_.iriString)
+
+      final implicit val ipv4HostEq: Eq[IPv4Host] =
+        Eq.fromUniversalEquals
+    }
+
+    /**
+      * An IPv6 host representation as specified by RFC 3987.
+      *
+      * @param bytes the underlying bytes
+      */
+    final case class IPv6Host private[iri] (bytes: immutable.Seq[Byte]) extends Host {
+      override def isIPv6: Boolean          = true
+      override def asIPv6: Option[IPv6Host] = Some(this)
+      override lazy val uriString: String   = value
+      override lazy val iriString: String   = value
+
+      override lazy val value: String =
+        bytesToString(bytes.view)
+
+      lazy val asMixedString: String =
+        bytesToString(bytes.view.slice(0, 12)) + ":" + bytes.view.slice(12, 16).map(_ & 0xFF).mkString(".")
+
+      private def bytesToString(bytes: View[Byte]): String =
+        bytes.grouped(2).map(two => Integer.toHexString(BigInt(two.toArray).intValue)).mkString(":")
+    }
+
+    object IPv6Host {
+
+      /**
+        * Attempt to construct a new IPv6Host from its 128bit representation.
+        *
+        * @param bytes a 128bit IPv6 address
+        * @return Right(IPv6Host(bytes)) if the bytes is a 16byte array, Left(error) otherwise
+        */
+      final def apply(bytes: Array[Byte]): Either[String, IPv6Host] =
+        Either
+          .catchNonFatal(fromBytes(bytes))
+          .leftMap(_ => "Illegal IPv6Host byte representation")
+
+      private def fromBytes(bytes: Array[Byte]): IPv6Host = {
+        require(bytes.length == 16)
+        new IPv6Host(bytes.toIndexedSeq)
+      }
+
+      final implicit val ipv6HostShow: Show[IPv6Host] =
+        Show.show(_.iriString)
+
+      final implicit val ipv6HostEq: Eq[IPv6Host] =
+        Eq.fromUniversalEquals
+    }
+
+    /**
+      * A named host representation as specified by RFC 3987.
+      *
+      * @param value the underlying string representation
+      */
+    final case class NamedHost private[iri] (value: String) extends Host {
+      override def isNamed: Boolean           = true
+      override def asNamed: Option[NamedHost] = Some(this)
+      override lazy val iriString: String     = value.pctEncodeIgnore(`inamed_host_allowed`)
+      override lazy val uriString: String     = value.pctEncodeIgnore(`named_host_allowed`)
+    }
+
+    object NamedHost {
+
+      /**
+        * Attempt to construct a new NamedHost from the argument validating the character encodings as per RFC 3987.
+        *
+        * @param string the string to parse as a named host.
+        * @return Right(NamedHost(value)) if the string conforms to specification, Left(error) otherwise
+        */
+      final def apply(string: String): Either[String, NamedHost] =
+        new IriParser(string).parseNamed
+
+      final implicit val namedHostShow: Show[NamedHost] =
+        Show.show(_.iriString)
+
+      final implicit val namedHostEq: Eq[NamedHost] =
+        Eq.fromUniversalEquals
+    }
+
+    final implicit val hostShow: Show[Host] = Show.show(_.iriString)
+  }
+
+  /**
+    * Port part of an Iri as defined by RFC 3987.
+    *
+    * @param value the underlying int value
+    */
+  final case class Port private[iri] (value: Int)
+
+  object Port {
+
+    /**
+      * Attempts to construct a port from the argument int value.  Valid values are [0, 65535].
+      *
+      * @param value the underlying port value
+      * @return Right(port) if successful, Left(error) otherwise
+      */
+    final def apply(value: Int): Either[String, Port] =
+      if (value >= 0 && value < 65536) Right(new Port(value))
+      else Left("Port value must in range [0, 65535]")
+
+    /**
+      * Attempts to construct a port from the argument string value.  Valid values are [0, 65535] without leading zeroes.
+      *
+      * @param string the string representation of the port
+      * @return Right(port) if successful, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, Port] =
+      new IriParser(string).parsePort
+
+    final implicit val portShow: Show[Port] = Show.show(_.value.toString)
+    final implicit val portEq: Eq[Port]     = Eq.fromUniversalEquals
+  }
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Component.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Component.scala
@@ -1,0 +1,39 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.PctString._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+
+/**
+  * Urn R or Q component as defined by RFC 8141.
+  */
+final case class Component private[iri] (value: String) {
+
+  /**
+    * @return the string representation for the Component segment compatible with the rfc3987
+    *         (using percent-encoding only for delimiters)
+    */
+  lazy val iriString: String = value.pctEncodeIgnore(`icomponent_allowed`)
+
+  /**
+    * @return the string representation using percent-encoding for the Component segment
+    *         when necessary according to rfc3986
+    */
+  lazy val uriString: String = value.pctEncodeIgnore(`component_allowed`)
+}
+
+object Component {
+
+  /**
+    * Attempts to parse the argument string as a Urn R or Q component as defined by RFC 8141, but with the character
+    * restrictions of RFC 3897.
+    *
+    * @param string the string to parse as a URN component
+    * @return Right(Component) if the parsing succeeds, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Component] =
+    new IriParser(string).parseComponent
+
+  final implicit val componentShow: Show[Component] = Show.show(_.iriString)
+  final implicit val componentEq: Eq[Component]     = Eq.fromUniversalEquals
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Curie.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Curie.scala
@@ -1,0 +1,81 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.syntax.show._
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.iri.Curie._
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri._
+
+/**
+  * A Compact URI as defined by W3C in ''CURIE Syntax 1.0''.
+  * A curie is form by a ''prefix'', a '':'' and a ''reference''.
+  * Example: xsd:integer
+  *
+  * @param prefix    the curie prefix
+  * @param reference the curie reference
+  */
+final case class Curie(prefix: Prefix, reference: RelativeIri) {
+
+  /**
+    * Converts the curie to an iri using the provided ''namespace'' and the curie ''reference''.
+    *
+    * @param namespace the namespace to produce the resulting iri
+    * @return an [[Uri]] when successfully joined the ''namespace'' and ''reference'' or
+    *         an string with the error message otherwise
+    */
+  def toIri(namespace: Uri): Either[String, Uri] =
+    Iri.uri(namespace.iriString + reference.iriString)
+
+  /**
+    * Converts the curie to an iri using the provided ''prefixMappings'' to resolve the value of the ''prefix''.
+    *
+    * @param prefixMappings the mappings to attempt to apply to the ''prefix'' value of the curie
+    * @return an [[Uri]] when successfully joined the resolution of the prefix with the ''reference'' or
+    *         an string with the error message otherwise
+    */
+  def toIri(prefixMappings: Map[Prefix, Uri]): Either[String, Uri] =
+    prefixMappings
+      .get(prefix)
+      .toRight(s"Could not find a namespace definition for '${prefix.value}'")
+      .flatMap(toIri)
+}
+
+object Curie {
+
+  /**
+    * Attempt to construct a new [[Curie]] from the argument validating the structure and the character encodings as per
+    * ''CURIE Syntax 1.0''.
+    *
+    * @param string the string to parse as a Curie.
+    * @return Right(Curie) if the string conforms to specification, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Curie] =
+    new IriParser(string).parseCurie
+
+  /**
+    * The Compact URI prefix as defined by W3C in ''CURIE Syntax 1.0''.
+    *
+    * @param value the prefix value
+    */
+  final case class Prefix private[iri] (value: String)
+
+  object Prefix {
+
+    /**
+      * Attempt to construct a new [[Prefix]] from the argument validating the structure and the character encodings as per
+      * ''CURIE Syntax 1.0''.
+      *
+      * @param string the string to parse as a Prefix.
+      * @return Right(prefix) if the string conforms to specification, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, Prefix] =
+      new IriParser(string).parseNcName
+
+    final implicit val prefixShow: Show[Prefix] = Show.show(_.value)
+    final implicit val prefixEq: Eq[Prefix]     = Eq.fromUniversalEquals
+  }
+
+  final implicit def curieShow(implicit p: Show[Prefix], r: Show[RelativeIri]): Show[Curie] =
+    Show.show { case Curie(prefix, reference) => prefix.show + ":" + reference.show }
+
+  final implicit val curieEq: Eq[Curie] = Eq.fromUniversalEquals
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Fragment.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Fragment.scala
@@ -1,0 +1,41 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.PctString._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+
+/**
+  * Fragment part of an Iri as defined by RFC 3987.
+  *
+  * @param value the string value of the fragment
+  */
+final case class Fragment private[iri] (value: String) {
+
+  /**
+    * @return the string representation for the Path segment compatible with the rfc3987
+    *         (using percent-encoding only for delimiters)
+    */
+  lazy val iriString: String = value.pctEncodeIgnore(`ifragment_allowed`)
+
+  /**
+    * @return the string representation using percent-encoding for the Fragment segment
+    *         when necessary according to rfc3986
+    */
+  lazy val uriString: String = value.pctEncodeIgnore(`fragment_allowed`)
+
+}
+
+object Fragment {
+
+  /**
+    * Attempts to parse the argument string as an `ifragment` as defined by RFC 3987.
+    *
+    * @param string the string to parse as a Fragment
+    * @return Right(Fragment) if the parsing succeeds, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Fragment] =
+    new IriParser(string).parseFragment
+
+  final implicit val fragmentShow: Show[Fragment] = Show.show(_.iriString)
+  final implicit val fragmentEq: Eq[Fragment]     = Eq.fromUniversalEquals
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Iri.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Iri.scala
@@ -1,0 +1,503 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.syntax.show._
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority.Port
+
+import scala.annotation.tailrec
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri._
+import ch.epfl.bluebrain.nexus.rdf.iri.Path._
+
+/**
+  * An Iri as defined by RFC 3987.
+  */
+sealed abstract class Iri extends Product with Serializable {
+
+  /**
+    * @return true if this Iri is an (absolute) Uri, false otherwise
+    */
+  def isUri: Boolean
+
+  /**
+    * @return Some(this) if this Iri is an (absolute) Uri, None otherwise
+    */
+  def asUri: Option[Uri]
+
+  /**
+    * @return true if this Iri is relative, false otherwise
+    */
+  def isRelative: Boolean = !isUri
+
+  /**
+    * @return Some(this) if this Iri is relative, None otherwise
+    */
+  def asRelative: Option[RelativeIri]
+
+  /**
+    * @return true if this Iri is an Url, false otherwise
+    */
+  def isUrl: Boolean
+
+  /**
+    * @return Some(this) if this Iri is an Url, None otherwise
+    */
+  def asUrl: Option[Url]
+
+  /**
+    * @return true if this Iri is an Urn, false otherwise
+    */
+  def isUrn: Boolean
+
+  /**
+    * @return Some(this) if this Iri is an Urn, None otherwise
+    */
+  def asUrn: Option[Urn]
+
+  /**
+    * @return the string representation as a valid Iri
+    *         (using percent-encoding only for delimiters)
+    */
+  def iriString: String
+
+  /**
+    * @return the string representation of this Iri as a valid Uri
+    *         (using percent-encoding when required according to rfc3986)
+    */
+  def uriString: String
+
+}
+
+object Iri {
+
+  /**
+    * Attempt to construct a new Url from the argument validating the structure and the character encodings as per
+    * RFC 3987.
+    *
+    * @param string the string to parse as an absolute url.
+    * @return Right(url) if the string conforms to specification, Left(error) otherwise
+    */
+  final def url(string: String): Either[String, Url] =
+    Url(string)
+
+  /**
+    * Attempt to construct a new Urn from the argument validating the structure and the character encodings as per
+    * RFC 3987 and 8141.
+    *
+    * @param string the string to parse as an Urn.
+    * @return Right(urn) if the string conforms to specification, Left(error) otherwise
+    */
+  final def urn(string: String): Either[String, Urn] =
+    Urn(string)
+
+  /**
+    * Attempt to construct a new Uri (Url or Urn) from the argument as per the RFC 3987 and 8141.
+    *
+    * @param string the string to parse as an absolute iri.
+    * @return Right(Uri) if the string conforms to specification, Left(error) otherwise
+    */
+  final def uri(string: String): Either[String, Uri] =
+    Uri(string)
+
+  /**
+    * Attempt to construct a new RelativeIri from the argument as per the RFC 3987.
+    *
+    * @param string the string to parse as a relative iri
+    * @return Right(RelativeIri) if the string conforms to specification, Left(error) otherwise
+    */
+  final def relative(string: String): Either[String, RelativeIri] =
+    RelativeIri(string)
+
+  /**
+    * Attempt to construct a new Iri (Url, Urn or RelativeIri) from the argument as per the RFC 3987 and 8141.
+    *
+    * @param string the string to parse as an iri.
+    * @return Right(Iri) if the string conforms to specification, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Iri] =
+    uri(string) orElse relative(string)
+
+  @SuppressWarnings(Array("EitherGet"))
+  final def unsafe(string: String): Iri =
+    apply(string).fold(left => throw new IllegalArgumentException(left), identity)
+
+  /**
+    * A relative IRI.
+    *
+    * @param authority the optional authority part
+    * @param path      the path part
+    * @param query     an optional query part
+    * @param fragment  an optional fragment part
+    */
+  final case class RelativeIri(
+      authority: Option[Authority],
+      path: Path,
+      query: Option[Query],
+      fragment: Option[Fragment]
+  ) extends Iri {
+    override def isUri: Boolean                  = false
+    override def asUri: Option[Uri]              = None
+    override def isUrl: Boolean                  = false
+    override def isUrn: Boolean                  = false
+    override def asUrn: Option[Urn]              = None
+    override def asUrl: Option[Url]              = None
+    override def asRelative: Option[RelativeIri] = Some(this)
+
+    override lazy val iriString: String = {
+      val a = authority.map("//" + _.iriString).getOrElse("")
+      val q = query.map("?" + _.iriString).getOrElse("")
+      val f = fragment.map("#" + _.iriString).getOrElse("")
+
+      s"$a${path.iriString}$q$f"
+    }
+
+    override lazy val uriString: String = {
+      val a = authority.map("//" + _.uriString).getOrElse("")
+      val q = query.map("?" + _.uriString).getOrElse("")
+      val f = fragment.map("#" + _.uriString).getOrElse("")
+
+      s"$a${path.uriString}$q$f"
+    }
+
+    /**
+      * Resolves a [[RelativeIri]] into an [[Uri]] with the provided ''base''.
+      * The resolution algorithm is taken from the rfc3986 and
+      * can be found in https://tools.ietf.org/html/rfc3986#section-5.2.
+      *
+      * Ex: given a base = "http://a/b/c/d;p?q" and a relative iri = "./g" the output will be
+      * "http://a/b/c/g"
+      *
+      * @param base the base [[Uri]] from where to resolve the [[RelativeIri]]
+      */
+    def resolve(base: Uri): Uri =
+      base match {
+        case url: Url => resolveUrl(url)
+        case urn: Urn => resolveUrn(urn)
+      }
+
+    private def resolveUrl(base: Url): Uri =
+      authority match {
+        case Some(_) =>
+          Url(base.scheme, authority, path, query, fragment)
+        case None =>
+          val (p, q) = path match {
+            case Empty =>
+              base.path -> (if (query.isDefined) query else base.query)
+            case _ if path.startWithSlash =>
+              removeDotSegments(path) -> query
+            case _ =>
+              merge(base) -> query
+          }
+          base.copy(query = q, path = p, fragment = fragment)
+      }
+
+    private def resolveUrn(base: Urn): Uri = {
+      val (p, q) = path match {
+        case Empty =>
+          base.nss -> (if (query.isDefined) query else base.q)
+        case _ if path.startWithSlash =>
+          path -> query
+        case _ =>
+          merge(base) -> query
+      }
+      base.copy(q = q, nss = p, fragment = fragment)
+    }
+
+    private def merge(base: Url): Path =
+      if (base.authority.isDefined && base.path.isEmpty) Slash(path)
+      else removeDotSegments(path.prepend(deleteLast(base.path), allowSlashDup = true))
+
+    private def merge(base: Urn): Path =
+      removeDotSegments(path.prepend(deleteLast(base.nss), allowSlashDup = true))
+
+    private def deleteLast(path: Path, withSlash: Boolean = false): Path =
+      path match {
+        case Segment(_, Slash(rest)) if withSlash => rest
+        case Segment(_, rest)                     => rest
+        case _                                    => path
+      }
+
+    private def removeDotSegments(path: Path): Path = {
+
+      @tailrec
+      def inner(input: Path, output: Path): Path =
+        input match {
+          // -> "../" or "./"
+          case Segment("..", Slash(rest)) => inner(rest, output)
+          case Segment(".", Slash(rest))  => inner(rest, output)
+          // -> "/./" or "/.",
+          case Slash(Segment(".", Slash(rest))) => inner(Slash(rest), output)
+          case Slash(Segment(".", rest))        => inner(Slash(rest), output)
+          // -> "/../" or "/.."
+          case Slash(Segment("..", Slash(rest))) => inner(Slash(rest), deleteLast(output, withSlash = true))
+          case Slash(Segment("..", rest))        => inner(Slash(rest), deleteLast(output, withSlash = true))
+          // only "." or ".."
+          case Segment(".", Empty) | Segment("..", Empty) => inner(Path.Empty, output)
+          // move
+          case Slash(rest)      => inner(rest, Slash(output))
+          case Segment(s, rest) => inner(rest, output / s)
+          case Empty            => output
+        }
+
+      inner(path.reverse, Path.Empty)
+    }
+
+  }
+
+  object RelativeIri {
+
+    /**
+      * Attempt to construct a new RelativeIri from the argument validating the structure and the character encodings as per
+      * RFC 3987.
+      *
+      * @param string the string to parse as a relative IRI.
+      * @return Right(url) if the string conforms to specification, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, RelativeIri] =
+      new IriParser(string).parseRelative
+
+    final implicit val relativeIriShow: Show[RelativeIri] = Show.show(_.iriString)
+
+    final implicit val relativeIriEq: Eq[RelativeIri] = Eq.fromUniversalEquals
+  }
+
+  /**
+    * An (absolute) Uri as defined by RFC 3986.
+    */
+  sealed abstract class Uri extends Iri {
+    override def isUri: Boolean                  = true
+    override def asUri: Option[Uri]              = Some(this)
+    override def asRelative: Option[RelativeIri] = None
+
+    /**
+      * Appends the segment to the end of the ''path'' section of the current ''Uri''. If the path section ends with slash it
+      * directly appends, otherwise it adds a slash before appending
+      *
+      * @param segment the segment to be appended to the end of the path section
+      */
+    def /(segment: String): Uri
+
+    /**
+      * Appends the path to the end of the ''path'' section of the current ''Uri''. If the path section ends with slash it
+      * directly appends, otherwise it adds a slash before appending
+      *
+      * @param path the path to be appended to the end of the path section
+      */
+    def /(path: Path): Uri
+
+    /**
+      * @return the path from an [[Url]] or the nss from a [[Urn]]
+      */
+    def path: Path
+
+    /**
+      *
+      * @return the optional [[Fragment]] of the Uri
+      */
+    def fragment: Option[Fragment]
+
+    /**
+      * Returns a copy of this Uri with the fragment value set to the argument fragment.
+      *
+      * @param fragment the fragment to replace
+      * @return a copy of this Uri with the fragment value set to the argument fragment
+      */
+    def withFragment(fragment: Fragment): Uri
+  }
+
+  object Uri {
+
+    /**
+      * Attempt to construct a new Uri (Url or Urn) from the argument as per the RFC 3987 and 8141.
+      *
+      * @param string the string to parse as an (absolute) Uri.
+      * @return Right(Uri) if the string conforms to specification, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, Uri] =
+      new IriParser(string).parseAbsolute
+
+    @SuppressWarnings(Array("EitherGet"))
+    final def unsafe(string: String): Uri =
+      apply(string).fold(left => throw new IllegalArgumentException(left), identity)
+
+    final implicit val absoluteIriShow: Show[Uri] = Show.show(_.iriString)
+    final implicit val absoluteIriEq: Eq[Uri]     = Eq.fromUniversalEquals
+  }
+
+  /**
+    * An absolute Url.
+    *
+    * @param scheme    the scheme part
+    * @param authority an optional authority part
+    * @param path      the path part
+    * @param query     an optional query part
+    * @param fragment  an optional fragment part
+    */
+  final case class Url(
+      scheme: Scheme,
+      authority: Option[Authority],
+      path: Path,
+      query: Option[Query],
+      fragment: Option[Fragment]
+  ) extends Uri {
+    override def isUrl: Boolean     = true
+    override def asUrl: Option[Url] = Some(this)
+    override def isUrn: Boolean     = false
+    override def asUrn: Option[Urn] = None
+    @tailrec
+    override def /(segment: String): Uri =
+      if (segment.startsWith("/")) this / segment.drop(1)
+      else if (path.endsWithSlash) copy(path = path / segment)
+      else copy(path = path / segment)
+
+    override def /(p: Path): Uri = copy(path = path / p)
+
+    override def withFragment(fragment: Fragment): Url =
+      copy(fragment = Some(fragment))
+
+    override lazy val iriString: String = {
+      val a = authority.map("//" + _.iriString).getOrElse("")
+      val q = query.map("?" + _.iriString).getOrElse("")
+      val f = fragment.map("#" + _.iriString).getOrElse("")
+
+      s"${scheme.value}:$a${path.iriString}$q$f"
+    }
+
+    override lazy val uriString: String = {
+      val a = authority.map("//" + _.uriString).getOrElse("")
+      val q = query.map("?" + _.uriString).getOrElse("")
+      val f = fragment.map("#" + _.uriString).getOrElse("")
+
+      s"${scheme.value}:$a${path.uriString}$q$f"
+    }
+  }
+
+  object Url {
+
+    private val defaultSchemePortMapping: Map[Scheme, Port] = Map(
+      "ftp"    -> 21,
+      "ssh"    -> 22,
+      "telnet" -> 23,
+      "smtp"   -> 25,
+      "domain" -> 53,
+      "tftp"   -> 69,
+      "http"   -> 80,
+      "ws"     -> 80,
+      "pop3"   -> 110,
+      "nntp"   -> 119,
+      "imap"   -> 143,
+      "snmp"   -> 161,
+      "ldap"   -> 389,
+      "https"  -> 443,
+      "wss"    -> 443,
+      "imaps"  -> 993,
+      "nfs"    -> 2049
+    ).map { case (s, p) => (new Scheme(s), new Port(p)) }
+
+    private def normalize(scheme: Scheme, authority: Authority): Authority =
+      if (authority.port == defaultSchemePortMapping.get(scheme)) authority.copy(port = None) else authority
+
+    /**
+      * Constructs an Url from its constituents.
+      *
+      * @param scheme    the scheme part
+      * @param authority an optional authority part
+      * @param path      the path part
+      * @param query     an optional query part
+      * @param fragment  an optional fragment part
+      */
+    final def apply(
+        scheme: Scheme,
+        authority: Option[Authority],
+        path: Path,
+        query: Option[Query],
+        fragment: Option[Fragment]
+    ): Url = new Url(scheme, authority.map(normalize(scheme, _)), path, query, fragment)
+
+    /**
+      * Attempt to construct a new Url from the argument validating the structure and the character encodings as per
+      * RFC 3987.
+      *
+      * @param string the string to parse as an absolute url.
+      * @return Right(url) if the string conforms to specification, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, Url] =
+      new IriParser(string).parseUrl
+
+    @SuppressWarnings(Array("EitherGet"))
+    private[rdf] def unsafe(string: String): Url =
+      apply(string).fold(left => throw new IllegalArgumentException(left), identity)
+
+    final implicit def urlShow: Show[Url] = Show.show(_.iriString)
+
+    final implicit val urlEq: Eq[Url] = Eq.fromUniversalEquals
+  }
+
+  /**
+    * An urn as defined by RFC 8141.
+    *
+    * @param nid      the namespace identifier
+    * @param nss      the namespace specific string
+    * @param r        the r component of the urn
+    * @param q        the q component of the urn
+    * @param fragment the f component of the urn, also known as fragment
+    */
+  final case class Urn(nid: Nid, nss: Path, r: Option[Component], q: Option[Query], fragment: Option[Fragment])
+      extends Uri {
+    override def isUrl: Boolean     = false
+    override def asUrl: Option[Url] = None
+    override def isUrn: Boolean     = true
+    override def asUrn: Option[Urn] = Some(this)
+    override val path: Path         = nss
+    override def /(segment: String): Uri =
+      if (nss.endsWithSlash) copy(nss = nss / segment) else copy(nss = nss / segment)
+
+    override def /(p: Path): Uri = copy(nss = p / path)
+
+    override def withFragment(fragment: Fragment): Urn =
+      copy(fragment = Some(fragment))
+
+    override lazy val iriString: String = {
+      val rstr = r.map("?+" + _.iriString).getOrElse("")
+      val qstr = q.map("?=" + _.iriString).getOrElse("")
+      val f    = fragment.map("#" + _.iriString).getOrElse("")
+      s"urn:${nid.iriString}:${nss.iriString}$rstr$qstr$f"
+    }
+
+    override lazy val uriString: String = {
+      val rstr = r.map("?+" + _.uriString).getOrElse("")
+      val qstr = q.map("?=" + _.uriString).getOrElse("")
+      val f    = fragment.map("#" + _.uriString).getOrElse("")
+      s"urn:${nid.uriString}:${nss.uriString}$rstr$qstr$f"
+    }
+
+  }
+
+  object Urn {
+
+    /**
+      * Attempt to construct a new Urn from the argument validating the structure and the character encodings as per
+      * RFC 3987 and 8141.
+      *
+      * @param string the string to parse as an Urn.
+      * @return Right(urn) if the string conforms to specification, Left(error) otherwise
+      */
+    final def apply(string: String): Either[String, Urn] =
+      new IriParser(string).parseUrn
+
+    @SuppressWarnings(Array("EitherGet"))
+    private[rdf] def unsafe(string: String): Urn =
+      apply(string).fold(left => throw new IllegalArgumentException(left), identity)
+
+    final implicit val urnShow: Show[Urn] = Show.show(_.iriString)
+
+    final implicit val urnEq: Eq[Urn] = Eq.fromUniversalEquals
+  }
+
+  final implicit val iriEq: Eq[Iri] = Eq.fromUniversalEquals
+  final implicit def iriShow(implicit urnShow: Show[Urn], urlShow: Show[Url], relShow: Show[RelativeIri]): Show[Iri] =
+    Show.show {
+      case r: RelativeIri => r.show
+      case url: Url       => url.show
+      case urn: Urn       => urn.show
+    }
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/IriParser.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/IriParser.scala
@@ -1,0 +1,474 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import java.lang.{StringBuilder => JStringBuilder}
+import java.nio.charset.Charset
+
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority.Host._
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority._
+import ch.epfl.bluebrain.nexus.rdf.iri.Curie._
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+import ch.epfl.bluebrain.nexus.rdf.iri.Path._
+import com.github.ghik.silencer.silent
+import org.parboiled2.CharPredicate._
+import org.parboiled2.Parser.DeliveryScheme.{Either => E}
+import org.parboiled2._
+
+// format: off
+@SuppressWarnings(Array("MethodNames", "unused", "UnsafeTraversableMethods"))
+@silent
+private[iri] class IriParser(val input: ParserInput)
+                            (implicit formatter: ErrorFormatter = new ErrorFormatter(showExpected = false, showTraces = false))
+  extends Parser with StringBuilding {
+
+  def parseScheme: Either[String, Scheme] =
+    rule(scheme ~ EOI).run()
+      .map(_ => _scheme)
+      .leftMap(_.format(input, formatter))
+
+  def parseIPv4: Either[String, IPv4Host] =
+    rule(IPv4address ~ EOI).run()
+      .map(_ => _host.asInstanceOf[IPv4Host])
+      .leftMap(_.format(input, formatter))
+
+  def parseNamed: Either[String, NamedHost] =
+    rule(`ireg-name` ~ EOI).run()
+      .map(_ => _host.asInstanceOf[NamedHost])
+      .leftMap(_.format(input, formatter))
+
+  def parsePort: Either[String, Port] =
+    rule(`port` ~ EOI).run()
+      .leftMap(_.format(input, formatter))
+      .flatMap(_ => Port(_port))
+
+  def parseUserInfo: Either[String, UserInfo] =
+    rule(`iuserinfo` ~ EOI).run()
+      .map(_ => _userInfo)
+      .leftMap(_.format(input, formatter))
+
+  def parsePathAbempty: Either[String, Path] =
+    rule(`ipath-abempty` ~ EOI).run()
+      .map(_ => _path)
+      .leftMap(_.format(input, formatter))
+
+  def parsePathRootLess: Either[String, Path] =
+    rule(`ipath-rootless` ~ EOI).run()
+      .map(_ => _path)
+      .leftMap(_.format(input, formatter))
+
+  def parsePathSegment: Either[String, Path] =
+    rule(`isegment-nz` ~ EOI ~ push(getDecodedSB)).run()
+      .map(str => Segment(str, Path.Empty))
+      .leftMap(_.format(input, formatter))
+
+  def parseQuery: Either[String, Query] =
+    rule(`iquery` ~ EOI).run()
+      .map(_ => _query)
+      .leftMap(_.format(input, formatter))
+
+  def parseFragment: Either[String, Fragment] =
+    rule(`ifragment` ~ EOI).run()
+      .map(_ => _fragment)
+      .leftMap(_.format(input, formatter))
+
+  def parseUrl: Either[String, Url] =
+    rule(`url`).run()
+      .map(_ => Url(
+        scheme    = _scheme,
+        authority = Option(_authority),
+        path      = _path,
+        query     = Option(_query),
+        fragment  = Option(_fragment))
+      )
+      .leftMap(_.format(input, formatter))
+
+  def parseUrn: Either[String, Urn] =
+    rule(`urn`).run()
+      .map(_ => Urn(
+        nid      = _nid,
+        nss      = _path,
+        r        = Option(_r),
+        q        = Option(_query),
+        fragment = Option(_fragment))
+      )
+      .leftMap(_.format(input, formatter))
+
+  def parseAbsolute: Either[String, Uri] =
+    rule(`urn` | `url`).run()
+      .map { _ =>
+        if (_nid != null) Urn(
+          nid      = _nid,
+          nss      = _path,
+          r        = Option(_r),
+          q        = Option(_query),
+          fragment = Option(_fragment))
+        else Url(
+          scheme    = _scheme,
+          authority = Option(_authority),
+          path      = _path,
+          query     = Option(_query),
+          fragment  = Option(_fragment))
+      }
+      .leftMap(_.format(input, formatter))
+
+  def parseRelative: Either[String, RelativeIri] =
+    rule(`irelative-ref` ~ EOI).run()
+      .map(_ => RelativeIri(
+        authority = Option(_authority),
+        path      = _path,
+        query     = Option(_query),
+        fragment  = Option(_fragment))
+      )
+      .leftMap(_.format(input, formatter))
+
+  def parseNid: Either[String, Nid] =
+    rule(`nid` ~ EOI).run()
+      .map(_ => _nid)
+      .leftMap(_.format(input, formatter))
+
+  def parseComponent: Either[String, Component] =
+    rule(`component` ~ EOI).run()
+      .leftMap(_.format(input, formatter))
+
+  def parseCurie: Either[String, Curie] =
+    rule(`curie`).run()
+      .map { _ =>
+        val prefix    = _ncName
+        val reference = RelativeIri(
+          authority = Option(_authority),
+          path      = _path,
+          query     = Option(_query),
+          fragment  = Option(_fragment))
+        Curie(prefix, reference)
+      }
+      .leftMap(_.format(input, formatter))
+
+  def parseNcName: Either[String, Prefix] =
+    rule(`nc-name` ~ EOI).run()
+      .map(_ => _ncName)
+      .leftMap(_.format(input, formatter))
+
+  private def appendSBAsLower(): Rule0 = rule { run(sb.append(CharUtils.toLowerCase(lastChar))) }
+  private def getDecodedSB: String = IriParser.decode(sb.toString, UTF8)
+
+  private[this] var _scheme: Scheme = _
+  private[this] var _host: Host = _
+  private[this] var _port: Int = 0
+  private[this] var _userInfo: UserInfo = _
+  private[this] var _authority: Authority = _
+  private[this] var _path: Path = Path.Empty
+  private[this] var _query: Query = _
+  private[this] var _fragment: Fragment = _
+
+  private[this] var _nid: Nid = _
+  private[this] var _r: Component = _
+
+  private[this] var _ncName: Prefix = _
+
+  private val schemeNonFirstPred = AlphaNum ++ "+-."
+  private def scheme: Rule0 = rule {
+    clearSB() ~ Alpha ~ appendSBAsLower() ~ zeroOrMore(schemeNonFirstPred ~ appendSBAsLower()) ~ run {
+      _scheme = new Scheme(sb.toString)
+    }
+  }
+
+  private val Digit04 = CharPredicate('0' to '4')
+  private val Digit05 = CharPredicate('0' to '5')
+
+  private def `dec-octet`: Rule1[Byte] = rule {
+    capture(
+      (ch('2') ~ ((Digit04 ~ Digit) | (ch('5') ~ Digit05)))
+        | (ch('1') ~ Digit ~ Digit)
+        | (Digit19 ~ Digit)
+        | Digit
+    ) ~> ((str: String) => java.lang.Integer.parseInt(str).toByte)
+  }
+
+  private def IPv4address: Rule0 = rule {
+    clearSB() ~ `dec-octet` ~ "." ~ `dec-octet` ~ "." ~ `dec-octet` ~ "." ~ `dec-octet` ~> ((a: Byte, b: Byte, c: Byte, d: Byte) => {
+      _host = IPv4Host(a, b, c, d)
+    })
+  }
+
+  private def `pct-encoded`: Rule0 = rule {
+    '%' ~ HexDigit ~ HexDigit ~ run {
+      sb.append('%').append(charAt(-2)).append(lastChar)
+    }
+  }
+
+  private def `ipchar`: Rule0 = rule {
+    `ipchar_preds` ~ appendSB() | `pct-encoded`
+  }
+
+  private def `ireg-name`: Rule0 = rule {
+    clearSB() ~ oneOrMore(`inamed_host_allowed` ~ appendSBAsLower() | `pct-encoded`) ~ run {
+      _host = new NamedHost(getDecodedSB.toLowerCase)
+    }
+  }
+
+  private def `port`: Rule0 = rule {
+    Digit19 ~ run { _port = lastChar - '0' } ~ optional(
+      Digit ~ run { _port = 10 * _port + (lastChar - '0') } ~ optional(
+        Digit ~ run { _port = 10 * _port + (lastChar - '0') } ~ optional(
+          Digit ~ run { _port = 10 * _port + (lastChar - '0') } ~ optional(
+            Digit ~ run { _port = 10 * _port + (lastChar - '0') } )))) | '0'
+  }
+
+  private def `ihost`: Rule0 = rule { IPv4address | `ireg-name` }
+
+  private def `iuserinfo`: Rule0 = rule {
+    clearSB() ~ oneOrMore(`iuser_info_allowed` ~ appendSB() | `pct-encoded`) ~ run {
+      _userInfo = new UserInfo(getDecodedSB)
+    }
+  }
+
+  private def `iauthority`: Rule0 = rule {
+    clearSB() ~ optional(`iuserinfo` ~ '@' | run { _userInfo = null }) ~ `ihost` ~ optional(':' ~ port) ~ run {
+      _authority = Authority(Option(_userInfo), _host, if (_port == 0) None else Some(new Port(_port)))
+    }
+  }
+
+  private def `ipath-abempty`: Rule0 = {
+    def setPath(value: String): Unit = {
+      val res = (_path, value) match {
+        case (Segment(_, Slash(acc)), "..") => acc
+        case (Slash(acc), "..")             => acc
+        case (acc, "..")                    => acc
+        case (acc, ".")                     => acc
+        case (acc, el) if el.length == 0    => Slash(acc)
+        case (acc, el)                      => Segment(el, Slash(acc))
+      }
+      _path = res
+    }
+
+    rule {
+      zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB) })
+    }
+  }
+
+  private def `ipath-absolute`: Rule0 = rule {
+    clearSB() ~ '/' ~ optional(`isegment` ~ run {
+      _path = if (sb.length() == 0) Slash(Path.Empty) else Segment(getDecodedSB, Slash(Path.Empty))
+    } ~ `ipath-abempty`)
+  }
+
+  private def `ipath-noscheme`: Rule0 = {
+    def setPath(value: String): Unit = {
+      val res = (_path, value) match {
+        case (Segment(el, Slash(acc)), "..") if el != ".."        => acc
+        case (Segment(el, acc), "..") if el != ".." && el != "."  => acc
+        case (Slash(acc), "..")                                   => acc
+        case (acc, ".")                                           => acc
+        case (acc, el) if el.length == 0                          => Slash(acc)
+        case (Path.Empty, el)                                     => Segment(el, Path.Empty)
+        case (acc, el)                                            => Segment(el, Slash(acc))
+      }
+      _path = res
+    }
+
+    rule {
+      clearSB() ~ `isegment-nz-nc` ~ run {
+        _path = Segment(getDecodedSB, Path.Empty)
+      } ~ zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB) })
+    }
+  }
+
+  private def `ipath-rootless`: Rule0 = rule {
+    clearSB() ~ `isegment-nz` ~ run {
+      _path = Segment(getDecodedSB, Path.Empty)
+    } ~ `ipath-abempty`
+  }
+
+  private def `ipath-empty`: Rule0 = rule {
+    clearSB() ~ MATCH ~ run {
+      _path = Path.Empty
+    }
+  }
+
+  private def `isegment`: Rule0 = rule { zeroOrMore(`ipchar`) }
+  private def `isegment-nz`: Rule0 = rule { oneOrMore(`ipchar`) }
+  private def `isegment-nz-nc`: Rule0 = rule { oneOrMore(!':' ~ `ipchar`) }
+  private def `iquery`: Rule0 = {
+    def part: Rule1[String] = rule {
+      clearSB() ~ oneOrMore(!"?+" ~ ('+' ~ appendSB(' ') | `iquery_allowed` ~ appendSB() | `pct-encoded`)) ~ push(getDecodedSB)
+    }
+
+    /*_*/
+    def entry: Rule1[(String, String)] = rule {
+      part ~ optional('=' ~ part) ~> ((key: String, value: Option[String]) => (key, value.getOrElse("")))
+    }
+    /*_*/
+
+    /*_*/
+    rule {
+      zeroOrMore(entry).separatedBy('&') ~> ((seq: Seq[(String, String)]) => _query = Query(seq))
+    }
+    /*_*/
+  }
+
+  private def `ifragment`: Rule0 = rule {
+    clearSB() ~ zeroOrMore(`ipchar` | (CharPredicate("/?") ~ appendSB())) ~ run {
+      _fragment = new Fragment(getDecodedSB)
+    }
+  }
+
+  private def `ihier-part`: Rule0 = rule {
+    ("//" ~ `iauthority` ~ `ipath-abempty`) | (run { _authority = null } ~ (`ipath-absolute` | `ipath-rootless` | `ipath-empty`))
+  }
+
+  private def `url`: Rule0 = rule {
+    scheme ~ ':' ~ `ihier-part` ~ optional('?' ~ `iquery`) ~ optional('#' ~ `ifragment`) ~ EOI
+  }
+
+  private def `irelative-part`: Rule0 = rule {
+    ("//" ~ `iauthority` ~ `ipath-abempty`) | `ipath-absolute` | `ipath-noscheme` | `ipath-empty`
+  }
+
+  private def `irelative-ref`: Rule0 = rule {
+    `irelative-part` ~ optional('?' ~ `iquery`) ~ optional('#' ~ `ifragment`) ~ test {
+      _path.nonEmpty || _authority != null || _query != null || _fragment != null
+    }
+  }
+
+  private val ldh = AlphaNum ++ '-'
+  private def `nid`: Rule0 = rule {
+    clearSB() ~ `inid_allowed` ~ appendSBAsLower() ~ (1 to 31).times(ldh ~ appendSBAsLower()) ~ test(AlphaNum(lastChar)) ~ run {
+      _nid = new Nid(sb.toString)
+    }
+  }
+
+  private def `nss`: Rule0 = rule {
+    `ipath-rootless`
+  }
+
+  private def `component`: Rule1[Component] = rule {
+    clearSB() ~ oneOrMore(!"?+" ~ !"?=" ~ `icomponent_allowed` ~ appendSB() | `pct-encoded`) ~ push(new Component(getDecodedSB))
+  }
+
+  private def `rq-components`: Rule0 = {
+    def `r-component`: Rule0 = rule {
+      "?+" ~ test(_r == null) ~ `component` ~> ((c: Component) => _r = c)
+    }
+
+    def `q-component`: Rule0 = rule {
+      "?=" ~ `iquery` ~ test(sb.length() > 0)
+    }
+
+    rule {
+      // r component can only be matched once per parser, this allows components to be commutative
+      optional(`r-component`) ~ optional(`q-component`) ~ optional(`r-component`)
+    }
+  }
+
+  private def `urn`: Rule0 = rule {
+    "urn:" ~ `nid` ~ ':' ~ `nss` ~ `rq-components` ~ optional('#' ~ `ifragment`) ~ EOI
+  }
+
+  private val `nc-name-start` = Alpha ++ '_' ++ List(
+    0xC0   to 0xD6,   0xD8   to 0xF6,   0xF8    to 0x2FF,
+    0x370  to 0x37D,  0x37F  to 0x1FFF, 0x200C  to 0x200D,
+    0x2070 to 0x218F, 0x2C00 to 0x2FEF, 0x300   to 0xD7FF,
+    0xF900 to 0xFDCF, 0xFDF0 to 0xFFFD, 0x10000 to 0xEFFFF
+  ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
+
+  private val `nc-name-rest` = `nc-name-start` ++ Digit ++ CharPredicate("-.", "\u00B7", '\u0300' to '\u036F', '\u203F' to '\u2040')
+
+  private def `nc-name`: Rule0 = rule {
+    clearSB() ~ `nc-name-start` ~ appendSB() ~ zeroOrMore(`nc-name-rest` ~ appendSB()) ~ run {
+      _ncName = new Prefix(sb.toString)
+    }
+  }
+
+  private def `curie`: Rule0 = rule {
+    `nc-name` ~ ':' ~ `irelative-ref` ~ EOI
+  }
+}
+
+@SuppressWarnings(Array("UnsafeTraversableMethods"))
+object IriParser {
+
+  private[iri] val `ucschar` = List(
+    0xA0    to 0xD7FF,  0xF900  to 0xFDCF,  0xFDF0  to 0xFFEF,
+    0x10000 to 0x1FFFD, 0x20000 to 0x2FFFD, 0x30000 to 0x3FFFD,
+    0x40000 to 0x4FFFD, 0x50000 to 0x5FFFD, 0x60000 to 0x6FFFD,
+    0x70000 to 0x7FFFD, 0x80000 to 0x8FFFD, 0x90000 to 0x9FFFD,
+    0xA0000 to 0xAFFFD, 0xB0000 to 0xBFFFD, 0xC0000 to 0xCFFFD,
+    0xD0000 to 0xDFFFD, 0xE1000 to 0xEFFFD
+  ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
+
+  private[iri] val `iprivate` = List(
+    0xE000 to 0xF8FF, 0xF0000 to 0xFFFFD, 0x100000 to 0x10FFFD
+  ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
+
+  private[iri] val `sub-delims_preds` = CharPredicate("!$&'()*+,;=")
+  private[iri] val `unreserved_preds` = AlphaNum ++ CharPredicate("-._~")
+  private[iri] val `iunreserved_preds` = `unreserved_preds` ++ `ucschar`
+  private[iri] val `ipchar_preds` = `iunreserved_preds` ++ `sub-delims_preds` ++ CharPredicate(":@")
+  private[iri] val `pchar_preds` = `unreserved_preds` ++ `sub-delims_preds` ++ CharPredicate(":@")
+
+  private[iri] val `iuser_info_allowed` = `iunreserved_preds` ++ `sub-delims_preds` ++ ':'
+  private[iri] val `user_info_allowed` = `unreserved_preds` ++ `sub-delims_preds` ++ ':'
+
+  private[iri] val `inamed_host_allowed` = `iunreserved_preds` ++ `sub-delims_preds`
+  private[iri] val `named_host_allowed` = `unreserved_preds` ++ `sub-delims_preds`
+
+  private[iri] val `iquery_allowed` = `ipchar_preds` ++ `iprivate` ++ CharPredicate("/?") -- CharPredicate("=&")
+  private[iri] val `query_allowed` = `pchar_preds` ++ CharPredicate("/?") -- CharPredicate("=&")
+
+  private[iri] val `ifragment_allowed` = `ipchar_preds`  ++ CharPredicate("/?")
+  private[iri] val `fragment_allowed` = `pchar_preds`  ++ CharPredicate("/?")
+
+  private[iri] val `inid_allowed` = AlphaNum
+  private[iri] val `nid_allowed` = AlphaNum
+
+  private[iri] val `icomponent_allowed` = `ipchar_preds`  ++ CharPredicate("/?")
+  private[iri] val `component_allowed` = `pchar_preds`  ++ CharPredicate("/?")
+
+  /**
+    * A direct port of the JDKs [[java.net.URLDecoder#decode(String, Charset)]] implementation that doesn't attempt to convert
+    * ''+'' into a space character '' ''. Decodes a percent encoded string using the specified charset.
+    *
+    * @param string  the string to decode
+    * @param charset the given charset
+    * @throws IllegalArgumentException if it encounters illegal characters
+    * @see [[java.net.URLDecoder#decode(String, Charset)]]
+    */
+  @SuppressWarnings(Array("NullAssignment", "NullParameter"))
+  private[iri] def decode(string: String, charset: Charset): String = {
+    var needToChange = false
+    val numChars = string.length
+    val sb = new JStringBuilder(if (numChars > 500) numChars / 2 else numChars)
+    var i = 0
+
+    var c: Char = 0
+    var bytes: Array[Byte] = null
+    while (i < numChars) {
+      c = string.charAt(i)
+      c match {
+        case '%' =>
+          try {
+            if (bytes == null) bytes = new Array[Byte]((numChars - i) / 3)
+            var pos = 0
+            while ({ ((i + 2) < numChars) && (c == '%') }) {
+              val v = Integer.parseInt(string.substring(i + 1, i + 3), 16)
+              if (v < 0) throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape " + "(%) pattern - negative value")
+              bytes({ pos += 1; pos - 1 }) = v.toByte
+              i += 3
+              if (i < numChars) c = string.charAt(i)
+            }
+            if ((i < numChars) && (c == '%')) throw new IllegalArgumentException("URLDecoder: Incomplete trailing escape (%) pattern")
+            sb.append(new String(bytes, 0, pos, charset))
+          } catch {
+            case e: NumberFormatException =>
+              throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape (%) pattern - " + e.getMessage)
+          }
+          needToChange = true
+        case _ =>
+          sb.append(c)
+          i += 1
+      }
+    }
+    if (needToChange) sb.toString else string
+  }
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Nid.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Nid.scala
@@ -1,0 +1,40 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.PctString._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+
+/**
+  * NID part of an Urn as defined by RFC 8141.
+  *
+  * @param value the string value of the fragment
+  */
+final case class Nid private[iri] (value: String) {
+
+  /**
+    * @return the string representation for the Nid segment compatible with the rfc3987
+    *         (using percent-encoding only for delimiters)
+    */
+  lazy val iriString: String = value.pctEncodeIgnore(`inid_allowed`)
+
+  /**
+    * @return the string representation using percent-encoding for the Nid segment
+    *         when necessary according to rfc3986
+    */
+  lazy val uriString: String = value.pctEncodeIgnore(`nid_allowed`)
+}
+
+object Nid {
+
+  /**
+    * Attempts to parse the argument string as a `NID` as defined by RFC 8141.
+    *
+    * @param string the string to parse as a NID
+    * @return Right(NID) if the parsing succeeds, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Nid] =
+    new IriParser(string).parseNid
+
+  final implicit val nidShow: Show[Nid] = Show.show(_.iriString)
+  final implicit val nidEq: Eq[Nid]     = Eq.fromUniversalEquals
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Path.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Path.scala
@@ -1,0 +1,295 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.PctString._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+import ch.epfl.bluebrain.nexus.rdf.iri.Path._
+
+import scala.annotation.tailrec
+
+/**
+  * Path part of an Iri as defined in RFC 3987.
+  */
+sealed abstract class Path extends Product with Serializable {
+
+  /**
+    * The type of the Head element of this path
+    */
+  type Head
+
+  /**
+    * @return true if the path contains no characters, false otherwise
+    */
+  def isEmpty: Boolean
+
+  /**
+    * @return the [[Head]] element of this [[Path]]
+    */
+  def head: Head
+
+  /**
+    * @param dropSlash a flag to decide whether it should skip slashes or not when returning the tail element
+    * @return the remainder of this [[Path]] after subtracting its head.
+    */
+  def tail(dropSlash: Boolean = false): Path
+
+  /**
+    * @return false if the path contains no characters, true otherwise
+    */
+  def nonEmpty: Boolean = !isEmpty
+
+  /**
+    * @return true if this path is a [[Path.Slash]] (ends with a slash '/'), false otherwise
+    */
+  def isSlash: Boolean
+
+  /**
+    * @return true if this path is a [[Path.Segment]] (ends with a segment), false otherwise
+    */
+  def isSegment: Boolean
+
+  /**
+    * @return Some(this) if this path is an Empty path, None otherwise
+    */
+  def asEmpty: Option[Empty]
+
+  /**
+    * @return Some(this) if this path is a Slash (ends with a slash '/') path, None otherwise
+    */
+  def asSlash: Option[Slash]
+
+  /**
+    * @return Some(this) if this path is a Segment (ends with a segment) path, None otherwise
+    */
+  def asSegment: Option[Segment]
+
+  /**
+    * @return true if this path ends with a slash ('/'), false otherwise
+    */
+  def endsWithSlash: Boolean = isSlash
+
+  /**
+    * @return true if this path starts with a slash ('/'), false otherwise
+    */
+  def startWithSlash: Boolean
+
+  /**
+    * @param other the other path
+    * @return true if this path starts with the provided ''other'' path, false otherwise
+    */
+  def startsWith(other: Path): Boolean = {
+    @tailrec
+    @SuppressWarnings(Array("ComparingUnrelatedTypes"))
+    def inner(remainingCurr: Path, remainingOther: Path): (Path, Path) = {
+      if (remainingOther.isEmpty) remainingCurr -> remainingOther
+      else if (remainingCurr.head == remainingOther.head) inner(remainingCurr.tail(), remainingOther.tail())
+      else remainingCurr -> remainingOther
+    }
+    val (_, otherResult) = inner(this.reverse, other.reverse)
+    otherResult.isEmpty
+  }
+
+  /**
+    * @return the string representation for the Path segment compatible with the rfc3987
+    *         (using percent-encoding only for delimiters)
+    */
+  def iriString: String
+
+  /**
+    * @return the string representation using percent-encoding for the Path segment
+    *         when necessary according to rfc3986
+    */
+  def uriString: String
+
+  /**
+    * @return the reversed path
+    */
+  def reverse: Path = {
+    @tailrec
+    def inner(acc: Path, remaining: Path): Path = remaining match {
+      case Empty         => acc
+      case Segment(h, t) => inner(Segment(h, acc), t)
+      case Slash(t)      => inner(Slash(acc), t)
+    }
+    inner(Empty, this)
+  }
+
+  /**
+    * Adds the ''other'' path to the end of the current path. This operation does not
+    * create double slashes when merging paths.
+    *
+    * @param other the path to be suffixed to the current path
+    * @return the current path plus the provided path
+    *         Ex: current = "/a/b/c/d", other = "/e/f" will output "/a/b/c/d/e/f"
+    *         current = "/a/b/c/def/", other = "/ghi/f" will output "/a/b/c/def/ghi/f"
+    */
+  def /(other: Path): Path = other.prepend(this, allowSlashDup = false)
+
+  /**
+    * @param other         the path to be prepended to the current path
+    * @param allowSlashDup a flag to decide whether or not we allow slash duplication on path merging
+    * @return the current path plus the provided path
+    *         Ex: current = "/e/f", other = "/a/b/c/d" will output "/a/b/c/d/e/f"
+    *         current = "ghi/f", other = "/a/b/c/def" will output "/a/b/c/def/ghi/f"
+   **/
+  def prepend(other: Path, allowSlashDup: Boolean = false): Path
+
+  /**
+    * @param segment the segment to be appended to a path
+    * @return current / segment. If the current path is a [[Segment]], a slash will be added
+
+    */
+  def /(segment: String): Path
+
+  /**
+    * Converts the current path to a list of segments. A `/` is not counted as a segment.
+    * E.g.: /a/b//c/d will be converted to List("a", "b", "c", "d")
+    *
+    * @return a list of segments represented as string
+    */
+  def segments: Seq[String]
+
+  /**
+    * Returns the last segment, if any. A `/` is not counted as a segment.
+    * Example: /a/b/c/ will return "c"
+    *
+    * @return the last segment.
+    */
+  def lastSegment: Option[String]
+
+  /**
+    * Number of segments present on the current path. A `/` is not counted as a segment.
+    * E.g.: `/a/b//c/d` will have 4 segments. The same as `/a/b/c/d`
+    */
+  def size: Int
+}
+
+object Path {
+
+  /**
+    * Constant value for a single slash.
+    */
+  final val / = Slash(Empty)
+
+  /**
+    * Attempts to parse the argument string as an `ipath-abempty` Path as defined by RFC 3987.
+    *
+    * @param string the string to parse as a Path
+    * @return Right(Path) if the parsing succeeds, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Path] =
+    abempty(string)
+
+  /**
+    * Attempts to parse the argument string as an `ipath-abempty` Path as defined by RFC 3987.
+    *
+    * @param string the string to parse as a Path
+    * @return Right(Path) if the parsing succeeds, Left(error) otherwise
+    */
+  final def abempty(string: String): Either[String, Path] =
+    new IriParser(string).parsePathAbempty
+
+  /**
+    * Attempts to parse the argument string as an `ipath-rootless` Path as defined by RFC 3987.
+    * A rootless path is a path which does not start with slash
+    *
+    * @param string the string to parse as a Path
+    * @return Right(Path) if the parsing succeeds, Left(error) otherwise
+    */
+  final def rootless(string: String): Either[String, Path] =
+    new IriParser(string).parsePathRootLess
+
+  /**
+    * Attempts to parse the argument string as an `isegment-nz` Segment as defined by RFC 3987.
+    *
+    * @param string the string to parse as a Path
+    * @return Right(Path) if the parsing succeeds, Left(error) otherwise
+    */
+  final def segment(string: String): Either[String, Path] =
+    new IriParser(string).parsePathSegment
+
+  /**
+    * An empty path.
+    */
+  sealed trait Empty extends Path
+
+  /**
+    * An empty path.
+    */
+  final case object Empty extends Empty {
+    type Head = this.type
+    def isEmpty: Boolean                                   = true
+    def head: Head                                         = this
+    def tail(dropSlash: Boolean): Path                     = this
+    def isSlash: Boolean                                   = false
+    def isSegment: Boolean                                 = false
+    def asEmpty: Option[Empty]                             = Some(this)
+    def asSlash: Option[Slash]                             = None
+    def asSegment: Option[Segment]                         = None
+    def iriString: String                                  = ""
+    def uriString: String                                  = ""
+    def startWithSlash: Boolean                            = false
+    def prepend(other: Path, allowSlashDup: Boolean): Path = other
+    def /(segment: String): Path                           = if (segment.isEmpty) this else Segment(segment, this)
+    def segments: Seq[String]                              = Vector.empty
+    def lastSegment: Option[String]                        = None
+    def size: Int                                          = 0
+  }
+
+  /**
+    * A path that ends with a '/' character.
+    *
+    * @param rest the remainder of the path (excluding the '/')
+    */
+  final case class Slash(rest: Path) extends Path {
+    type Head = Char
+    def isEmpty: Boolean               = false
+    def head                           = '/'
+    def tail(dropSlash: Boolean): Path = if (dropSlash && rest.endsWithSlash) rest.tail(dropSlash) else rest
+    def isSlash: Boolean               = true
+    def isSegment: Boolean             = false
+    def asEmpty: Option[Empty]         = None
+    def asSlash: Option[Slash]         = Some(this)
+    def asSegment: Option[Segment]     = None
+    def iriString: String              = rest.iriString + "/"
+    def uriString: String              = rest.uriString + "/"
+    def startWithSlash: Boolean        = if (rest.isEmpty) true else rest.startWithSlash
+    @tailrec
+    def prepend(other: Path, allowSlashDup: Boolean): Path =
+      if (!allowSlashDup && other.endsWithSlash) prepend(other.tail(), allowSlashDup)
+      else Slash(rest.prepend(other, allowSlashDup))
+    def /(segment: String): Path    = if (segment.isEmpty) this else Segment(segment, this)
+    def segments: Seq[String]       = rest.segments
+    def lastSegment: Option[String] = rest.lastSegment
+    def size: Int                   = rest.size
+  }
+
+  /**
+    * A path that ends with a segment.
+    *
+    * @param rest the remainder of the path (excluding the segment denoted by this)
+    */
+  final case class Segment private[iri] (segment: String, rest: Path) extends Path {
+    type Head = String
+    def isEmpty: Boolean                                   = false
+    def head: String                                       = segment
+    def tail(dropSlash: Boolean): Path                     = if (dropSlash && rest.endsWithSlash) rest.tail(dropSlash) else rest
+    def isSlash: Boolean                                   = false
+    def isSegment: Boolean                                 = true
+    def asEmpty: Option[Empty]                             = None
+    def asSlash: Option[Slash]                             = None
+    def asSegment: Option[Segment]                         = Some(this)
+    def iriString: String                                  = rest.iriString + segment.pctEncodeIgnore(`ipchar_preds`)
+    def uriString: String                                  = rest.uriString + segment.pctEncodeIgnore(`pchar_preds`)
+    def startWithSlash: Boolean                            = rest.startWithSlash
+    def prepend(other: Path, allowSlashDup: Boolean): Path = rest.prepend(other, allowSlashDup) / segment
+    def /(s: String): Path                                 = if (segment.isEmpty) this else Segment(s, Slash(this))
+    def segments: Seq[String]                              = rest.segments :+ segment
+    def lastSegment: Option[String]                        = Some(segment)
+    def size: Int                                          = 1 + rest.size
+  }
+
+  final implicit val pathShow: Show[Path] = Show.show(_.iriString)
+
+  final implicit val pathEq: Eq[Path] = Eq.fromUniversalEquals
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Query.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Query.scala
@@ -1,0 +1,65 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.{Eq, Show}
+import ch.epfl.bluebrain.nexus.rdf.PctString._
+import ch.epfl.bluebrain.nexus.rdf.iri.IriParser._
+
+import scala.collection.SortedMap
+import scala.collection.immutable.SortedSet
+
+/**
+  * Query part of an Iri as defined in RFC 3987.
+  *
+  * @param value a seq of key values
+  */
+final case class Query private[iri] (value: Seq[(String, String)]) {
+
+  /**
+    * The query values on a sorted multi-map
+    */
+  lazy val sorted: SortedMap[String, SortedSet[String]] =
+    SortedMap(value.groupBy(_._1).view.mapValues(e => SortedSet(e.map(_._2): _*)).toList: _*)
+
+  def get(key: String): Set[String] =
+    sorted.getOrElse(key, SortedSet.empty[String])
+
+  /**
+    * @return the string representation for the Query segment compatible with the rfc3987
+    *         (using percent-encoding only for delimiters)
+    */
+  lazy val iriString: String =
+    value
+      .map {
+        case (k, v) if v.isEmpty => k.pctEncodeIgnore(`iquery_allowed`)
+        case (k, v)              => s"${k.pctEncodeIgnore(`iquery_allowed`)}=${v.pctEncodeIgnore(`iquery_allowed`)}"
+      }
+      .mkString("&")
+
+  /**
+    * @return the string representation using percent-encoding for the Query segment
+    *         when necessary according to rfc3986
+    */
+  lazy val uriString: String =
+    value
+      .map {
+        case (k, v) if v.isEmpty => k.pctEncodeIgnore(`query_allowed`)
+        case (k, v)              => s"${k.pctEncodeIgnore(`query_allowed`)}=${v.pctEncodeIgnore(`query_allowed`)}"
+      }
+      .mkString("&")
+}
+
+object Query {
+
+  /**
+    * Attempts to parse the argument string as an `iquery` as defined by RFC 3987 and evaluate the key=value pairs.
+    *
+    * @param string the string to parse as a Query
+    * @return Right(Query) if the parsing succeeds, Left(error) otherwise
+    */
+  final def apply(string: String): Either[String, Query] =
+    new IriParser(string).parseQuery
+
+  final implicit val queryShow: Show[Query] = Show.show(_.iriString)
+
+  final implicit val queryEq: Eq[Query] = (x: Query, y: Query) => x.sorted == y.sorted
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Scheme.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/iri/Scheme.scala
@@ -1,0 +1,45 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.{Eq, Show}
+
+/**
+  * Scheme part of an Iri as defined by RFC 3987.
+  *
+  * @param value the string value of the scheme
+  */
+final case class Scheme private[iri] (value: String) {
+
+  /**
+    * Whether this scheme identifies an URN.
+    */
+  def isUrn: Boolean = value equalsIgnoreCase "urn"
+
+  /**
+    * Whether this scheme identifies an HTTPS Iri.
+    */
+  def isHttps: Boolean = value equalsIgnoreCase "https"
+
+  /**
+    * Whether this scheme identifies an HTTP Iri.
+    */
+  def isHttp: Boolean = value equalsIgnoreCase "http"
+}
+
+object Scheme {
+
+  /**
+    * Attempts to construct a scheme from the argument string value.  The provided value, if correct, will be normalized
+    * such that:
+    * {{{
+    *   Scheme("HTTPS").right.get.value == "https"
+    * }}}
+    *
+    * @param value the string representation of the scheme
+    * @return Right(value) if successful or Left(error) if the string does not conform to the RFC 3987 format
+    */
+  final def apply(value: String): Either[String, Scheme] =
+    new IriParser(value).parseScheme
+
+  final implicit val schemeShow: Show[Scheme] = Show.show(_.value)
+  final implicit val schemeEq: Eq[Scheme]     = Eq.fromUniversalEquals
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/IriSyntax.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/IriSyntax.scala
@@ -1,0 +1,28 @@
+package ch.epfl.bluebrain.nexus.rdf.syntax
+
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri._
+import ch.epfl.bluebrain.nexus.rdf.iri.Path.{Segment, Slash}
+import ch.epfl.bluebrain.nexus.rdf.iri.{Iri, Path}
+
+trait IriSyntax {
+  implicit final def iriContext(sc: StringContext): IriContext            = new IriContext(sc)
+  implicit final def stringPathOpsContext(segment: String): StringPathOps = new StringPathOps(segment)
+}
+
+final class IriContext(private val sc: StringContext) extends AnyVal {
+  def url(args: Any*): Url =
+    Url.unsafe(sc.s(args: _*))
+  def urn(args: Any*): Urn =
+    Urn.unsafe(sc.s(args: _*))
+  def iri(args: Any*): Iri =
+    Iri.unsafe(sc.s(args: _*))
+}
+
+final class StringPathOps(private val segment: String) extends AnyVal {
+
+  /**
+    * @param string the segment to be appended to a previous ''segment''
+    * @return / segment / string
+    */
+  def /(string: String): Path = Segment(string, Slash(Segment(segment, Path./)))
+}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/NodeSyntax.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/NodeSyntax.scala
@@ -1,0 +1,19 @@
+//package ch.epfl.bluebrain.nexus.rdf.syntax
+//
+//import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+//import ch.epfl.bluebrain.nexus.rdf.Node.{BNode, IriNode}
+//
+//trait NodeSyntax {
+//  implicit final def nodeContext(sc: StringContext): NodeContext = new NodeContext(sc)
+//}
+//
+//final class NodeContext(private val sc: StringContext) extends AnyVal {
+//  def b(args: Any*): BNode = {
+//    val string = sc.s(args: _*)
+//    BNode(string).getOrElse(throw new IllegalArgumentException(s"Illegal blank node identifier '$string'"))
+//  }
+//  def in(args: Any*): IriNode = {
+//    val string = sc.s(args: _*)
+//    IriNode(AbsoluteIri.unsafe(string))
+//  }
+//}

--- a/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/package.scala
+++ b/rdf/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/package.scala
@@ -1,0 +1,10 @@
+package ch.epfl.bluebrain.nexus.rdf
+
+package object syntax {
+
+  object all extends IriSyntax
+//  object all  extends IriSyntax with NodeSyntax
+  object iri extends IriSyntax
+//  object node extends NodeSyntax
+
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/RdfSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/RdfSpec.scala
@@ -1,0 +1,41 @@
+package ch.epfl.bluebrain.nexus.rdf
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.scalactic
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{EitherValues, Inspectors, OptionValues, TryValues}
+
+trait RdfSpec extends AnyWordSpecLike with Matchers with Inspectors with EitherValues with OptionValues with TryValues {
+
+  implicit def convertEitherToValuable[L, R](
+      either: Either[L, R]
+  )(implicit p: scalactic.source.Position): EitherValuable[L, R] =
+    new EitherValuable(either, p)
+
+  final class EitherValuable[L, R](either: Either[L, R], pos: scalactic.source.Position) {
+    def rightValue: R = either match {
+      case Right(value) => value
+      case Left(th: Throwable) =>
+        throw new TestFailedException(
+          (_: StackDepthException) => Some("The Either value is not a Right(_)"),
+          Some(th),
+          pos
+        )
+      case Left(_) =>
+        throw new TestFailedException((_: StackDepthException) => Some("The Either value is not a Right(_)"), None, pos)
+    }
+
+    def leftValue: L = either match {
+      case Left(value) => value
+      case Right(_) =>
+        throw new TestFailedException((_: StackDepthException) => Some("The Either value is not a Left(_)"), None, pos)
+    }
+  }
+
+  def urlEncode(s: String): String = URLEncoder.encode(s, UTF_8.displayName()).replaceAll("\\+", "%20")
+
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/AuthoritySpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/AuthoritySpec.scala
@@ -1,0 +1,32 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority.{Host, Port, UserInfo}
+
+class AuthoritySpec extends RdfSpec {
+  "An Authority" should {
+    "be constructed successfully" in {
+      // format: off
+      val values = List(
+        "user:pass@1.1.1.1:8080"  -> Authority(Some(UserInfo("user:pass").rightValue), Host.ipv4("1.1.1.1").rightValue, Some(Port(8080).rightValue)),
+        "google.com"              -> Authority(None, Host.named("google.com").rightValue, None),
+        "user:£¤¥@epfl.ch"        -> Authority(Some(UserInfo("user:£¤¥").rightValue), Host.named("epfl.ch").rightValue, None)
+      )
+      // format: on
+      forAll(values) {
+        case (string, authority) =>
+          authority.iriString shouldEqual string
+          authority.show shouldEqual string
+      }
+    }
+
+    "eq" in {
+      val upper = Authority(None, Host.named("EPFL.CH").rightValue, None)
+      val lower = Authority(None, Host.named("epfl.ch").rightValue, None)
+      Eq.eqv(upper, lower) shouldEqual true
+    }
+  }
+
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/ComponentSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/ComponentSpec.scala
@@ -1,0 +1,36 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+
+class ComponentSpec extends RdfSpec {
+
+  "A R or Q Component" should {
+    "be constructed successfully" in {
+      val cases = List(
+        "a"                     -> "a",
+        "a%C2%A3/?:@;&b%C3%86c" -> "a£/?:@;&bÆc",
+        "a£/?:@;&bÆc"           -> "a£/?:@;&bÆc"
+      )
+      forAll(cases) {
+        case (str, expected) =>
+          Component(str).rightValue.value shouldEqual expected
+      }
+    }
+    "fail to construct" in {
+      val strings = List("", "asd?=", "asd?+", "asd?=a", "asd?+a")
+      forAll(strings) { s =>
+        Component(s).leftValue
+      }
+    }
+    "show" in {
+      Component("a%C2%A3/?:@;&b%C3%86c").rightValue.show shouldEqual "a£/?:@;&bÆc"
+    }
+    "eq" in {
+      val lhs = Component("a%C2%A3/?:@;&b%C3%86c").rightValue
+      val rhs = Component("a£/?:@;&bÆc").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/CurieSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/CurieSpec.scala
@@ -1,0 +1,97 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Curie._
+
+class CurieSpec extends RdfSpec {
+  "A Prefix" should {
+
+    val valid   = List("prefix", "PrEfIx", "_prefix", "__prefix", "_.prefix", "pre-fix", "_123.456", "Àprefix", "Öfix")
+    val invalid = List("-prefix", "!prefix", ":prefix", ".prefix", "6prefix", "prefi!x", "prefix:", "")
+
+    "be parsed correctly from string" in {
+      forAll(valid)(in => Prefix(in).rightValue.value shouldEqual in)
+    }
+
+    "fail parsing from an invalid string" in {
+      forAll(invalid)(in => Prefix(in).leftValue should not be empty)
+    }
+
+    "show" in {
+      forAll(valid)(in => Prefix(in).rightValue.show shouldEqual in)
+    }
+
+    "eq" in {
+      val lhs = Prefix("prefix").rightValue
+      val rhs = Prefix("prefix").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+
+  "A Curie" should {
+    val valid = List(
+      ("rdf:type", "rdf", "type"),
+      ("prefix://me:me@hOst:443/a/b?a&e=f&b=c#frag", "prefix", "//me:me@host:443/a/b?a&e=f&b=c#frag"),
+      ("PrEfIx://me:me@hOst#frag", "PrEfIx", "//me:me@host#frag"),
+      ("_prefix:/some/:/path", "_prefix", "/some/:/path"),
+      ("_.prefix:/:/some/path", "_.prefix", "/:/some/path"),
+      ("pre-fix:some/:/path", "pre-fix", "some/:/path"),
+      ("_123.456:?q=v", "_123.456", "?q=v"),
+      ("Àprefix:#frag", "Àprefix", "#frag"),
+      ("Öfix://hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://", "Öfix", "//host£:80/a£/bÆc//:://")
+    )
+    val invalid = List(
+      "-prefix",
+      "!prefix",
+      ":prefix",
+      ".prefix",
+      "6prefix",
+      "prefi!x",
+      "prefix:",
+      "//hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://",
+      "?q=v",
+      ""
+    )
+
+    "be parsed correctly from string" in {
+      forAll(valid) {
+        case (in, p, r) =>
+          val curie = Curie(in).rightValue
+          curie.prefix.value shouldEqual p
+          curie.reference.iriString shouldEqual r
+          curie.show shouldEqual s"$p:${curie.reference.iriString}"
+      }
+    }
+
+    "fail parsing from an invalid string" in {
+      forAll(invalid)(in => Curie(in).leftValue should not be empty)
+    }
+
+    "eq" in {
+      val lhs = Curie("rdf:type").rightValue
+      val rhs = Curie("rdf:type").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+
+    "not eq" in {
+      val lhs = Curie("rdf:type").rightValue
+      val rhs = Curie("RdF:type").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual false
+    }
+
+    "fail to convert to iri when resolved curie is not an AbsoluteIri" in {
+      val c   = Curie("rdf:type?a=b").rightValue
+      val iri = Iri.uri("http://example.com/b?c=d").rightValue
+      c.toIri(iri).leftValue
+    }
+
+    "convert to iri with prefix map" in {
+      val c   = Curie("rdf:type").rightValue
+      val iri = Iri.uri("http://example.com/a/").rightValue
+      val map = Map(Prefix("rdf").rightValue -> iri)
+      c.toIri(map).rightValue shouldEqual Iri.uri("http://example.com/a/type").rightValue
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/FragmentSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/FragmentSpec.scala
@@ -1,0 +1,40 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+
+class FragmentSpec extends RdfSpec {
+
+  "A Fragment" should {
+    val pct =
+      "%C2%A3%C2%A4%C2%A5%C2%A6%C2%A7%C2%A8%C2%A9%C2%AA%C2%AB%C2%AC%C2%AD%C2%AE%C2%AF%C2%B0%C2%B1%C2%B2%C2%B3%C2%B4%C2%B5%C2%B6%C2%B7%C2%B8%C2%B9%C2%BA%C2%BB%C2%BC%C2%BD%C2%BE%C2%BF%C3%80%C3%81%C3%82%C3%83%C3%84%C3%85%C3%86"
+    val ucs    = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆ"
+    val delims = "!$&'()*+,;=:"
+    val rest   = "?/:@"
+
+    "be parsed correctly from a string" in {
+      Fragment(pct + ucs + delims + rest).rightValue.value shouldEqual ucs + ucs + delims + rest
+    }
+
+    "succeed for empty" in {
+      Fragment("").rightValue
+    }
+
+    "show" in {
+      val encodedDelims = urlEncode("#[]")
+      Fragment(pct + ucs + delims + rest + encodedDelims).rightValue.show shouldEqual ucs + ucs + delims + rest + encodedDelims
+    }
+
+    "pct encoded representation" in {
+      val encodedDelims = urlEncode("#[]")
+      Fragment(pct + ucs + delims + rest + encodedDelims).rightValue.uriString shouldEqual pct + pct + delims + rest + encodedDelims
+    }
+
+    "eq" in {
+      val lhs = Fragment(pct + ucs + delims + rest).rightValue
+      val rhs = Fragment(ucs + ucs + delims + rest).rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/HostSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/HostSpec.scala
@@ -1,0 +1,173 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority.Host
+
+class HostSpec extends RdfSpec {
+
+  "An IPv4Host" should {
+    val one = Host.ipv4("1.1.1.1").rightValue
+    "be parsed correctly from string" in {
+      val values = List("127.0.0.1", "255.255.255.255", "199.99.9.0", "249.249.249.249")
+      forAll(values) { v =>
+        Host.ipv4(v).rightValue.show shouldEqual v
+      }
+    }
+    "be constructed correctly from bytes" in {
+      Host.ipv4(1, 1, 1, 1).show shouldEqual one.show
+    }
+    "be constructed correctly from array" in {
+      Host.ipv4(Array.fill[Byte](4)(1)).rightValue.show shouldEqual one.show
+    }
+    "fail to construct from incorrect array length" in {
+      forAll(List(Array.fill[Byte](3)(1), Array.fill[Byte](5)(1))) { arr =>
+        Host.ipv4(arr).leftValue should not be empty
+      }
+    }
+    "fail to parse from string" in {
+      val values = List(
+        "1",
+        "1.1.1",
+        "1.1.1.",
+        "1..1.1",
+        "a.b.c.d",
+        "01.1.1.1",
+        "1.01.1.1",
+        "1.1.01.1",
+        "1.1.1.01",
+        "1.1.1.1a",
+        "256.255.255.255",
+        "255.256.255.255",
+        "255.255.256.255",
+        "255.255.255.256",
+        "355.255.255.255",
+        "260.255.255.256"
+      )
+      forAll(values) { v =>
+        Host.ipv4(v).leftValue should not be empty
+      }
+    }
+    "be an IPv4 address" in {
+      one.isIPv4 shouldEqual true
+    }
+    "return itself as IPv4 address" in {
+      one.asIPv4 shouldEqual Some(one)
+    }
+    "not be an IPv6 address" in {
+      one.isIPv6 shouldEqual false
+    }
+    "not be a named host" in {
+      one.isNamed shouldEqual false
+    }
+    "not return an IPv6Host" in {
+      one.asIPv6 shouldEqual None
+    }
+    "not return a NamedHost" in {
+      one.asNamed shouldEqual None
+    }
+    "show" in {
+      one.show shouldEqual "1.1.1.1"
+    }
+    "eq" in {
+      Eq.eqv(Host.ipv4("1.1.1.1").rightValue, one) shouldEqual true
+    }
+  }
+
+  "An IPv6Host" should {
+    val one       = Host.ipv6(Array.fill(16)(1.toByte))
+    val oneString = "101:101:101:101:101:101:101:101"
+    "be constructed correctly from array" in {
+      one.rightValue.show shouldEqual oneString
+    }
+    "be rendered correctly as mixed ipv4/ipv6" in {
+      one.rightValue.asMixedString shouldEqual "101:101:101:101:101:101:1.1.1.1"
+    }
+    "fail to construct from incorrect array length" in {
+      forAll(List(Array.fill(17)(1.toByte), Array.fill(3)(1.toByte), Array.fill(15)(1.toByte))) { arr =>
+        Host.ipv6(arr).leftValue should not be empty
+      }
+    }
+    "be an IPv6 address" in {
+      one.rightValue.isIPv6 shouldEqual true
+    }
+    "return itself as IPv6 address" in {
+      one.rightValue.asIPv6 shouldEqual Some(one.rightValue)
+    }
+    "not be an IPv4 address" in {
+      one.rightValue.isIPv4 shouldEqual false
+    }
+    "not be a named host" in {
+      one.rightValue.isNamed shouldEqual false
+    }
+    "not return an IPv4Host" in {
+      one.rightValue.asIPv4 shouldEqual None
+    }
+    "not return a NamedHost" in {
+      one.rightValue.asNamed shouldEqual None
+    }
+    "show" in {
+      one.rightValue.show shouldEqual oneString
+    }
+    "eq" in {
+      Eq.eqv(Host.ipv6(Array.fill(16)(1.toByte)).rightValue, one.rightValue) shouldEqual true
+    }
+  }
+
+  "A NamedHost" should {
+    val pct =
+      "%C2%A3%C2%A4%C2%A5%C2%A6%C2%A7%C2%A8%C2%A9%C2%AA%C2%AB%C2%AC%C2%AD%C2%AE%C2%AF%C2%B0%C2%B1%C2%B2%C2%B3%C2%B4%C2%B5%C2%B6%C2%B7%C2%B8%C2%B9%C2%BA%C2%BB%C2%BC%C2%BD%C2%BE%C2%BF%C3%80%C3%81%C3%82%C3%83%C3%84%C3%85%C3%86"
+    val pctLow =
+      "%C2%A3%C2%A4%C2%A5%C2%A6%C2%A7%C2%A8%C2%A9%C2%AA%C2%AB%C2%AC%C2%AD%C2%AE%C2%AF%C2%B0%C2%B1%C2%B2%C2%B3%C2%B4%C2%B5%C2%B6%C2%B7%C2%B8%C2%B9%C2%BA%C2%BB%C2%BC%C2%BD%C2%BE%C2%BF%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6"
+    val ucsUp  = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆ"
+    val ucsLow = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿àáâãäåæ"
+    val delims = "!$&'()*+,;="
+    val up     = "ABCD"
+    val low    = "abcd"
+
+    "be parsed correctly from a string" in {
+      Host.named("epfl.ch").rightValue.value shouldEqual "epfl.ch"
+    }
+
+    "be parsed correctly from percent encoded string" in {
+      Host.named(pct).rightValue.value shouldEqual ucsLow
+    }
+
+    "be parsed correctly from ucs chars" in {
+      Host.named(ucsUp).rightValue.value shouldEqual ucsLow
+    }
+
+    "be parsed correctly from delimiters" in {
+      Host.named(delims).rightValue.value shouldEqual delims
+    }
+
+    "be parsed correctly from mixed characters" in {
+      Host.named(ucsUp + pct + delims + up).rightValue.value shouldEqual (ucsLow + ucsLow + delims + low)
+    }
+
+    "show" in {
+      val encodedDelim = urlEncode("[]#")
+      Host.named(up + encodedDelim).rightValue.show shouldEqual (low + encodedDelim)
+      Host.named(up + encodedDelim).rightValue.asInstanceOf[Host].show shouldEqual (low + encodedDelim)
+    }
+
+    "pct encoded representation" in {
+      val encodedDelim = urlEncode("[]#")
+      Host.named(ucsUp + pct + ucsLow + delims + up + encodedDelim).rightValue.uriString shouldEqual
+        (pctLow + pctLow + pctLow + delims + low + encodedDelim)
+    }
+
+    "be named" in {
+      Host.named(up).rightValue.isNamed shouldEqual true
+    }
+
+    "return an optional self" in {
+      Host.named(up).rightValue.asNamed shouldEqual Some(Host.named(up).rightValue)
+    }
+
+    "eq" in {
+      Eq.eqv(Host.named(ucsUp).rightValue, Host.named(ucsLow).rightValue) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/IriSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/IriSpec.scala
@@ -1,0 +1,110 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri.Urn
+
+class IriSpec extends RdfSpec {
+  "An Iri" should {
+    val casesRelative = List(
+      "//me:me@hOst:443/a/b?a&e=f&b=c#frag" -> "//me:me@host:443/a/b?a&e=f&b=c#frag",
+      "//me:me@hOst#frag"                   -> "//me:me@host#frag",
+      "/some/:/path"                        -> "/some/:/path"
+    )
+    val casesRelativeEncoded = List(
+      "/some/!/path/€/other" -> "/some/!/path/%E2%82%AC/other"
+    )
+    val casesUrn = List(
+      "urn:uUid:6e8bc430-9c3a-11d9-9669-0800200c9a66"      -> "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
+      "urn:lex:eu:council:directive:2010-03-09;2010-19-UE" -> "urn:lex:eu:council:directive:2010-03-09;2010-19-UE"
+    )
+    val casesUrnEncoded = List(
+      "urn:example:a%C2%A3/b%C3%86c//:://?=a=£"            -> "urn:example:a%C2%A3/b%C3%86c//:://?=a=%C2%A3",
+      "urn:lex:eu:council:directive:2010-03-09;2010-19-UE" -> "urn:lex:eu:council:directive:2010-03-09;2010-19-UE"
+    )
+    val casesUrl = List(
+      "hTtps://me:me@hOst:443/a%20path/b?a&e=f&b=c#frag" -> "https://me:me@host/a%20path/b?a&e=f&b=c#frag",
+      "hTtps://me:me@hOst#frag"                          -> "https://me:me@host#frag"
+    )
+
+    val casesUrlEncoded = List(
+      "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//%3A%3A//"    -> "http://host%C2%A3/a%C2%A3/b%C3%86c//:://",
+      "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//%3A%3A/%20/" -> "http://host%C2%A3/a%C2%A3/b%C3%86c//::/%20/"
+    )
+
+    "be parsed correctly into a relative uri" in {
+      forAll(casesRelative) {
+        case (in, expected) =>
+          val iri = Iri(in).rightValue
+          iri shouldEqual Iri.relative(in).rightValue
+          iri.iriString shouldEqual expected
+          iri.show shouldEqual expected
+      }
+    }
+
+    "be parsed correctly into a urn" in {
+      forAll(casesUrn) {
+        case (in, expected) =>
+          val iri = Iri(in).rightValue
+          iri shouldEqual Iri.urn(in).rightValue
+          iri.iriString shouldEqual expected
+      }
+    }
+
+    "be parsed correctly into a url" in {
+      forAll(casesUrl) {
+        case (in, expected) =>
+          val iri = Iri(in).rightValue
+          iri shouldEqual Iri.url(in).rightValue
+          iri.iriString shouldEqual expected
+      }
+    }
+
+    "avoid double pct-encoding" in {
+      val iri = Iri.uri("http://example.com/a/path").rightValue / "http%3A%2F%2Fsome.com%2Fa%2Fb%C3%86c"
+      iri.iriString shouldEqual "http://example.com/a/path/http%3A%2F%2Fsome.com%2Fa%2Fb%C3%86c"
+      iri.iriString shouldEqual iri.uriString
+    }
+
+    "show as url" in {
+      forAll(casesUrlEncoded) {
+        case (in, expected) =>
+          Iri(in).rightValue.uriString shouldEqual expected
+      }
+    }
+
+    "show as uri" in {
+      forAll(casesUrnEncoded) {
+        case (in, expected) =>
+          Iri(in).rightValue.uriString shouldEqual expected
+      }
+    }
+
+    "show as relative uri" in {
+      forAll(casesRelativeEncoded) {
+        case (in, expected) =>
+          Iri(in).rightValue.uriString shouldEqual expected
+      }
+    }
+
+    "eq relative" in {
+      val lhs = Iri("/?q=asd#1").rightValue
+      val rhs = Iri("/?q=asd#1").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+
+    "eq urn" in {
+      val lhs = Urn("urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash").rightValue
+      val rhs = Urn("urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+
+    "eq url" in {
+      val lhs = Iri("hTtp://gooGle.com/?q=asd#1").rightValue
+      val rhs = Iri("http://google.com/?q=asd#1").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/NidSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/NidSpec.scala
@@ -1,0 +1,34 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+
+class NidSpec extends RdfSpec {
+
+  "A Nid" should {
+    "be constructed successfully" in {
+      val strings = List("aa", "a-a", "1a", "11", "AA", s"a${List.fill(30)("1").mkString}a")
+      forAll(strings) { s =>
+        Nid(s).rightValue
+      }
+    }
+    "fail to construct" in {
+      val strings = List("", "-a", "a-", "a", "%20a", "-", s"a${List.fill(31)("1").mkString}a")
+      forAll(strings) { s =>
+        Nid(s).leftValue
+      }
+    }
+    val normalized = Nid("IbAn")
+
+    "normalize input during construction" in {
+      normalized.rightValue.value shouldEqual "iban"
+    }
+    "show" in {
+      normalized.rightValue.show shouldEqual "iban"
+    }
+    "eq" in {
+      Eq.eqv(Nid("iban").rightValue, normalized.rightValue) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/PathSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/PathSpec.scala
@@ -1,0 +1,237 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Path._
+import ch.epfl.bluebrain.nexus.rdf.syntax.all._
+
+class PathSpec extends RdfSpec {
+
+  "A Path" should {
+    val abcd = Path("/a/b//c/d")
+    "be parsed in the correct ADT" in {
+      // format: off
+      val cases = List(
+        ""                        -> Empty,
+        "/"                       -> Slash(Empty),
+        "///"                     -> Slash(Slash(Slash(Empty))),
+        "/a/b//c/d"               -> Segment("d", Slash(Segment("c", Slash(Slash(Segment("b", Slash(Segment("a", Slash(Empty))))))))),
+        "/a/b//c//"               -> Slash(Slash(Segment("c", Slash(Slash(Segment("b", Slash(Segment("a", Slash(Empty))))))))),
+        "/a/b//:@//"              -> Slash(Slash(Segment(":@", Slash(Slash(Segment("b", Slash(Segment("a", Slash(Empty))))))))),
+        "/a/b//:://"              -> Slash(Slash(Segment("::", Slash(Slash(Segment("b", Slash(Segment("a", Slash(Empty))))))))),
+        "/a/b/%20/:://"           -> Slash(Slash(Segment("::", Slash(Segment(" ", Slash(Segment("b", Slash(Segment("a", Slash(Empty)))))))))),
+        "/a£/bÆc//:://"           -> Slash(Slash(Segment("::", Slash(Slash(Segment("bÆc", Slash(Segment("a£", Slash(Empty))))))))),
+        "/a%C2%A3/b%C3%86c//:://" -> Slash(Slash(Segment("::", Slash(Slash(Segment("bÆc", Slash(Segment("a£", Slash(Empty)))))))))
+      )
+      // format: on
+      forAll(cases) {
+        case (str, expected) =>
+          Path(str).rightValue shouldEqual expected
+      }
+    }
+
+    "be parsed in the correct ADT for rootless paths" in {
+      // format: off
+      val cases = List(
+        "a/b//c/d"               -> Segment("d", Slash(Segment("c", Slash(Slash(Segment("b", Slash(Segment("a", Empty)))))))),
+        "a/b//c//"               -> Slash(Slash(Segment("c", Slash(Slash(Segment("b", Slash(Segment("a", Empty)))))))),
+        "a/b//:@//"              -> Slash(Slash(Segment(":@", Slash(Slash(Segment("b", Slash(Segment("a", Empty)))))))),
+        "a/b//:://"              -> Slash(Slash(Segment("::", Slash(Slash(Segment("b", Slash(Segment("a", Empty)))))))),
+        "a/b/%20/:://"           -> Slash(Slash(Segment("::", Slash(Segment(" ", Slash(Segment("b", Slash(Segment("a", Empty))))))))),
+        "a£/bÆc//:://"           -> Slash(Slash(Segment("::", Slash(Slash(Segment("bÆc", Slash(Segment("a£", Empty)))))))),
+        "a%C2%A3/b%C3%86c//:://" -> Slash(Slash(Segment("::", Slash(Slash(Segment("bÆc", Slash(Segment("a£", Empty))))))))
+      )
+      // format: on
+      forAll(cases) {
+        case (str, expected) =>
+          Path.rootless(str).rightValue shouldEqual expected
+      }
+    }
+    "fail to construct for invalid chars" in {
+      val cases = List("/a/b?", "abc", "/a#", ":asd", " ")
+      forAll(cases) { c =>
+        Path(c).leftValue
+      }
+    }
+    "normalize paths" in {
+      val cases = List(
+        ("/a/b/../c/", Slash(Segment("c", Slash(Segment("a", Slash(Empty))))), "/a/c/"),
+        ("/../../../", Slash(Empty), "/"),
+        ("/a/./b/./c/./", Slash(Segment("c", Slash(Segment("b", Slash(Segment("a", Slash(Empty))))))), "/a/b/c/"),
+        ("/a//../b/./c/./", Slash(Segment("c", Slash(Segment("b", Slash(Segment("a", Slash(Empty))))))), "/a/b/c/"),
+        ("/a/./b/../c/./", Slash(Segment("c", Slash(Segment("a", Slash(Empty))))), "/a/c/"),
+        ("/a/c/../", Slash(Segment("a", Slash(Empty))), "/a/"),
+        ("/a/c/./", Slash(Segment("c", Slash(Segment("a", Slash(Empty))))), "/a/c/")
+      )
+      forAll(cases) {
+        case (str, expected, expectedStr) =>
+          val value = Path(str).rightValue
+          value shouldEqual expected
+          value.show shouldEqual expectedStr
+      }
+    }
+    "return the correct information about the internal structure" in {
+      val cases = List(
+        ("", true, false, false, Some(Empty), None, None),
+        ("/", false, true, false, None, Some(Slash(Empty)), None),
+        ("/a/", false, true, false, None, Some(Slash(Segment("a", Slash(Empty)))), None),
+        ("/a", false, false, true, None, None, Some(Segment("a", Slash(Empty))))
+      )
+      forAll(cases) {
+        case (str, isEmpty, isSlash, isSegment, asEmpty, asSlash, asSegment) =>
+          val p = Path(str).rightValue
+          p.isEmpty shouldEqual isEmpty
+          p.isSlash shouldEqual isSlash
+          p.isSegment shouldEqual isSegment
+          p.asEmpty shouldEqual asEmpty
+          p.asSlash shouldEqual asSlash
+          p.asSegment shouldEqual asSegment
+      }
+    }
+    "show" in {
+      val encodedDelims = urlEncode("/#[]?")
+      Path("/" + encodedDelims + "/%20a/b//c/d/£¤¥").rightValue.show shouldEqual "/" + encodedDelims + "/%20a/b//c/d/£¤¥"
+    }
+    "pct encoded representation" in {
+      val encodedDelims = urlEncode("/#[]?")
+      val utf8          = "£¤¥"
+      val utf8Encoded   = urlEncode(utf8)
+      Path("/" + encodedDelims + "/a/b//c/d/" + utf8 + "/" + utf8Encoded).rightValue.uriString shouldEqual
+        "/" + encodedDelims + "/a/b//c/d/" + utf8Encoded + "/" + utf8Encoded
+    }
+    "be slash" in {
+      Path("/").rightValue.isSlash shouldEqual true
+    }
+    "not be slash" in {
+      abcd.rightValue.isSlash shouldEqual false
+    }
+    "end with slash" in {
+      Path("/a/b//c/d/").rightValue.endsWithSlash shouldEqual true
+    }
+    "not end with slash" in {
+      abcd.rightValue.endsWithSlash shouldEqual false
+    }
+    "show decoded" in {
+      Path("/a%C2%A3/b%C3%86c//:://").rightValue.show shouldEqual "/a£/bÆc//:://"
+    }
+    "eq" in {
+      Eq.eqv(abcd.rightValue, Segment("d", Path("/a/b//c/").rightValue)) shouldEqual true
+    }
+
+    "start with slash" in {
+      val cases = List("/", "///", "/a/b/c/d", "/a/b/c/d/")
+      forAll(cases)(str => Path(str).rightValue.startWithSlash shouldEqual true)
+    }
+
+    "does not start with slash" in {
+      val cases = List(Empty, Segment("d", Slash(Segment("c", Slash(Slash(Segment("b", Slash(Segment("a", Empty)))))))))
+      forAll(cases)(p => p.startWithSlash shouldEqual false)
+    }
+
+    "reverse" in {
+      val cases = List(
+        Path("/a/b").rightValue    -> Slash(Segment("a", Slash(Segment("b", Empty)))),
+        Empty                      -> Empty,
+        Path("/a/b/c/").rightValue -> Path("/c/b/a/").rightValue,
+        Path./                     -> Path./
+      )
+      forAll(cases) {
+        case (path, reversed) =>
+          path.reverse shouldEqual reversed
+          path.reverse.reverse shouldEqual path
+      }
+    }
+
+    "concatenate segments" in {
+      segment("a").rightValue / "b" / "c" shouldEqual Segment("c", Slash(Segment("b", Slash(Segment("a", Empty)))))
+    }
+
+    "build" in {
+      val path = "a" / "b" / "c"
+      path shouldEqual Path("/a/b/c").rightValue
+    }
+
+    "join two paths" in {
+      val cases = List(
+        (Path("/e/f").rightValue, Path("/a/b/c/d").rightValue)           -> Path("/a/b/c/d/e/f").rightValue,
+        (segment("ghi").rightValue / "f", Path("/a/b/c/def").rightValue) -> Path("/a/b/c/def/ghi/f").rightValue,
+        (Empty, Path("/a/b").rightValue)                                 -> Path("/a/b").rightValue,
+        (Empty, Slash(Empty))                                            -> Slash(Empty),
+        (Slash(Empty), Empty)                                            -> Slash(Empty),
+        (Path("/e/f/").rightValue, Path("/a/b/c/d").rightValue)          -> Path("/a/b/c/d/e/f/").rightValue,
+        (Path("/e/f/").rightValue, Path("/a/b/c/d/").rightValue)         -> Path("/a/b/c/d/e/f/").rightValue,
+        (Empty, Empty)                                                   -> Empty
+      )
+      forAll(cases) {
+        case ((left, right), expected) => right / left shouldEqual expected
+      }
+      Path("/e/f/").rightValue.prepend(Path("/a/b/c/d/").rightValue, allowSlashDup = true) shouldEqual Path(
+        "/a/b/c/d//e/f/"
+      ).rightValue
+    }
+
+    "return the head" in {
+      Path("/a/b/c/").rightValue.head shouldEqual '/'
+      Path("/a/b/c").rightValue.head shouldEqual "c"
+      Path.Empty.head shouldEqual Path.Empty
+    }
+
+    "return the tail" in {
+      Path("/a/b/c/").rightValue.tail() shouldEqual Path("/a/b/c").rightValue
+      Path("/a/b/c").rightValue.tail() shouldEqual Path("/a/b/").rightValue
+      Path.Empty.tail() shouldEqual Path.Empty
+      Path("/a/b/c").rightValue.tail().tail().tail().tail().tail() shouldEqual Path("/").rightValue
+
+      Path("/a/b/c/").rightValue.tail(dropSlash = true) shouldEqual Path("/a/b/c").rightValue
+      Path("/a/b/c///").rightValue.tail(dropSlash = true) shouldEqual Path("/a/b/c").rightValue
+      Path("/a/b/c").rightValue.tail().tail(dropSlash = true) shouldEqual Path("/a/b").rightValue
+      Path.Empty.tail(dropSlash = true) shouldEqual Path.Empty
+      Path("/a/b/c").rightValue.tail(dropSlash = true).tail(dropSlash = true) shouldEqual Path("/a").rightValue
+    }
+
+    "to segments" in {
+      val cases =
+        List(Path("/a/b/c/d/e/").rightValue, Path("/a//b/c//d//e//").rightValue, Path("/a/b/c/d/e").rightValue)
+      forAll(cases) { path =>
+        path.segments shouldEqual List("a", "b", "c", "d", "e")
+      }
+      Path.Empty.segments shouldEqual List.empty[String]
+      Path("/a/").rightValue.segments shouldEqual List("a")
+    }
+
+    "return the last segment" in {
+      Path("/a/b/c").rightValue.lastSegment shouldEqual Some("c")
+      Path("/a/b/c/").rightValue.lastSegment shouldEqual Some("c")
+      Path("/a/b//c//").rightValue.lastSegment shouldEqual Some("c")
+      Path.Empty.lastSegment shouldEqual None
+    }
+
+    "number of segments" in {
+      val cases =
+        List(Path("/a/b/c/d/e/").rightValue, Path("/a//b/c//d//e//").rightValue, Path("/a/b/c/d/e").rightValue)
+      forAll(cases) { path =>
+        path.size shouldEqual 5
+      }
+      Path.Empty.size shouldEqual 0
+      Path("/a/").rightValue.size shouldEqual 1
+    }
+
+    "starts with another path" in {
+      val cases = List(
+        Path("/a/b//c/d") -> true,
+        Path("/a/b//c")   -> true,
+        Path("/a/b//")    -> true,
+        Path("/a")        -> true,
+        Path("/")         -> true,
+        Path("//")        -> false,
+        Path("/a/c")      -> false
+      )
+      forAll(cases) {
+        case (other, expected) => abcd.rightValue startsWith other.rightValue shouldEqual expected
+      }
+      Path("/").rightValue startsWith Path("/").rightValue shouldEqual true
+      Path.Empty startsWith Path("/").rightValue shouldEqual false
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/PortSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/PortSpec.scala
@@ -1,0 +1,36 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority.Port
+
+class PortSpec extends RdfSpec {
+
+  "A Port" should {
+    "be constructed successfully" in {
+      val strings = List("0", "1", "10", "65535", "60000")
+      forAll(strings) { s =>
+        Port(s).rightValue
+      }
+    }
+    "be range checked" in {
+      val ints = List(-1, 65536)
+      forAll(ints) { i =>
+        Port(i).leftValue
+      }
+    }
+    "fail to construct" in {
+      val strings = List("", "00", "01", "-1", "65536")
+      forAll(strings) { s =>
+        Port(s).leftValue
+      }
+    }
+    "show" in {
+      Port(1).rightValue.show shouldEqual "1"
+    }
+    "eq" in {
+      Eq.eqv(Port("1").rightValue, Port(1).rightValue) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/QuerySpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/QuerySpec.scala
@@ -1,0 +1,62 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+class QuerySpec extends RdfSpec {
+
+  "A Query" should {
+    "be constructed successfully" in {
+      // format: off
+      val cases = List(
+        "" -> SortedMap.empty[String, SortedSet[String]],
+        "a=b&a=b&a=c&a&b&b&b=c&d/&e?" -> SortedMap(
+          "a" -> SortedSet("", "b", "c"),
+          "b" -> SortedSet("", "c"),
+          "d/" -> SortedSet(""),
+          "e?" -> SortedSet("")),
+        "%3D%26=%3D%26&%3D&%26" -> SortedMap(
+          "=&" -> SortedSet("=&"),
+          "="  -> SortedSet(""),
+          "&"  -> SortedSet("")),
+        "%C2%A3=%C3%86" -> SortedMap("£" -> SortedSet("Æ"))
+      )
+      // format: on
+      forAll(cases) {
+        case (raw, map) =>
+          Query(raw).rightValue.sorted shouldEqual map
+      }
+    }
+    "fail to parse" in {
+      val cases = List("a==b", "a=b&", "a#", "a&&", "a=&b")
+      forAll(cases) { str =>
+        Query(str).leftValue
+      }
+    }
+    "show" in {
+      val encodedDelim = urlEncode("[]#")
+      Query("a=b&a=b&a=c&a&b&b&b=c&d&e" + encodedDelim).rightValue.show shouldEqual "a=b&a=b&a=c&a&b&b&b=c&d&e" + encodedDelim
+    }
+    "fetch key" in {
+      Query("a=b&a=c&b=d").rightValue.get("a") shouldEqual Set("b", "c")
+      Query("a=b&a=c&b=d").rightValue.get("b") shouldEqual Set("d")
+      Query("a=b&a=c&b=d").rightValue.get("r") shouldEqual Set.empty[String]
+    }
+    "pct encoded representation" in {
+      val utf8         = "£Æ"
+      val encodedUtf8  = urlEncode(utf8)
+      val allowedDelim = "!:@!$()*,"
+      val encodedDelim = urlEncode("[]#")
+      Query(utf8 + encodedUtf8 + allowedDelim + encodedDelim).rightValue.uriString shouldEqual
+        (encodedUtf8 + encodedUtf8 + allowedDelim + encodedDelim)
+    }
+    "eq" in {
+      val lhs = Query("a=b&a=b&a=c&a&b&b&b=c&d&e").rightValue
+      val rhs = Query("a=b&a=b&a=c&a&b&b=c&d&e").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/RelativeIriSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/RelativeIriSpec.scala
@@ -1,0 +1,188 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri.{RelativeIri, Url}
+
+class RelativeIriSpec extends RdfSpec {
+
+  "A RelativeIri" should {
+    "be parsed correctly" in {
+      val cases = List(
+        "//me:me@hOst:443/a/b?a&e=f&b=c#frag" -> "//me:me@host:443/a/b?a&e=f&b=c#frag",
+        "//me:me@hOst#frag"                   -> "//me:me@host#frag",
+        "/some/:/path"                        -> "/some/:/path",
+        "a/../b/./c"                          -> "b/c",
+        "../../../"                           -> "../../../",
+        "/../../"                             -> "/",
+        "/:/some/path"                        -> "/:/some/path",
+        "some/:/path"                         -> "some/:/path",
+        "?q=v"                                -> "?q=v",
+        "#frag"                               -> "#frag",
+        "//hOst:443/a/b/../c"                 -> "//host:443/a/c",
+        "//1.2.3.4:80/a%C2%A3/b%C3%86c//:://" -> "//1.2.3.4:80/a£/bÆc//:://",
+        "//1.2.3.4:80/a%C2%A3/b%C3%86c//:://" -> "//1.2.3.4:80/a£/bÆc//:://",
+        "//1.2.3.4:80/a%C2%A3/b%C3%86c//:://" -> "//1.2.3.4:80/a£/bÆc//:://"
+      )
+      forAll(cases) {
+        case (in, expected) => RelativeIri(in).rightValue.iriString shouldEqual expected
+      }
+    }
+
+    "fail to parse from string" in {
+      val cases = List(
+        "http://me:me@hOst:443/a/b?a&e=f&b=c#frag",
+        ":/some/path",
+        " ",
+        ""
+      )
+      forAll(cases)(in => RelativeIri(in).leftValue should not be empty)
+    }
+    val withHash = Iri.relative("//1.2.3.4:80/a%C2%A3/b%C3%86c//:://#hash").rightValue
+
+    "be relative" in {
+      withHash.isRelative shouldEqual true
+    }
+
+    "return an optional self" in {
+      withHash.asRelative shouldEqual Some(withHash)
+    }
+
+    "not be an Urn" in {
+      withHash.isUrn shouldEqual false
+    }
+
+    "not be a Uri" in {
+      withHash.isUri shouldEqual false
+    }
+
+    "not return a Uri" in {
+      withHash.asUri shouldEqual None
+    }
+
+    "not be an Url" in {
+      withHash.isUrl shouldEqual false
+    }
+
+    "not return a urn" in {
+      withHash.asUrn shouldEqual None
+    }
+
+    "not return a url" in {
+      withHash.asUrl shouldEqual None
+    }
+
+    "eq" in {
+      val lhs = RelativeIri("a/./b/../?q=asd#1").rightValue
+      val rhs = RelativeIri("a/?q=asd#1").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+
+    "resolve from base url http://a/b/c/d;p?q" in {
+      val base = Url("http://a/b/c/d;p?q").rightValue
+      val cases = List(
+        "g"             -> "http://a/b/c/g",
+        "./g"           -> "http://a/b/c/g",
+        "g/"            -> "http://a/b/c/g/",
+        "/g"            -> "http://a/g",
+        "//g"           -> "http://g",
+        "?y"            -> "http://a/b/c/d;p?y",
+        "g?y"           -> "http://a/b/c/g?y",
+        "#s"            -> "http://a/b/c/d;p?q#s",
+        "g#s"           -> "http://a/b/c/g#s",
+        "g?y#s"         -> "http://a/b/c/g?y#s",
+        ";x"            -> "http://a/b/c/;x",
+        "g;x"           -> "http://a/b/c/g;x",
+        "g;x?y#s"       -> "http://a/b/c/g;x?y#s",
+        "."             -> "http://a/b/c/",
+        "./"            -> "http://a/b/c/",
+        ".."            -> "http://a/b/",
+        "../"           -> "http://a/b/",
+        "../g"          -> "http://a/b/g",
+        "../.."         -> "http://a/",
+        "../../"        -> "http://a/",
+        "../../../../"  -> "http://a/",
+        ".././g"        -> "http://a/b/g",
+        "../../g"       -> "http://a/g",
+        "../../../g"    -> "http://a/g",
+        "../../../../g" -> "http://a/g",
+        "..g"           -> "http://a/b/c/..g",
+        "g."            -> "http://a/b/c/g.",
+        ".g"            -> "http://a/b/c/.g",
+        "g.."           -> "http://a/b/c/g..",
+        "/../g"         -> "http://a/g",
+        "./../g"        -> "http://a/b/g",
+        "g/./h"         -> "http://a/b/c/g/h",
+        "g/../h"        -> "http://a/b/c/h",
+        "g;x=1/./y"     -> "http://a/b/c/g;x=1/y",
+        "g;x=1/../y"    -> "http://a/b/c/y"
+      )
+      forAll(cases) {
+        case (in, result) =>
+          RelativeIri(in).rightValue.resolve(base) shouldEqual Url(result).rightValue
+      }
+    }
+
+    "resolve from base url http://a/b/c/" in {
+      val base = Url("http://a/b/c/").rightValue
+      val cases = List(
+        "g"            -> "http://a/b/c/g",
+        "./g"          -> "http://a/b/c/g",
+        "g/"           -> "http://a/b/c/g/",
+        "/g"           -> "http://a/g",
+        "//g"          -> "http://g",
+        "?y"           -> "http://a/b/c/?y",
+        "g?y"          -> "http://a/b/c/g?y",
+        "#s"           -> "http://a/b/c/#s",
+        "g#s"          -> "http://a/b/c/g#s",
+        "g?y#s"        -> "http://a/b/c/g?y#s",
+        ";x"           -> "http://a/b/c/;x",
+        "g;x"          -> "http://a/b/c/g;x",
+        "g;x?y#s"      -> "http://a/b/c/g;x?y#s",
+        "."            -> "http://a/b/c/",
+        "./"           -> "http://a/b/c/",
+        ".."           -> "http://a/b/",
+        "../"          -> "http://a/b/",
+        "../g"         -> "http://a/b/g",
+        "../.."        -> "http://a/",
+        "../../"       -> "http://a/",
+        "../../../../" -> "http://a/",
+        "../../g"      -> "http://a/g"
+      )
+      forAll(cases) {
+        case (in, result) => RelativeIri(in).rightValue.resolve(base) shouldEqual Url(result).rightValue
+      }
+    }
+
+    "resolve from base url http://a/b/c/d#fragment" in {
+      val base = Url("http://a/b/c/").rightValue
+      val cases = List(
+        "g"            -> "http://a/b/c/g",
+        "./g"          -> "http://a/b/c/g",
+        "g/"           -> "http://a/b/c/g/",
+        "/g"           -> "http://a/g",
+        "//g"          -> "http://g",
+        "?y"           -> "http://a/b/c/?y",
+        "g?y"          -> "http://a/b/c/g?y",
+        "#s"           -> "http://a/b/c/#s",
+        "g#s"          -> "http://a/b/c/g#s",
+        "g?y#s"        -> "http://a/b/c/g?y#s",
+        ";x"           -> "http://a/b/c/;x",
+        "g;x"          -> "http://a/b/c/g;x",
+        "g;x?y#s"      -> "http://a/b/c/g;x?y#s",
+        "."            -> "http://a/b/c/",
+        "./"           -> "http://a/b/c/",
+        ".."           -> "http://a/b/",
+        "../"          -> "http://a/b/",
+        "../g"         -> "http://a/b/g",
+        "../.."        -> "http://a/",
+        "../../"       -> "http://a/",
+        "../../../../" -> "http://a/",
+        "../../g"      -> "http://a/g"
+      )
+      forAll(cases) {
+        case (in, result) => RelativeIri(in).rightValue.resolve(base) shouldEqual Url(result).rightValue
+      }
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/SchemeSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/SchemeSpec.scala
@@ -1,0 +1,52 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+
+class SchemeSpec extends RdfSpec {
+
+  "A Scheme" should {
+    "be constructed successfully" in {
+      val strings = List("urn", "https", "http", "file", "ftp", "ssh", "a", "a0", "a-", "a+", "a.", "HTTPS", "A0-+.")
+      forAll(strings) { s =>
+        Scheme(s).rightValue
+      }
+    }
+    "fail to construct" in {
+      val strings = List("", "0", "0a", "as_", "%20a", "0-+.")
+      forAll(strings) { s =>
+        Scheme(s).leftValue
+      }
+    }
+    "return the appropriate boolean flag" in {
+      val cases = List(
+        ("urn", true, false, false),
+        ("URN", true, false, false),
+        ("https", false, true, false),
+        ("HTTPS", false, true, false),
+        ("http", false, false, true),
+        ("HTTP", false, false, true)
+      )
+      forAll(cases) {
+        case (string, isUrn, isHttps, isHttp) =>
+          val scheme = Scheme(string).rightValue
+          scheme.isUrn shouldEqual isUrn
+          scheme.isHttps shouldEqual isHttps
+          scheme.isHttp shouldEqual isHttp
+      }
+    }
+
+    val normalized = Scheme("HtTpS").rightValue
+
+    "normalize input during construction" in {
+      normalized.value shouldEqual "https"
+    }
+    "show" in {
+      normalized.show shouldEqual "https"
+    }
+    "eq" in {
+      Eq.eqv(Scheme("https").rightValue, normalized) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/UrlSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/UrlSpec.scala
@@ -1,0 +1,112 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri._
+import ch.epfl.bluebrain.nexus.rdf.syntax.all._
+
+class UrlSpec extends RdfSpec {
+
+  "An Url" should {
+    "be parsed correctly" in {
+      val cases = List(
+        "hTtps://me:me@hOst:443/a/b?a&e=f&b=c#frag"                                                  -> "https://me:me@host/a/b?a&e=f&b=c#frag",
+        "hTtps://me:me@hOst#frag"                                                                    -> "https://me:me@host#frag",
+        "hTtps://me:me@hOst?"                                                                        -> "https://me:me@host?",
+        "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://"                                                -> "http://host£/a£/bÆc//:://",
+        "hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://"                                                   -> "http://1.2.3.4/a£/bÆc//:://",
+        "hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://"                                                   -> "http://1.2.3.4/a£/bÆc//:://",
+        "http://google.com/#"                                                                        -> "http://google.com/#",
+        "FiLe:///bin/bash"                                                                           -> "file:///bin/bash",
+        "FiLe:/bin/bash"                                                                             -> "file:/bin/bash",
+        "MailtO:test@example.com"                                                                    -> "mailto:test@example.com",
+        "http://google.com/.."                                                                       -> "http://google.com",
+        "http://google.com/./"                                                                       -> "http://google.com/",
+        "http://google.com/a/../search/."                                                            -> "http://google.com/search",
+        "http://google.com/a/../search/.."                                                           -> "http://google.com",
+        "https://my%40user:my%3Apassword%24@myhost.com/a/path/http%3A%2F%2Fexample.com%2Fnxv%3Asome" -> "https://my%40user:my:password$@myhost.com/a/path/http:%2F%2Fexample.com%2Fnxv:some",
+        "http://abc%40:def@example.com/a/http%3A%2F%2Fother.com"                                     -> "http://abc%40:def@example.com/a/http:%2F%2Fother.com"
+      )
+      forAll(cases) {
+        case (in, expected) => Url(in).rightValue.iriString shouldEqual expected
+      }
+    }
+    val withHash = Iri.uri("hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://#hash").rightValue
+
+    "be a Uri" in {
+      withHash.isUri shouldEqual true
+    }
+
+    "be a Url" in {
+      withHash.isUrl shouldEqual true
+    }
+
+    "as uri" in {
+      val iri = Iri.uri("hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c/£/#hash").rightValue
+      iri.uriString shouldEqual "http://1.2.3.4/a%C2%A3/b%C3%86c/%C2%A3/#hash"
+    }
+
+    "show" in {
+      val iri = Iri.uri("hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c/£/#hash").rightValue
+      iri.show shouldEqual "http://1.2.3.4/a£/bÆc/£/#hash"
+    }
+
+    "return an optional self" in {
+      withHash.asUrl shouldEqual Some(withHash)
+    }
+
+    "return an optional self from asUri" in {
+      withHash.asUri shouldEqual Some(withHash)
+    }
+
+    "not be an Urn" in {
+      withHash.isUrn shouldEqual false
+    }
+
+    "not return a urn" in {
+      withHash.asUrn shouldEqual None
+    }
+
+    "not be a RelativeIri" in {
+      withHash.isRelative shouldEqual false
+    }
+
+    "not return a RelativeIri" in {
+      withHash.asRelative shouldEqual None
+    }
+
+    "append segment" in {
+      val cases = List(
+        ("http://google.com/a/", "bcd", "http://google.com/a/bcd"),
+        ("http://google.com/a/", "/bcd", "http://google.com/a/bcd"),
+        ("http://google.com/a/", "/", "http://google.com/a/"),
+        ("http://google.com/a?one=two&three", "bcd", "http://google.com/a/bcd?one=two&three"),
+        ("http://google.com/a#other", "bcd", "http://google.com/a/bcd#other")
+      )
+      forAll(cases) {
+        case (in, segment, expected) => (Url(in).rightValue / segment) shouldEqual Url(expected).rightValue
+      }
+    }
+
+    "append path" in {
+      val cases = List(
+        ("http://google.com/a/", "/b/c/d", "http://google.com/a/b/c/d"),
+        ("http://google.com/a/", "/", "http://google.com/a/"),
+        ("http://google.com/a/", "/bcd", "http://google.com/a/bcd"),
+        ("http://google.com/a?one=two&three", "/b/c/d", "http://google.com/a/b/c/d?one=two&three"),
+        ("http://google.com/a#other", "/b/c/d", "http://google.com/a/b/c/d#other")
+      )
+      forAll(cases) {
+        case (in, p, expected) => (Url(in).rightValue / Path(p).rightValue) shouldEqual Url(expected).rightValue
+      }
+      Url("http://google.com/a").rightValue / ("b" / "c") shouldEqual Url("http://google.com/a/b/c").rightValue
+    }
+
+    "eq" in {
+      val lhs = Url("hTtp://gooGle.com/a/../search?q=asd#1").rightValue
+      val rhs = Url("http://google.com/search?q=asd#1").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/UrnSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/UrnSpec.scala
@@ -1,0 +1,90 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Iri._
+
+class UrnSpec extends RdfSpec {
+
+  "An Urn" should {
+    "be parsed correctly" in {
+      // format: off
+      val cases = List(
+        "urn:uUid:6e8bc430-9c3a-11d9-9669-0800200c9a66"           -> "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
+        "urn:example:a%C2%A3/b%C3%86c//:://?=a=b#"                -> "urn:example:a£/bÆc//:://?=a=b#",
+        "urn:lex:eu:council:directive:2010-03-09;2010-19-UE"      -> "urn:lex:eu:council:directive:2010-03-09;2010-19-UE",
+        "urn:Example:weather?=op=map&lat=39.56&lon=-104.85#test"  -> "urn:example:weather?=op=map&lat=39.56&lon=-104.85#test",
+        "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk"           -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk",
+        "urn:examp-lE:foo-bar-baz-qux?=a=b?+CCResolve:cc=uk"      -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b",
+        "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b"      -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b",
+        "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash" -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash"
+      )
+      // format: on
+      forAll(cases) {
+        case (in, expected) =>
+          Urn(in).rightValue.iriString shouldEqual expected
+      }
+    }
+
+    "fail to parse" in {
+      val fail = List(
+        "urn:example:some/path/?+",
+        "urn:example:some/path/?="
+      )
+      forAll(fail) { str =>
+        Urn(str).leftValue
+      }
+    }
+
+    val withHash = Iri.uri("urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash").rightValue
+
+    "be a Uri" in {
+      withHash.isUri shouldEqual true
+    }
+
+    "be a Urn" in {
+      withHash.isUrn shouldEqual true
+    }
+
+    "as uri" in {
+      val iri = Iri.uri("urn:example:a£/bÆc//:://?=a=b#").rightValue
+      iri.uriString shouldEqual "urn:example:a%C2%A3/b%C3%86c//:://?=a=b#"
+    }
+
+    "show" in {
+      val iri = Iri.uri("urn:example:a£/bÆc//:://?=a=b#").rightValue
+      iri.show shouldEqual "urn:example:a£/bÆc//:://?=a=b#"
+    }
+
+    "return an optional self" in {
+      withHash.asUrn shouldEqual Some(withHash)
+    }
+
+    "return an optional self from asAbsolute" in {
+      withHash.asUri shouldEqual Some(withHash)
+    }
+
+    "not be an Url" in {
+      withHash.isUrl shouldEqual false
+    }
+
+    "not return a url" in {
+      withHash.asUrl shouldEqual None
+    }
+
+    "not be a RelativeIri" in {
+      withHash.isRelative shouldEqual false
+    }
+
+    "not return a RelativeIri" in {
+      withHash.asRelative shouldEqual None
+    }
+
+    "eq" in {
+      val lhs = Urn("urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash").rightValue
+      val rhs = Urn("urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash").rightValue
+      Eq.eqv(lhs, rhs) shouldEqual true
+    }
+  }
+}

--- a/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/UserInfoSpec.scala
+++ b/rdf/src/test/scala/ch/epfl/bluebrain/nexus/rdf/iri/UserInfoSpec.scala
@@ -1,0 +1,61 @@
+package ch.epfl.bluebrain.nexus.rdf.iri
+
+import cats.Eq
+import cats.syntax.show._
+import ch.epfl.bluebrain.nexus.rdf.RdfSpec
+import ch.epfl.bluebrain.nexus.rdf.iri.Authority._
+
+class UserInfoSpec extends RdfSpec {
+
+  "An UserInfo" should {
+    val pct =
+      "%C2%A3%C2%A4%C2%A5%C2%A6%C2%A7%C2%A8%C2%A9%C2%AA%C2%AB%C2%AC%C2%AD%C2%AE%C2%AF%C2%B0%C2%B1%C2%B2%C2%B3%C2%B4%C2%B5%C2%B6%C2%B7%C2%B8%C2%B9%C2%BA%C2%BB%C2%BC%C2%BD%C2%BE%C2%BF%C3%80%C3%81%C3%82%C3%83%C3%84%C3%85%C3%86"
+    val ucsUp  = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆ"
+    val ucsLow = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿àáâãäåæ"
+    val delims = "!$&'()*+,;=:"
+    val up     = "ABCD"
+    val low    = "abcd"
+
+    "be parsed correctly from a string" in {
+      UserInfo("aBcd:Efgh").rightValue.value shouldEqual "aBcd:Efgh"
+    }
+
+    "equal when compared with ignored casing" in {
+      UserInfo("aBcd:Efgh").rightValue equalsIgnoreCase UserInfo("Abcd:efgH").rightValue shouldEqual true
+    }
+
+    "be parsed correctly from percent encoded string" in {
+      UserInfo(pct).rightValue.value shouldEqual ucsUp
+    }
+
+    "be parsed correctly from ucs chars" in {
+      UserInfo(ucsUp).rightValue.value shouldEqual ucsUp
+    }
+
+    "be parsed correctly from delimiters" in {
+      UserInfo(delims).rightValue.value shouldEqual delims
+    }
+
+    "be parsed correctly from mixed characters" in {
+      val in  = ucsUp + ucsLow + pct + delims + up
+      val out = ucsUp + ucsLow + ucsUp + delims + up
+      UserInfo(in).rightValue.value shouldEqual out
+    }
+
+    "fail for empty" in {
+      UserInfo("").leftValue
+    }
+
+    "show" in {
+      UserInfo(up + low).rightValue.show shouldEqual (up + low)
+    }
+
+    "eq" in {
+      Eq.eqv(UserInfo(ucsUp + ucsLow).rightValue, UserInfo(ucsUp + ucsLow).rightValue) shouldEqual true
+    }
+
+    "not eq" in {
+      Eq.eqv(UserInfo(ucsUp).rightValue, UserInfo(ucsLow).rightValue) shouldEqual false
+    }
+  }
+}


### PR DESCRIPTION
Related to #1068 

While porting, these are the changes I've made:
- AbsoluteIri -> Uri
- uri + "segment" -> uri / "segment"
-all `asString` methods -> `iriString`
-all `asUri` method -> `uriString`
- query value was previously a `SortedMap[String, SortedSet[String]]`. Now its value is simply `Seq[(String, String)]`. The `sorted` map functionality can be accessed through the `sorted lazy val`. This should improve performance on the construction and printing of an Iri
- added `uri.withFragment` (before it was only present on the `Url` level)