### PR TITLE
Added InfluxClient to CliModules (fix) and small refactoring

### DIFF
--- a/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/CliModule.scala
+++ b/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/CliModule.scala
@@ -3,7 +3,7 @@ package ch.epfl.bluebrain.nexus.cli
 import cats.effect.concurrent.Ref
 import cats.effect.{ConcurrentEffect, Timer}
 import cats.implicits._
-import ch.epfl.bluebrain.nexus.cli.clients.{EventStreamClient, ProjectClient, SparqlClient}
+import ch.epfl.bluebrain.nexus.cli.clients._
 import ch.epfl.bluebrain.nexus.cli.config.AppConfig
 import ch.epfl.bluebrain.nexus.cli.sse.{OrgLabel, OrgUuid, ProjectLabel, ProjectUuid}
 import distage.{ModuleDef, TagK}
@@ -33,6 +33,10 @@ final class CliModule[F[_]: ConcurrentEffect: Timer: TagK] extends ModuleDef {
 
   make[EventStreamClient[F]].tagged(Repo.Prod).from { (cfg: AppConfig, client: Client[F], pc: ProjectClient[F]) =>
     EventStreamClient(client, pc, cfg.env)
+  }
+
+  make[InfluxClient[F]].tagged(Repo.Prod).from { (cfg: AppConfig, client: Client[F], console: Console[F]) =>
+    InfluxClient(client, cfg, console)
   }
 }
 

--- a/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/clients/AbstractHttpClient.scala
+++ b/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/clients/AbstractHttpClient.scala
@@ -1,0 +1,50 @@
+package ch.epfl.bluebrain.nexus.cli.clients
+
+import cats.effect.{Sync, Timer}
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.cli.CliError.ClientError
+import ch.epfl.bluebrain.nexus.cli.CliError.ClientError.{SerializationError, Unexpected}
+import ch.epfl.bluebrain.nexus.cli.config.EnvConfig
+import ch.epfl.bluebrain.nexus.cli.{logRetryErrors, ClientErrOr, Console}
+import io.circe.Decoder
+import org.http4s.circe.CirceEntityDecoder._
+import org.http4s.client.Client
+import org.http4s.{Request, Response}
+import retry.CatsEffect._
+import retry.RetryPolicy
+import retry.syntax.all._
+
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+class AbstractHttpClient[F[_]: Timer](client: Client[F], env: EnvConfig)(
+    implicit protected val F: Sync[F],
+    protected val console: Console[F]
+) {
+
+  protected val retry                                = env.httpClient.retry
+  protected def successCondition[A]                  = retry.condition.notRetryFromEither[A] _
+  implicit protected val retryPolicy: RetryPolicy[F] = retry.retryPolicy
+  implicit protected def logOnError[A]               = logRetryErrors[F, A]("interacting with an HTTP API")
+
+  protected def executeDiscard[A](req: Request[F], returnValue: => A): F[ClientErrOr[A]] =
+    execute(req, _.body.compile.drain.as(Right(returnValue)))
+
+  protected def executeParse[A: Decoder](req: Request[F])(implicit A: ClassTag[A]): F[ClientErrOr[A]] =
+    execute(
+      req,
+      _.attemptAs[A].value.map(
+        _.leftMap(err =>
+          SerializationError(err.message, s"The response payload was not of type '${A.runtimeClass.getSimpleName}'")
+        )
+      )
+    )
+
+  private def execute[A](req: Request[F], f: Response[F] => F[ClientErrOr[A]]): F[ClientErrOr[A]] =
+    client
+      .fetch(req)(ClientError.errorOr[F, A](r => f(r)))
+      .recoverWith {
+        case NonFatal(err) => F.delay(Left(Unexpected(Option(err.getMessage).getOrElse("").take(30))))
+      }
+      .retryingM(successCondition[A])
+}

--- a/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/clients/InfluxClient.scala
+++ b/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/clients/InfluxClient.scala
@@ -2,20 +2,12 @@ package ch.epfl.bluebrain.nexus.cli.clients
 
 import cats.effect.{Sync, Timer}
 import cats.implicits._
-import ch.epfl.bluebrain.nexus.cli.CliError.ClientError
-import ch.epfl.bluebrain.nexus.cli.CliError.ClientError.{SerializationError, Unexpected}
 import ch.epfl.bluebrain.nexus.cli._
 import ch.epfl.bluebrain.nexus.cli.config.influx.InfluxConfig
 import ch.epfl.bluebrain.nexus.cli.config.{AppConfig, EnvConfig}
 import io.circe.Json
-import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.client.Client
-import org.http4s.{Method, Request, Response, UrlForm}
-import retry.CatsEffect._
-import retry.RetryPolicy
-import retry.syntax.all._
-
-import scala.util.control.NonFatal
+import org.http4s.{Method, Request, UrlForm}
 
 trait InfluxClient[F[_]] {
 
@@ -46,35 +38,16 @@ trait InfluxClient[F[_]] {
 
 object InfluxClient {
 
-  private class LiveInfluxDbClient[F[_]: Timer](
+  private class LiveInfluxDbClient[F[_]: Timer: Sync: Console](
       client: Client[F],
       config: InfluxConfig,
       env: EnvConfig
-  )(implicit val F: Sync[F], console: Console[F])
-      extends InfluxClient[F] {
-
-    private val retry                                = env.httpClient.retry
-    private def successCondition[A]                  = retry.condition.notRetryFromEither[A] _
-    implicit private val retryPolicy: RetryPolicy[F] = retry.retryPolicy
-    implicit private def logOnError[A]               = logRetryErrors[F, A]("interacting with the influxDB API")
-
-    private def executeDrain(req: Request[F]): F[ClientErrOr[Unit]] =
-      execute(req, _.body.compile.drain.as(Right(())))
-
-    private def executeParseJson(req: Request[F]): F[ClientErrOr[Json]] =
-      execute(req, _.attemptAs[Json].value.map(_.leftMap(err => SerializationError(err.message, "Json"))))
-
-    private def execute[A](req: Request[F], f: Response[F] => F[ClientErrOr[A]]): F[ClientErrOr[A]] =
-      client
-        .fetch(req)(ClientError.errorOr[F, A](r => f(r)))
-        .recoverWith {
-          case NonFatal(err) => F.delay(Left(Unexpected(Option(err.getMessage).getOrElse("").take(30))))
-        }
-        .retryingM(successCondition[A])
+  ) extends AbstractHttpClient(client, env)
+      with InfluxClient[F] {
 
     override def createDb: F[Unit] = {
       val req = Request[F](Method.POST, config.endpoint / "query").withEntity(UrlForm("q" -> config.dbCreationCommand))
-      executeDrain(req).flatMap {
+      executeDiscard(req, returnValue = ()).flatMap {
         case Left(err) => console.printlnErr(err.show)
         case _         => F.unit
       }
@@ -82,33 +55,33 @@ object InfluxClient {
 
     override def write(point: InfluxPoint): F[ClientErrOr[Unit]] = {
       val uri = (config.endpoint / "write").withQueryParam("db", config.database)
-      executeDrain(Request[F](Method.POST, uri).withEntity(point))
+      val req = Request[F](Method.POST, uri).withEntity(point)
+      executeDiscard(req, returnValue = ())
     }
 
     override def query(ql: String): F[ClientErrOr[Json]] = {
       val uri = (config.endpoint / "query").withQueryParam("db", config.database)
       val req = Request[F](Method.POST, uri).withEntity(UrlForm("q" -> ql))
-      executeParseJson(req)
+      executeParse[Json](req)
     }
 
     override def health: F[ClientErrOr[Json]] = {
       val req = Request[F](Method.GET, config.endpoint / "health")
-      executeParseJson(req)
+      executeParse[Json](req)
     }
   }
 
   /**
     * Construct an instance of [[InfluxClient]].
     *
-    * @param client  the underlying HTTP client.
-    * @param console [[Console]] for logging.
-    * @param config  InfluxDB config
-    * @tparam F the effect type
+    * @param client  the underlying HTTP client
+    * @param config  the application config
+    * @param console [[Console]] for logging
     */
   final def apply[F[_]: Sync: Timer](
       client: Client[F],
-      console: Console[F],
-      config: AppConfig
+      config: AppConfig,
+      console: Console[F]
   ): InfluxClient[F] = {
     implicit val c: Console[F] = console
     new LiveInfluxDbClient[F](client, config.influx, config.env)

--- a/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/modules/influx/InfluxProjection.scala
+++ b/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/modules/influx/InfluxProjection.scala
@@ -61,7 +61,7 @@ class InfluxProjection[F[_]: ContextShift](
             .replaceAllLiterally("{event_rev}", ev.rev.toString)
           spc.query(org, proj, pc.sparqlView, query).flatMap(res => insert(tc, res, org, proj))
       }
-      .through(printEvaluatedProjection(console))
+      .through(printEvaluatedProjectionSkipFailed(console))
       .attempt
       .map(_.leftMap(err => Unexpected(Option(err.getMessage).getOrElse("").take(30))).map(_ => ()))
       .compile

--- a/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/modules/postgres/PostgresProjection.scala
+++ b/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/modules/postgres/PostgresProjection.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import ch.epfl.bluebrain.nexus.cli.CliError.ClientError
 import ch.epfl.bluebrain.nexus.cli.CliError.ClientError.Unexpected
 import ch.epfl.bluebrain.nexus.cli.{logRetryErrors, Console}
-import ch.epfl.bluebrain.nexus.cli.ProjectionPipes.{printConsumedEventSkipFailed, printEvaluatedProjection}
+import ch.epfl.bluebrain.nexus.cli.ProjectionPipes.{printConsumedEventSkipFailed, printEvaluatedProjectionSkipFailed}
 import ch.epfl.bluebrain.nexus.cli.clients.SparqlResults.{Binding, Literal}
 import ch.epfl.bluebrain.nexus.cli.clients.{EventStreamClient, SparqlClient, SparqlResults}
 import ch.epfl.bluebrain.nexus.cli.config.AppConfig
@@ -77,7 +77,7 @@ class PostgresProjection[F[_]: ContextShift](
               .sequence
               .map(_.sequence)
         }
-        .through(printEvaluatedProjection(console))
+        .through(printEvaluatedProjectionSkipFailed(console))
         .attempt
         .map(_.leftMap(err => Unexpected(Option(err.getMessage).getOrElse("").take(30))).map(_ => ()))
         .compile

--- a/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/clients/InfluxClientSpec.scala
+++ b/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/clients/InfluxClientSpec.scala
@@ -58,7 +58,7 @@ class InfluxClientSpec extends AbstractCliSpec with Http4sExtras with TimeTransf
   "An InfluxClient" should {
 
     "create a db" in { (client: Client[IO], console: TestConsole[IO], cfg: AppConfig) =>
-      val cl = InfluxClient[IO](client, console, cfg)
+      val cl = InfluxClient[IO](client, cfg, console)
       for {
         dbResult <- cl.createDb
         err      <- console.errQueue.tryDequeue1
@@ -68,7 +68,7 @@ class InfluxClientSpec extends AbstractCliSpec with Http4sExtras with TimeTransf
     }
 
     "write a point" in { (client: Client[IO], console: TestConsole[IO], cfg: AppConfig) =>
-      val cl = InfluxClient[IO](client, console, cfg)
+      val cl = InfluxClient[IO](client, cfg, console)
       val point = InfluxPoint(
         "m1",
         Map("created" -> created.toString, "project" -> "org/proj", "deprecated" -> "false"),
@@ -84,7 +84,7 @@ class InfluxClientSpec extends AbstractCliSpec with Http4sExtras with TimeTransf
     }
 
     "fail to write an invalid point" in { (client: Client[IO], console: TestConsole[IO], cfg: AppConfig) =>
-      val cl    = InfluxClient[IO](client, console, cfg)
+      val cl    = InfluxClient[IO](client, cfg, console)
       val point = InfluxPoint("m2", Map.empty, Map.empty, Some(updated))
       for {
         result <- cl.write(point)
@@ -95,7 +95,7 @@ class InfluxClientSpec extends AbstractCliSpec with Http4sExtras with TimeTransf
     }
 
     "perform an influxQL query" in { (client: Client[IO], console: TestConsole[IO], cfg: AppConfig) =>
-      val cl = InfluxClient[IO](client, console, cfg)
+      val cl = InfluxClient[IO](client, cfg, console)
       for {
         dbResult <- cl.query(allowedQuery)
         err      <- console.errQueue.tryDequeue1

--- a/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/influx/AbstractInfluxSpec.scala
+++ b/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/influx/AbstractInfluxSpec.scala
@@ -38,7 +38,7 @@ class AbstractInfluxSpec extends AbstractCliSpec {
     make[InfluxClient[IO]].fromResource {
       (_: InfluxDocker.Container, cfg: AppConfig, blocker: Blocker, console: Console[IO]) =>
         BlazeClientBuilder[IO](blocker.blockingContext).resource.flatMap { client =>
-          val influxClient = InfluxClient(client, console, cfg)
+          val influxClient = InfluxClient(client, cfg, console)
           waitForPostgresReady(influxClient).map(_ => influxClient)
         }
     }


### PR DESCRIPTION
Fixes the following issue when running the CLI:
```
[info] running (fork) ch.epfl.bluebrain.nexus.cli.Main influx run
[error] izumi.distage.model.exceptions.ProvisioningException: Provisioner stopped after 1 instances, 1/43 operations failed: 
[error]  - {type.ch.epfl.bluebrain.nexus.cli.clients.InfluxClient[=? %0 ? Task[+0]]} (InfluxModule.scala:11), MissingInstanceException: Instance is not available in the object graph: {type.ch.epfl.bluebrain.nexus.cli.clients.InfluxClient[=? %0 ? Task[+0]]}.
[error] Required by refs:
[error]  * {type.ch.epfl.bluebrain.nexus.cli.modules.influx.InfluxProjection[=? %0 ? Task[+0]]}
[error]         at izumi.distage.model.provisioning.PlanInterpreter$FailedProvision.$anonfun$throwException$2(PlanInterpreter.scala:62)
[error]
...
```

This didn't happen during testing because we instantiate another `InfluxClient`