### PR TITLE
Added support for read/write a Config

### DIFF
--- a/cli/shared/src/main/resources/reference.conf
+++ b/cli/shared/src/main/resources/reference.conf
@@ -20,4 +20,9 @@ app {
       condition = "on-server-error"
     }
   }
+  # the SSE configuration
+  sse {
+    # the optionally latest consumed lastEventId (a Sequence or a TimeBased UUID)
+    # last-event-id = "bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"
+  }
 }

--- a/cli/shared/src/main/resources/reference.conf
+++ b/cli/shared/src/main/resources/reference.conf
@@ -20,9 +20,4 @@ app {
       condition = "on-server-error"
     }
   }
-  # the SSE configuration
-  sse {
-    # the optionally latest consumed lastEventId (a Sequence or a TimeBased UUID)
-    # last-event-id = "bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"
-  }
 }

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/ClientError.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/ClientError.scala
@@ -9,8 +9,8 @@ import scala.util.Try
 /**
   * Enumeration of possible Client errors.
   */
-sealed trait ClientError extends Product with Serializable {
-  def message: String
+sealed abstract class ClientError(message: String) extends Product with Serializable {
+  override def toString: String = message
 }
 
 object ClientError {
@@ -45,7 +45,8 @@ object ClientError {
     * @param message  the error message
     * @param original the optionally available original payload
     */
-  final case class SerializationError(message: String, original: Option[String] = None) extends ClientError
+  final case class SerializationError(message: String, original: Option[String] = None)
+      extends ClientError(s"Serialization error due to '$message'. Original payload: '$original'")
 
   /**
     * A Client status error (HTTP status codes 4xx).
@@ -53,7 +54,8 @@ object ClientError {
     * @param code    the HTTP status code
     * @param message the error message
     */
-  final case class ClientStatusError(code: Status, message: String) extends ClientError
+  final case class ClientStatusError(code: Status, message: String)
+      extends ClientError(s"Server responded with client error code '$code'. Reason: '$message'")
 
   /**
     * A server status error (HTTP status codes 5xx).
@@ -61,7 +63,8 @@ object ClientError {
     * @param code    the HTTP status code
     * @param message the error message
     */
-  final case class ServerStatusError(code: Status, message: String) extends ClientError
+  final case class ServerStatusError(code: Status, message: String)
+      extends ClientError(s"Server responded with server error code '$code'. Reason: '$message'")
 
   /**
     * Some other response error which is not 4xx nor 5xx
@@ -69,7 +72,8 @@ object ClientError {
     * @param code    the HTTP status code
     * @param message the error message
     */
-  final case class Unexpected(code: Status, message: String) extends ClientError
+  final case class Unexpected(code: Status, message: String)
+      extends ClientError(s"Server responded with unexpected error code '$code'. Reason: '$message'")
 
   def errorOr[F[_]: Sync, A](successF: Response[F] => F[ClientErrOr[A]]): Response[F] => F[ClientErrOr[A]] = {
     case Status.Successful(r)  => successF(r)

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/ConfigReader.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/ConfigReader.scala
@@ -1,0 +1,35 @@
+package ch.epfl.bluebrain.nexus.cli.config
+
+import java.nio.file.Path
+
+import cats.implicits._
+import com.typesafe.config.{Config, ConfigFactory}
+import pureconfig.ConfigSource
+
+import scala.util.Try
+
+/**
+  * A config reader. The pipeline is as follows: file -> (typesafe)Config -> A
+  *
+  * @tparam A the configuration result type
+  */
+class ConfigReader[A: pureconfig.ConfigReader] {
+
+  private def load(config: Config) =
+    ConfigSource.fromConfig(config).at("app").load[A].leftMap(_.head.description)
+
+  /**
+    * Attempts to read the passed ''path'' into a [[Config]] and then
+    * converts it to the type ''A'' using the pureconfig reader.
+    * If the file does not exists, it will use the ''defaultConfig''
+    */
+  def apply(path: Path, defaultConfig: => Config): Either[String, A] =
+    if (path.toFile.exists())
+      Try(ConfigFactory.parseFile(path.toFile)).toEither.leftMap(_.getMessage).flatMap(load)
+    else
+      load(defaultConfig)
+}
+
+object ConfigReader {
+  implicit def configReaderInstance[A: pureconfig.ConfigReader]: ConfigReader[A] = new ConfigReader[A]
+}

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/ConfigReader.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/ConfigReader.scala
@@ -15,19 +15,21 @@ import scala.util.Try
   */
 class ConfigReader[A: pureconfig.ConfigReader] {
 
-  private def load(config: Config) =
-    ConfigSource.fromConfig(config).at("app").load[A].leftMap(_.head.description)
+  private val emptyConfig = ConfigFactory.empty().root().toConfig
+
+  private def load(config: Config, prefix: String) =
+    ConfigSource.fromConfig(config).at(prefix).load[A].leftMap(_.head.description)
 
   /**
     * Attempts to read the passed ''path'' into a [[Config]] and then
     * converts it to the type ''A'' using the pureconfig reader.
     * If the file does not exists, it will use the ''defaultConfig''
     */
-  def apply(path: Path, defaultConfig: => Config): Either[String, A] =
+  def apply(path: Path, prefix: String, defaultConfig: => Config = emptyConfig): Either[String, A] =
     if (path.toFile.exists())
-      Try(ConfigFactory.parseFile(path.toFile)).toEither.leftMap(_.getMessage).flatMap(load)
+      Try(ConfigFactory.parseFile(path.toFile)).toEither.leftMap(_.getMessage).flatMap(load(_, prefix))
     else
-      load(defaultConfig)
+      load(defaultConfig, prefix)
 }
 
 object ConfigReader {

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/ConfigWriter.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/ConfigWriter.scala
@@ -1,0 +1,34 @@
+package ch.epfl.bluebrain.nexus.cli.config
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.Sync
+import cats.implicits._
+import com.typesafe.config.{ConfigFactory, ConfigRenderOptions, ConfigValue}
+
+import scala.util.Try
+
+/**
+  * A config writer. The pipeline is as follows: A -> (typesafe)Config -> string -> file
+  *
+  * @tparam A the configuration type
+  */
+class ConfigWriter[A, F[_]](implicit F: Sync[F], writer: pureconfig.ConfigWriter[A]) {
+  private val renderConfigOpts = ConfigRenderOptions.defaults().setOriginComments(false).setJson(false)
+
+  private def appConfig(config: ConfigValue): ConfigValue =
+    ConfigFactory.empty().withValue("app", config).root()
+
+  /**
+    * Attempts to convert the passed ''config'' to a (typesafe)Config and write the result to the passed ''path'' location.
+    */
+  def apply(config: A, path: Path): F[Either[String, Unit]] =
+    for {
+      configString <- F.delay(appConfig(writer.to(config)).render(renderConfigOpts))
+      writeResult  <- F.delay(Try(Files.writeString(path, configString)).map(_ => ()).toEither.leftMap(_.getMessage))
+    } yield writeResult
+}
+
+object ConfigWriter {
+  implicit def configWriterInstance[A: pureconfig.ConfigWriter, F[_]: Sync]: ConfigWriter[A, F] = new ConfigWriter[A, F]
+}

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfig.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfig.scala
@@ -1,13 +1,17 @@
 package ch.epfl.bluebrain.nexus.cli.config
 
+import java.nio.file.{Path, Paths}
+
 import cats.implicits._
-import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.ClientConfig
-import ch.epfl.bluebrain.nexus.cli.types.BearerToken
+import ch.epfl.bluebrain.nexus.cli.config.NexusConfig._
+import ch.epfl.bluebrain.nexus.cli.types.{BearerToken, Offset}
+import com.typesafe.config.ConfigFactory
 import org.http4s.headers.Authorization
 import org.http4s.{AuthScheme, Credentials, Uri}
 import pureconfig.ConfigConvert
 import pureconfig.ConvertHelpers.catchReadError
 import pureconfig.error.CannotConvert
+import pureconfig.generic.auto._
 import pureconfig.generic.semiauto.deriveConvert
 
 /**
@@ -16,8 +20,17 @@ import pureconfig.generic.semiauto.deriveConvert
   * @param endpoint   the Nexus service endpoint, including the prefix (if necessary)
   * @param token      the optional Bearer Token used to connect to the Nexus service
   * @param httpClient the HTTP Client configuration
+  * @param sse        the SSE configuration
   */
-final case class NexusConfig(endpoint: Uri, token: Option[BearerToken], httpClient: ClientConfig) {
+final case class NexusConfig(endpoint: Uri, token: Option[BearerToken], httpClient: ClientConfig, sse: SSEConfig) {
+
+  /**
+    * Writes the current config to the passed ''path'' location. If the path file already exists, it overrides its content.
+    */
+  def write[F[_]](
+      path: Path = defaultPath
+  )(implicit writer: ConfigWriter[NexusConfig, F]): F[Either[String, Unit]] =
+    writer(this, path)
 
   /**
     * Converts the Bearer Token to the HTTP Header Authorization header
@@ -31,6 +44,18 @@ final case class NexusConfig(endpoint: Uri, token: Option[BearerToken], httpClie
 
 object NexusConfig {
 
+  private[cli] val defaultPath     = Paths.get(System.getProperty("user.home"), ".nexus.conf")
+  private lazy val referenceConfig = ConfigFactory.defaultReference()
+
+  /**
+    * Attempts to construct a Nexus configuration from the passed path. If the path is not provided,
+    * the default path ~/.nexus.conf will be used.
+    *
+    * If that path does not exists, the default configuration in ''reference.conf'' will be used.
+    */
+  def apply(path: Path = defaultPath)(implicit reader: ConfigReader[NexusConfig]): Either[String, NexusConfig] =
+    reader(path, referenceConfig)
+
   /**
     * The HTTP Client configuration
     *
@@ -38,17 +63,31 @@ object NexusConfig {
     */
   final case class ClientConfig(retry: RetryStrategyConfig)
 
-  // $COVERAGE-OFF$
-  implicit val uriConfigConvert: ConfigConvert[Uri] =
+  /**
+    * The SSE configuration
+    *
+    * @param lastEventId the optionally latest consumed lastEventId (a Sequence or a TimeBased UUID)
+    */
+  final case class SSEConfig(lastEventId: Option[Offset])
+
+  /**
+    * The latest consumed lastEventId (a Sequence or a TimeBased UUID)
+    * @param value int value greater than 9
+    */
+  final case class LastEventIdFreq(value: Int)
+
+  implicit private[config] val uriConfigConvert: ConfigConvert[Uri] =
     ConfigConvert
       .viaNonEmptyString[Uri](s => Uri.fromString(s).leftMap(err => CannotConvert(s, "Uri", err.details)), _.toString)
 
-  implicit val bearerTokenConfigConvert: ConfigConvert[BearerToken] =
-    ConfigConvert.viaNonEmptyString(catchReadError(BearerToken), _.toString)
-  // $COVERAGE-ON$
+  implicit private[config] val bearerTokenConfigConvert: ConfigConvert[BearerToken] =
+    ConfigConvert.viaNonEmptyString(catchReadError(BearerToken), _.value)
 
-  implicit val httpClientConfigConvert: ConfigConvert[ClientConfig] =
-    deriveConvert[ClientConfig]
+  implicit private[config] val offsetConfigConverter: ConfigConvert[Offset] =
+    ConfigConvert.viaNonEmptyString(
+      string => Offset(string).toRight(CannotConvert(string, "Offset", "value must be a TimeBased UUID or a Long.")),
+      _.asString
+    )
 
   implicit val nexusConfigConvert: ConfigConvert[NexusConfig] =
     deriveConvert[NexusConfig]

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfig.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfig.scala
@@ -57,6 +57,33 @@ object NexusConfig {
     reader(path, referenceConfig)
 
   /**
+    * Attempts to construct a Nexus configuration from the passed path. If the path is not provided,
+    * the default path ~/.nexus.conf will be used.
+    * If that path does not exists, the default configuration in ''reference.conf'' will be used.
+    *
+    * The rest of the parameters, if present, will override the resulting Nexus configuration parameters.
+    */
+  def withDefaults(
+      path: Path = defaultPath,
+      endpoint: Option[Uri] = None,
+      token: Option[BearerToken] = None,
+      httpClient: Option[ClientConfig] = None,
+      sse: Option[SSEConfig] = None
+  ): Either[String, NexusConfig] =
+    apply(path).map { config =>
+      config.copy(
+        endpoint = mergeOpt(config.endpoint, endpoint),
+        token = mergeOpt(config.token, token),
+        httpClient = mergeOpt(config.httpClient, httpClient),
+        sse = mergeOpt(config.sse, sse)
+      )
+    }
+
+  private def mergeOpt[A](one: Option[A], other: Option[A]): Option[A] = other orElse one
+
+  private def mergeOpt[A](one: A, other: Option[A]): A = other.getOrElse(one)
+
+  /**
     * The HTTP Client configuration
     *
     * @param retry the retry strategy (policy and condition)

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/OffsetConfig.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/OffsetConfig.scala
@@ -1,0 +1,44 @@
+package ch.epfl.bluebrain.nexus.cli.config
+
+import java.nio.file.{Path, Paths}
+
+import ch.epfl.bluebrain.nexus.cli.config.OffsetConfig._
+import ch.epfl.bluebrain.nexus.cli.types.Offset
+import pureconfig.ConfigConvert
+import pureconfig.error.CannotConvert
+import pureconfig.generic.semiauto.deriveConvert
+
+/**
+  * It contains the offset value of the latest consumed eventId
+  */
+final case class OffsetConfig(value: Option[Offset]) {
+
+  /**
+    * Writes the current config to the passed ''path'' location. If the path file already exists, it overrides its content.
+    */
+  def write[F[_]](path: Path = defaultPath)(implicit writer: ConfigWriter[OffsetConfig, F]): F[Either[String, Unit]] =
+    writer(this, path, prefix)
+
+}
+
+object OffsetConfig {
+  private[cli] val defaultPath = Paths.get(System.getProperty("user.home"), ".nexus", "offset.conf")
+  private[cli] val prefix      = "offset"
+
+  /**
+    * Attempts to construct an Offset configuration from the passed path. If the path is not provided,
+    * the default path ~/.nexus/offset.conf will be used.
+    *
+    */
+  def apply(path: Path = defaultPath)(implicit reader: ConfigReader[OffsetConfig]): Either[String, OffsetConfig] =
+    reader(path, prefix)
+
+  implicit private[cli] val offsetValueConfigConverter: ConfigConvert[Offset] =
+    ConfigConvert.viaNonEmptyString(
+      string => Offset(string).toRight(CannotConvert(string, "Offset", "value must be a TimeBased UUID or a Long.")),
+      _.asString
+    )
+
+  implicit val offsetConfigConvert: ConfigConvert[OffsetConfig] =
+    deriveConvert[OffsetConfig]
+}

--- a/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/types/EventEnvelope.scala
+++ b/cli/shared/src/main/scala/ch/epfl/bluebrain/nexus/cli/types/EventEnvelope.scala
@@ -1,9 +1,0 @@
-package ch.epfl.bluebrain.nexus.cli.types
-
-/**
-  * Event wrapper adding its metadata.
-  *
-  * @param offset the offset of the event
-  * @param event  the event value
- **/
-final case class EventEnvelope(offset: Offset, event: Event)

--- a/cli/shared/src/test/resources/nexus-test.conf
+++ b/cli/shared/src/test/resources/nexus-test.conf
@@ -10,7 +10,4 @@ app {
       condition = "on-server-error"
     }
   }
-  sse {
-    last-event-id = "bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"
-  }
 }

--- a/cli/shared/src/test/resources/nexus-test.conf
+++ b/cli/shared/src/test/resources/nexus-test.conf
@@ -1,7 +1,7 @@
 app {
   endpoint = "https://nexus.example.com/v1"
   token = "mytoken"
-  http-client{
+  http-client {
     retry {
       strategy = "once"
       initial-delay = 100 millis
@@ -9,5 +9,8 @@ app {
       max-retries = 1
       condition = "on-server-error"
     }
+  }
+  sse {
+    last-event-id = "bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"
   }
 }

--- a/cli/shared/src/test/resources/offset-test.conf
+++ b/cli/shared/src/test/resources/offset-test.conf
@@ -1,0 +1,3 @@
+offset {
+  value = "b8a93f50-5c75-11ea-beb1-a5eb66b44d1c"
+}

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/EventStreamClientSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/EventStreamClientSpec.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.cli.ClientError.ServerStatusError
 import ch.epfl.bluebrain.nexus.cli.EventStreamClient.{LiveEventStreamClient, TestEventStreamClient}
-import ch.epfl.bluebrain.nexus.cli.types.Offset.{Sequence, TimeBasedUUID}
+import ch.epfl.bluebrain.nexus.cli.types.Offset.Sequence
 import ch.epfl.bluebrain.nexus.cli.types.{Event, Label, Offset}
 import ch.epfl.bluebrain.nexus.cli.utils.Fixtures
 import fs2.Stream
@@ -62,8 +62,8 @@ class EventStreamClientSpec extends AnyWordSpecLike with Matchers with Fixtures 
     val client: EventStreamClient[IO] = new LiveEventStreamClient(mockedHttpClient, projectClient, config)
 
     "return events" in {
-      val timeUpdated    = TimeBasedUUID(UUID.fromString("b8a93f50-5c75-11ea-beb1-a5eb66b44d1c"))
-      val timeDeprecated = TimeBasedUUID(UUID.fromString("bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"))
+      val timeUpdated    = Offset("b8a93f50-5c75-11ea-beb1-a5eb66b44d1c").value
+      val timeDeprecated = Offset("bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c").value
       val list =
         List(client(Some(eventId)), client(orgLabel, Some(eventId)), client(orgLabel, projectLabel, Some(eventId)))
       forAll(list) { eventStreamF =>

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/SparqlClientSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/SparqlClientSpec.scala
@@ -10,11 +10,10 @@ import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.client.Client
 import org.http4s.headers._
 import org.http4s.{HttpApp, Response, Status}
-import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class SparqlClientSpec extends AnyWordSpecLike with Matchers with Fixtures with OptionValues {
+class SparqlClientSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
   private val organization      = Label("myorg")
   private val project           = Label("mylabel")

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/SparqlResultsSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/SparqlResultsSpec.scala
@@ -4,11 +4,10 @@ import ch.epfl.bluebrain.nexus.cli.types.SparqlResults
 import ch.epfl.bluebrain.nexus.cli.types.SparqlResults.{Binding, Bindings, Head, Literal}
 import ch.epfl.bluebrain.nexus.cli.utils.{Fixtures, Resources}
 import org.http4s.Uri
-import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class SparqlResultsSpec extends AnyWordSpecLike with Matchers with Resources with Fixtures with OptionValues {
+class SparqlResultsSpec extends AnyWordSpecLike with Matchers with Resources with Fixtures {
 
   "A SparqlResult" should {
     val json    = jsonContentOf("/sparql_results.json")

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfigSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfigSpec.scala
@@ -1,19 +1,41 @@
 package ch.epfl.bluebrain.nexus.cli.config
 
+import java.nio.file.Paths
+
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.{ClientConfig, SSEConfig}
 import ch.epfl.bluebrain.nexus.cli.utils.Fixtures
-import com.typesafe.config.ConfigFactory
+import org.http4s.Uri
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import pureconfig._
+
+import scala.concurrent.duration._
 
 class NexusConfigSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
   "A Nexus Config" should {
 
-    "be converted successfully" in {
-      val c = ConfigFactory.load("nexus-test.conf")
-      ConfigSource.fromConfig(c).at("app").loadOrThrow[NexusConfig] shouldEqual config
+    "be created from a passed config file" in {
+      val path = Paths.get(getClass().getResource("/nexus-test.conf").toURI())
+      NexusConfig(path) shouldEqual Right(config)
     }
+
+    "be created from reference.conf file" in {
+      val clientConf = ClientConfig(RetryStrategyConfig("exponential", 100.millis, 20.seconds, 10, "on-server-error"))
+      val sseConf    = SSEConfig(None)
+      val conf       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), None, clientConf, sseConf)
+      val path       = Paths.get(s"${genString()}.conf")
+      NexusConfig(path) shouldEqual Right(conf)
+    }
+
+    "be saved to a file" in {
+      val path = Paths.get(s"${genString()}.conf")
+      config.write[IO](path).unsafeRunSync() shouldEqual Right(())
+      path.toFile.exists() shouldEqual true
+      NexusConfig(path) shouldEqual Right(config)
+      path.toFile.delete()
+    }
+
   }
 
 }

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfigSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfigSpec.scala
@@ -4,6 +4,7 @@ import java.nio.file.Paths
 
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.{ClientConfig, SSEConfig}
+import ch.epfl.bluebrain.nexus.cli.types.{BearerToken, Offset}
 import ch.epfl.bluebrain.nexus.cli.utils.Fixtures
 import org.http4s.Uri
 import org.scalatest.matchers.should.Matchers
@@ -18,6 +19,14 @@ class NexusConfigSpec extends AnyWordSpecLike with Matchers with Fixtures {
     "be created from a passed config file" in {
       val path = Paths.get(getClass().getResource("/nexus-test.conf").toURI())
       NexusConfig(path) shouldEqual Right(config)
+    }
+
+    "be created from passed config file and overriding parameters" in {
+      val sse   = SSEConfig(Offset("b8a93f50-5c75-11ea-beb1-a5eb66b44d1c"))
+      val token = BearerToken("myothertoken")
+      val path  = Paths.get(getClass().getResource("/nexus-test.conf").toURI())
+      NexusConfig.withDefaults(path, token = Some(token), sse = Some(sse)) shouldEqual
+        Right(config.copy(token = Some(token), sse = sse))
     }
 
     "be created from reference.conf file" in {

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfigSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/NexusConfigSpec.scala
@@ -3,8 +3,8 @@ package ch.epfl.bluebrain.nexus.cli.config
 import java.nio.file.Paths
 
 import cats.effect.IO
-import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.{ClientConfig, SSEConfig}
-import ch.epfl.bluebrain.nexus.cli.types.{BearerToken, Offset}
+import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.ClientConfig
+import ch.epfl.bluebrain.nexus.cli.types.BearerToken
 import ch.epfl.bluebrain.nexus.cli.utils.Fixtures
 import org.http4s.Uri
 import org.scalatest.matchers.should.Matchers
@@ -22,17 +22,16 @@ class NexusConfigSpec extends AnyWordSpecLike with Matchers with Fixtures {
     }
 
     "be created from passed config file and overriding parameters" in {
-      val sse   = SSEConfig(Offset("b8a93f50-5c75-11ea-beb1-a5eb66b44d1c"))
-      val token = BearerToken("myothertoken")
-      val path  = Paths.get(getClass().getResource("/nexus-test.conf").toURI())
-      NexusConfig.withDefaults(path, token = Some(token), sse = Some(sse)) shouldEqual
-        Right(config.copy(token = Some(token), sse = sse))
+      val token    = BearerToken("myothertoken")
+      val endpoint = Uri.unsafeFromString("https://other.nexus.ch")
+      val path     = Paths.get(getClass().getResource("/nexus-test.conf").toURI())
+      NexusConfig.withDefaults(path, endpoint = Some(endpoint), token = Some(token)) shouldEqual
+        Right(config.copy(endpoint = endpoint, token = Some(token)))
     }
 
     "be created from reference.conf file" in {
       val clientConf = ClientConfig(RetryStrategyConfig("exponential", 100.millis, 20.seconds, 10, "on-server-error"))
-      val sseConf    = SSEConfig(None)
-      val conf       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), None, clientConf, sseConf)
+      val conf       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), None, clientConf)
       val path       = Paths.get(s"${genString()}.conf")
       NexusConfig(path) shouldEqual Right(conf)
     }

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/OffsetConfigSpec.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/config/OffsetConfigSpec.scala
@@ -1,0 +1,32 @@
+package ch.epfl.bluebrain.nexus.cli.config
+
+import java.nio.file.Paths
+
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.cli.types.Offset
+import ch.epfl.bluebrain.nexus.cli.utils.Fixtures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class OffsetConfigSpec extends AnyWordSpecLike with Matchers with Fixtures {
+
+  "An Offset Config" should {
+
+    val offsetConfig = OffsetConfig(Some(Offset("b8a93f50-5c75-11ea-beb1-a5eb66b44d1c").value))
+
+    "be created from a passed config file" in {
+      val path = Paths.get(getClass().getResource("/offset-test.conf").toURI())
+      OffsetConfig(path) shouldEqual Right(offsetConfig)
+    }
+
+    "be saved to a file" in {
+      val path = Paths.get(s"${genString()}.conf")
+      offsetConfig.write[IO](path).unsafeRunSync() shouldEqual Right(())
+      path.toFile.exists() shouldEqual true
+      OffsetConfig(path) shouldEqual Right(offsetConfig)
+      path.toFile.delete()
+    }
+
+  }
+
+}

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/utils/Fixtures.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/utils/Fixtures.scala
@@ -1,9 +1,9 @@
 package ch.epfl.bluebrain.nexus.cli.utils
 
 import cats.effect.{ContextShift, IO, Timer}
-import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.{ClientConfig, SSEConfig}
+import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.ClientConfig
 import ch.epfl.bluebrain.nexus.cli.config.{NexusConfig, NexusEndpoints, RetryStrategyConfig}
-import ch.epfl.bluebrain.nexus.cli.types.{BearerToken, Offset}
+import ch.epfl.bluebrain.nexus.cli.types.BearerToken
 import org.http4s.Uri
 import org.scalatest.OptionValues
 
@@ -17,9 +17,8 @@ trait Fixtures extends Randomness with Resources with OptionValues {
   private val token         = Some(BearerToken("mytoken"))
   private val retryStrategy = RetryStrategyConfig("once", 100.millis, 5.seconds, 1, "on-server-error")
   private val client        = ClientConfig(retryStrategy)
-  private val sse           = SSEConfig(Some(Offset("bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c").value))
 
-  val config: NexusConfig       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), token, client, sse)
+  val config: NexusConfig       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), token, client)
   val endpoints: NexusEndpoints = NexusEndpoints(config)
   val nxv: Uri                  = Uri.unsafeFromString("https://bluebrain.github.io/nexus/vocabulary")
 }

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/utils/Fixtures.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/utils/Fixtures.scala
@@ -1,25 +1,23 @@
 package ch.epfl.bluebrain.nexus.cli.utils
 
-import java.util.UUID
-
 import cats.effect.{ContextShift, IO, Timer}
 import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.{ClientConfig, SSEConfig}
 import ch.epfl.bluebrain.nexus.cli.config.{NexusConfig, NexusEndpoints, RetryStrategyConfig}
-import ch.epfl.bluebrain.nexus.cli.types.BearerToken
-import ch.epfl.bluebrain.nexus.cli.types.Offset.TimeBasedUUID
+import ch.epfl.bluebrain.nexus.cli.types.{BearerToken, Offset}
 import org.http4s.Uri
+import org.scalatest.OptionValues
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-trait Fixtures extends Randomness with Resources {
+trait Fixtures extends Randomness with Resources with OptionValues {
   implicit val ctx: ContextShift[IO] = IO.contextShift(global)
   implicit val timer: Timer[IO]      = IO.timer(global)
 
   private val token         = Some(BearerToken("mytoken"))
   private val retryStrategy = RetryStrategyConfig("once", 100.millis, 5.seconds, 1, "on-server-error")
   private val client        = ClientConfig(retryStrategy)
-  private val sse           = SSEConfig(Some(TimeBasedUUID(UUID.fromString("bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"))))
+  private val sse           = SSEConfig(Some(Offset("bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c").value))
 
   val config: NexusConfig       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), token, client, sse)
   val endpoints: NexusEndpoints = NexusEndpoints(config)

--- a/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/utils/Fixtures.scala
+++ b/cli/shared/src/test/scala/ch/epfl/bluebrain/nexus/cli/utils/Fixtures.scala
@@ -1,9 +1,12 @@
 package ch.epfl.bluebrain.nexus.cli.utils
 
+import java.util.UUID
+
 import cats.effect.{ContextShift, IO, Timer}
-import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.ClientConfig
+import ch.epfl.bluebrain.nexus.cli.config.NexusConfig.{ClientConfig, SSEConfig}
 import ch.epfl.bluebrain.nexus.cli.config.{NexusConfig, NexusEndpoints, RetryStrategyConfig}
 import ch.epfl.bluebrain.nexus.cli.types.BearerToken
+import ch.epfl.bluebrain.nexus.cli.types.Offset.TimeBasedUUID
 import org.http4s.Uri
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -13,13 +16,14 @@ trait Fixtures extends Randomness with Resources {
   implicit val ctx: ContextShift[IO] = IO.contextShift(global)
   implicit val timer: Timer[IO]      = IO.timer(global)
 
-  val token: Option[BearerToken]         = Some(BearerToken("mytoken"))
-  val retryStrategy: RetryStrategyConfig = RetryStrategyConfig("once", 100.millis, 5.seconds, 1, "on-server-error")
-  val clientConfig: ClientConfig         = ClientConfig(retryStrategy)
-  val config: NexusConfig                = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), token, clientConfig)
-  val endpoints: NexusEndpoints          = NexusEndpoints(config)
+  private val token         = Some(BearerToken("mytoken"))
+  private val retryStrategy = RetryStrategyConfig("once", 100.millis, 5.seconds, 1, "on-server-error")
+  private val client        = ClientConfig(retryStrategy)
+  private val sse           = SSEConfig(Some(TimeBasedUUID(UUID.fromString("bd62f6d0-5c75-11ea-beb1-a5eb66b44d1c"))))
 
-  val nxv: Uri = Uri.unsafeFromString("https://bluebrain.github.io/nexus/vocabulary")
+  val config: NexusConfig       = NexusConfig(Uri.unsafeFromString("https://nexus.example.com/v1"), token, client, sse)
+  val endpoints: NexusEndpoints = NexusEndpoints(config)
+  val nxv: Uri                  = Uri.unsafeFromString("https://bluebrain.github.io/nexus/vocabulary")
 }
 
 object Fixtures extends Fixtures


### PR DESCRIPTION
- Support to write a configuration to disk
- Support to read a configuration from disk
- Added a way to fetch the current offset from a `EventStream`. Once having this, the saving of that value in NexusConfig is up to the client: It could be done using.

If the client would want an offset to be stored every X minutes, one could do:
```scala
      val eventStream: EventStream[IO] = ??? // an EventStream
      fs2.Stream.awakeEvery[IO](X.minutes).evalMap{ _ =>
        eventStream.currentEventId().flatMap(offset => OffsetConfig(Some(offset)).write())
      }.compile.last.unsafeRunSync()
```

Or maybe just want to store the `NexusConfig` prior to shutdown:
```scala
scala.sys.addShutdownHook {
  eventStream.currentEventId().flatMap(offset => OffsetConfig(Some(offset)).write()).unsafeRunSync() 
  actorSystem.terminate()
  Await.result(actorSystem.whenTerminated, 30 seconds)
}
```