### PR TITLE
Ported Storage service to module

### DIFF
--- a/.github/workflows/ci-storage.yml
+++ b/.github/workflows/ci-storage.yml
@@ -1,0 +1,64 @@
+name: Continuous Integration Storage
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'rdf/**'
+      - 'storage/**'
+      - 'build.sbt'
+      - 'project/**'
+  pull_request:
+    paths:
+      - 'rdf/**'
+      - 'storage/**'
+      - 'build.sbt'
+      - 'project/**'
+jobs:
+  review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - name: Cache Coursier
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.cache/coursier
+          key: ${{ runner.os }}-coursier-scala-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-coursier-scala-
+      - uses: olafurpg/setup-scala@v5
+        with:
+          java-version: adopt@1.11
+      - name: StaticAnalysis
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false "project storage" clean scalafmtCheck test:scalafmtCheck scalafmtSbtCheck scapegoat
+      - name: Tests
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false "project storage" clean coverage test coverageReport coverageAggregate
+  publish:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    env:
+      CI: true
+      BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+      BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - name: Cache Coursier
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.cache/coursier
+          key: ${{ runner.os }}-coursier-scala-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-coursier-scala-
+      - uses: olafurpg/setup-scala@v5
+        with:
+          java-version: adopt@1.11
+      - name: Publish
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false "project storage" releaseEarly
+      - name: RecordCoverage
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false "project storage" clean coverage test coverageReport coverageAggregate
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("io.github.jonas"       % "sbt-paradox-material-theme" % "0.5.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/storage/src/main/resources/akka.conf
+++ b/storage/src/main/resources/akka.conf
@@ -1,0 +1,38 @@
+akka {
+
+  http {
+    server {
+      transparent-head-requests = off
+      parsing.max-content-length = 10g
+      parsing.max-content-length = ${?AKKA_HTTP_MAX_CONTENT_LENGTH}
+      request-timeout = 50 seconds
+      request-timeout = ${?AKKA_HTTP_SERVER_REQ_TIMEOUT}
+    }
+    server.parsing.max-content-length = 100g
+    server.parsing.max-content-length = ${?AKKA_HTTP_MAX_CONTENT_LENGTH}
+    server.request-timeout = 20 seconds
+    server.request-timeout = ${?AKKA_HTTP_SERVER_REQUEST_TIMEOUT}
+    host-connection-pool  {
+      max-connections   = 16
+      max-connections   = ${?AKKA_HTTP_MAX_CONNECTIONS}
+      max-open-requests = 64
+      max-open-requests = ${?AKKA_HTTP_MAX_OPEN_REQUESTS}
+    }
+    sse {
+      # The maximum size for parsing server-sent events (96KiB).
+      max-event-size = 98304
+      max-event-size = ${?AKKA_HTTP_SSE_MAX_EVENT_SIZE}
+
+      # The maximum size for parsing lines of a server-sent event (48KiB).
+      max-line-size = 49152
+      max-line-size = ${?AKKA_HTTP_SSE_MAX_LINE_SIZE}
+    }
+  }
+
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  log-dead-letters = off
+  loglevel = INFO
+  loglevel = ${?AKKA_LOG_LEVEL}
+
+}

--- a/storage/src/main/resources/app.conf
+++ b/storage/src/main/resources/app.conf
@@ -1,0 +1,98 @@
+# All application specific configuration should reside here
+app {
+  # The service description namespace
+  description {
+    # The name of the service
+    name = "storage"
+  }
+
+  # Service instance specific settings
+  instance {
+    # The default interface to bind to
+    interface = 127.0.0.1
+    interface = ${?BIND_INTERFACE}
+  }
+
+  # Http binding settings
+  http {
+    # The interface to bind to
+    interface = ${app.instance.interface}
+    # The port to bind to
+    port = 8080
+    port = ${?BIND_PORT}
+    # The default uri prefix
+    prefix = "v1"
+    prefix = ${?HTTP_PREFIX}
+    # The service public uri
+    public-uri = "http://"${app.http.interface}":"${app.http.port}
+    public-uri = ${?PUBLIC_URI}
+  }
+
+  # Service runtime settings
+  runtime {
+    # Arbitrary Future completion timeout
+    default-timeout = 30 seconds
+  }
+
+  # Storage configuration
+  storage {
+    # the absolute path where the files are stored
+    root-volume = "/tmp"
+    root-volume = ${?STORAGE_ROOT_VOLUME}
+    # the relative path of the protected directory once the storage bucket is selected
+    protected-directory = "nexus"
+    protected-directory = ${?STORAGE_PROTECTED_DIRECTORY}
+    # permissions fixer
+    fixer-enabled = false
+    fixer-enabled = ${?STORAGE_FIXER_ENABLED}
+    fixer-command = []
+    fixer-command += ${?STORAGE_FIXER_COMMAND1}
+    fixer-command += ${?STORAGE_FIXER_COMMAND2}
+  }
+
+  digest {
+    # the digest algorithm
+    algorithm = "SHA-256"
+    algorithm = ${?DIGEST_FILE_ALGORITHM}
+    # the maximum number of digests stored in memory
+    max-in-memory = 10000
+    max-in-memory = ${?DIGEST_IN_MEMORY}
+    # the maximum number of concurrent computations of digest
+    concurrent-computations = 4
+    concurrent-computations = ${?DIGEST_CONCURRENT_COMPUTATIONS}
+    # the maximum number of computations in queue to be computed
+    max-in-queue = 10000
+    max-in-queue = ${?DIGEST_IN_QUEUE_COMPUTATIONS}
+    # the amout of time after a digest which is still in the queue to be computed can be retrigger
+    retrigger-after = 30 minutes
+    retrigger-after = ${?DIGEST_RETRIGGER_AFTER}
+
+  }
+
+  # Allowed subject to perform calls
+  subject {
+    # flag to decide whether or not the allowed subject is Anonymous or a User
+    anonymous = false
+    anonymous = ${?SUBJECT_ANONYMOUS}
+    # the user realm. It must be present when anonymous = false and it must be removed when anonymous = true
+    realm = ${?SUBJECT_REALM}
+    # the user name. It must be present when anonymous = false and it must be removed when anonymous = true
+    name = ${?SUBJECT_NAME}
+  }
+
+  # Iam client configuration
+  iam {
+    # The public iri to the iam service
+    public-iri = "http://localhost:8080"
+    public-iri = ${?IAM_PUBLIC_IRI}
+    # The internal iri to the iam service
+    internal-iri = "http://localhost:8080"
+    internal-iri = ${?IAM_INTERNAL_IRI}
+    # The version prefix
+    prefix = "v1"
+    prefix = ${?IAM_PREFIX}
+
+    # The delay for retrying after completion on SSE
+    sse-retry-delay = 1 second
+  }
+}

--- a/storage/src/main/resources/application.conf
+++ b/storage/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+include "app.conf"
+include "akka.conf"
+include "kamon.conf"

--- a/storage/src/main/resources/logback.xml
+++ b/storage/src/main/resources/logback.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender name="TRACED" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss} %-5level [%traceToken] %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL:-INFO}">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="ch.epfl.bluebrain.nexus.kg" additivity="false" level="${LOG_LEVEL:-INFO}">
+        <appender-ref ref="TRACED" />
+    </logger>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="akka.remote" level="WARN" />
+    <logger name="akka.cluster" level="WARN" />
+    <logger name="es.weso.shacl" level="WARN" />
+    <logger name="es.weso.schema" level="WARN" />
+
+</configuration>

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/File.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/File.scala
@@ -1,0 +1,67 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import akka.http.scaladsl.model.{ContentType, Uri}
+import ch.epfl.bluebrain.nexus.rdf.implicits._
+import ch.epfl.bluebrain.nexus.storage.config.Contexts.resourceCtxUri
+import scala.annotation.nowarn
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, Encoder}
+
+// $COVERAGE-OFF$
+object File {
+
+  @nowarn("cat=unused")
+  implicit private val config: Configuration = Configuration.default
+    .copy(transformMemberNames = {
+      case "@context" => "@context"
+      case key        => s"_$key"
+    })
+
+  /**
+    * Holds some of the metadata information related to a file.
+    *
+    * @param filename  the original filename of the file
+    * @param mediaType the media type of the file
+    */
+  final case class FileDescription(filename: String, mediaType: ContentType)
+
+  /**
+    * Holds all the metadata information related to the file.
+    *
+    * @param location  the file location
+    * @param bytes     the size of the file file in bytes
+    * @param digest    the digest information of the file
+    * @param mediaType the media type of the file
+    */
+  final case class FileAttributes(location: Uri, bytes: Long, digest: Digest, mediaType: ContentType)
+  object FileAttributes {
+    @nowarn("cat=unused")
+    implicit private val encMediaType: Encoder[ContentType] =
+      Encoder.encodeString.contramap(_.value)
+
+    @nowarn("cat=unused")
+    implicit private val decMediaType: Decoder[ContentType] =
+      Decoder.decodeString.emap(ContentType.parse(_).left.map(_.mkString("\n")))
+
+    implicit val fileAttrEncoder: Encoder[FileAttributes] =
+      deriveConfiguredEncoder[FileAttributes].mapJson(_.addContext(resourceCtxUri))
+    implicit val fileAttrDecoder: Decoder[FileAttributes] = deriveConfiguredDecoder[FileAttributes]
+  }
+
+  /**
+    * Digest related information of the file
+    *
+    * @param algorithm the algorithm used in order to compute the digest
+    * @param value     the actual value of the digest of the file
+    */
+  final case class Digest(algorithm: String, value: String)
+
+  object Digest {
+    val empty: Digest                           = Digest("", "")
+    implicit val digestEncoder: Encoder[Digest] = deriveConfiguredEncoder[Digest]
+    implicit val digestDecoder: Decoder[Digest] = deriveConfiguredDecoder[Digest]
+  }
+
+}
+// $COVERAGE-ON$

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/IamIdentitiesClient.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/IamIdentitiesClient.scala
@@ -1,0 +1,166 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import akka.util.ByteString
+import cats.effect.{ContextShift, Effect, IO}
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.rdf.implicits._
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.Identity._
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient._
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClientError.IdentitiesSerializationError
+import ch.epfl.bluebrain.nexus.storage.config.IamClientConfig
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport.{DecodingFailures => AccDecodingFailures}
+import io.circe.Decoder.Result
+import io.circe.{Decoder, DecodingFailure, HCursor}
+
+import scala.concurrent.ExecutionContext
+
+class IamIdentitiesClient[F[_]](config: IamClientConfig)(implicit F: Effect[F], as: ActorSystem)
+    extends JsonLdCirceSupport {
+
+  private val um: FromEntityUnmarshaller[Caller]      = unmarshaller[Caller]
+  implicit private val ec: ExecutionContext           = as.dispatcher
+  implicit private val contextShift: ContextShift[IO] = IO.contextShift(ec)
+
+  def apply()(implicit credentials: Option[AccessToken]): F[Caller] =
+    credentials match {
+      case Some(token) => execute(Get(config.identitiesIri.asAkka).addCredentials(OAuth2BearerToken(token.value)))
+      case None        => F.pure(Caller.anonymous)
+    }
+
+  private def execute(req: HttpRequest): F[Caller] = {
+    IO.fromFuture(IO(Http().singleRequest(req))).to[F].flatMap { resp =>
+      if (resp.status.isSuccess())
+        IO.fromFuture(IO(um(resp.entity))).to[F].recoverWith {
+          case err: AccDecodingFailures => F.raiseError(IdentitiesSerializationError(err.getMessage))
+          case err: Error               => F.raiseError(IdentitiesSerializationError(err.getMessage))
+        }
+      else
+        IO.fromFuture(IO(resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)))
+          .to[F]
+          .flatMap { err => F.raiseError(IamIdentitiesClientError.unsafe(resp.status, err)) }
+    }
+  }
+
+}
+
+object IamIdentitiesClient {
+
+  /**
+    * The client caller. It contains the subject and the list of identities (which contains the subject again)
+    *
+   * @param subject    the identity that performed the call
+    * @param identities the set of other identities associated to the ''subject''. E.g.: groups, anonymous, authenticated
+    */
+  final case class Caller(subject: Subject, identities: Set[Identity])
+
+  object Caller {
+
+    /**
+      * An anonymous caller
+      */
+    val anonymous: Caller = Caller(Anonymous: Subject, Set[Identity](Anonymous))
+
+    implicit final val callerDecoder: Decoder[Caller] =
+      Decoder.instance { cursor =>
+        cursor
+          .get[Set[Identity]]("identities")
+          .flatMap { identities =>
+            identities.collectFirst { case u: User => u } orElse identities.collectFirst {
+              case Anonymous => Anonymous
+            } match {
+              case Some(subject: Subject) => Right(Caller(subject, identities))
+              case _                      =>
+                val pos = cursor.downField("identities").history
+                Left(DecodingFailure("Unable to find a subject in the collection of identities", pos))
+            }
+          }
+      }
+  }
+
+  /**
+    * A data structure which represents an access token
+    *
+   * @param value the token value
+    */
+  final case class AccessToken(value: String)
+
+  /**
+    * Base enumeration type for identity classes.
+    */
+  sealed trait Identity extends Product with Serializable
+
+  object Identity {
+
+    /**
+      * Base enumeration type for subject classes.
+      */
+    sealed trait Subject extends Identity
+
+    sealed trait Anonymous extends Subject
+
+    /**
+      * The Anonymous subject
+      */
+    final case object Anonymous extends Anonymous
+
+    /**
+      * The User subject
+      *
+     * @param subject unique user name
+      * @param realm   user realm
+      */
+    final case class User(subject: String, realm: String) extends Subject
+
+    /**
+      * The Group identity
+      *
+     * @param group the group
+      * @param realm group realm
+      */
+    final case class Group(group: String, realm: String) extends Identity
+
+    /**
+      * The Authenticated identity
+      *
+     * @param realm the realm
+      */
+    final case class Authenticated(realm: String) extends Identity
+
+    private def decodeAnonymous(hc: HCursor): Result[Subject] =
+      hc.get[String]("@type").flatMap {
+        case "Anonymous" => Right(Anonymous)
+        case _           => Left(DecodingFailure("Cannot decode Anonymous Identity", hc.history))
+      }
+
+    private def decodeUser(hc: HCursor): Result[Subject] =
+      (hc.get[String]("subject"), hc.get[String]("realm")).mapN {
+        case (subject, realm) => User(subject, realm)
+      }
+
+    private def decodeGroup(hc: HCursor): Result[Identity] =
+      (hc.get[String]("group"), hc.get[String]("realm")).mapN {
+        case (group, realm) => Group(group, realm)
+      }
+
+    private def decodeAuthenticated(hc: HCursor): Result[Identity] =
+      hc.get[String]("realm").map(Authenticated)
+
+    private val attempts =
+      List[HCursor => Result[Identity]](decodeAnonymous, decodeUser, decodeGroup, decodeAuthenticated)
+
+    implicit val identityDecoder: Decoder[Identity] =
+      Decoder.instance { hc =>
+        attempts.foldLeft(Left(DecodingFailure("Unexpected", hc.history)): Result[Identity]) {
+          case (acc @ Right(_), _) => acc
+          case (_, f)              => f(hc)
+        }
+      }
+  }
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/IamIdentitiesClientError.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/IamIdentitiesClientError.scala
@@ -1,0 +1,58 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+
+/**
+  * Enumeration of possible Iam identities Client errors.
+  */
+@SuppressWarnings(Array("IncorrectlyNamedExceptions"))
+sealed abstract class IamIdentitiesClientError(val msg: String) extends Exception with Product with Serializable {
+  override def fillInStackTrace(): IamIdentitiesClientError = this
+  override def getMessage: String                           = msg
+}
+
+@SuppressWarnings(Array("IncorrectlyNamedExceptions"))
+object IamIdentitiesClientError {
+
+  final def unsafe(status: StatusCode, body: String): IamIdentitiesClientError =
+    status match {
+      case _ if status.isSuccess()       =>
+        throw new IllegalArgumentException(s"Successful status code '$status' found, error expected.")
+      case code: StatusCodes.ClientError => IdentitiesClientStatusError(code, body)
+      case code: StatusCodes.ServerError => IdentitiesServerStatusError(code, body)
+      case _                             => IdentitiesUnexpectedStatusError(status, body)
+    }
+
+  /**
+    * A serialization error when attempting to cast response.
+    */
+  final case class IdentitiesSerializationError(message: String)
+      extends IamIdentitiesClientError(
+        s"an IAM request to the identities endpoint could not be converted to 'Caller' type. Details '$message'"
+      )
+
+  /**
+    * A Client status error (HTTP status codes 4xx).
+    */
+  final case class IdentitiesClientStatusError(code: StatusCodes.ClientError, message: String)
+      extends IamIdentitiesClientError(
+        s"an IAM request to the identities endpoint that should have been successful, returned the HTTP status code '$code'. Details '$message'"
+      )
+
+  /**
+    * A server status error (HTTP status codes 5xx).
+    */
+  final case class IdentitiesServerStatusError(code: StatusCodes.ServerError, message: String)
+      extends IamIdentitiesClientError(
+        s"an IAM request to the identities endpoint that should have been successful, returned the HTTP status code '$code'. Details '$message'"
+      )
+
+  /**
+    * Some other response error which is not 4xx nor 5xx
+    */
+  final case class IdentitiesUnexpectedStatusError(code: StatusCode, message: String)
+      extends IamIdentitiesClientError(
+        s"an IAM request to the identities endpoint that should have been successful, returned the HTTP status code '$code'. Details '$message'"
+      )
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/JsonLdCirceSupport.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/JsonLdCirceSupport.scala
@@ -1,0 +1,97 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.model.{ContentTypeRange, HttpEntity}
+import ch.epfl.bluebrain.nexus.commons.http.RdfMediaTypes
+import ch.epfl.bluebrain.nexus.storage.JsonLdCirceSupport.{sortKeys, OrderedKeys}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.syntax._
+import io.circe.{Encoder, Json, JsonObject, Printer}
+
+import scala.collection.immutable.Seq
+
+/**
+  * Json-LD specific akka http circe support.
+  *
+ * It uses [[ch.epfl.bluebrain.nexus.commons.http.RdfMediaTypes.`application/ld+json`]] as the default content
+  * type for encoding json trees into http request payloads.
+  */
+trait JsonLdCirceSupport extends FailFastCirceSupport {
+
+  override def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    List(`application/json`, RdfMediaTypes.`application/ld+json`)
+
+  /**
+    * `A` => HTTP entity
+    *
+   * @tparam A type to encode
+    * @return marshaller for any `A` value
+    */
+  implicit final def marshallerHttp[A](implicit
+      encoder: Encoder[A],
+      printer: Printer = Printer.noSpaces.copy(dropNullValues = true),
+      keys: OrderedKeys = OrderedKeys()
+  ): ToEntityMarshaller[A] =
+    jsonLdMarshaller.compose(encoder.apply)
+
+  /**
+    * `Json` => HTTP entity
+    *
+   * @return marshaller for JSON-LD value
+    */
+  implicit final def jsonLdMarshaller(implicit
+      printer: Printer = Printer.noSpaces.copy(dropNullValues = true),
+      keys: OrderedKeys = OrderedKeys()
+  ): ToEntityMarshaller[Json] =
+    Marshaller.withFixedContentType(RdfMediaTypes.`application/ld+json`) { json =>
+      HttpEntity(RdfMediaTypes.`application/ld+json`, printer.print(sortKeys(json)))
+    }
+
+}
+
+object JsonLdCirceSupport extends JsonLdCirceSupport {
+
+  /**
+    * Data type which holds the ordering for the JSON-LD keys.
+    *
+   * @param keys list of strings which defines the ordering for the JSON-LD keys
+    */
+  final case class OrderedKeys(keys: List[String]) {
+    lazy val withPosition: Map[String, Int] = keys.zipWithIndex.toMap
+  }
+  object OrderedKeys                               {
+
+    /**
+      * Construct an empty [[OrderedKeys]]
+      */
+    final def apply(): OrderedKeys = new OrderedKeys(List(""))
+  }
+
+  /**
+    * Order json keys according to the passed [[OrderedKeys]]
+    */
+  def sortKeys(json: Json)(implicit keys: OrderedKeys): Json = {
+
+    implicit val customStringOrdering: Ordering[String] = new Ordering[String] {
+      private val middlePos = keys.withPosition("")
+
+      private def position(key: String): Int = keys.withPosition.getOrElse(key, middlePos)
+
+      override def compare(x: String, y: String): Int = {
+        val posX = position(x)
+        val posY = position(y)
+        if (posX == middlePos && posY == middlePos) x compareTo y
+        else posX compareTo posY
+      }
+    }
+
+    def canonicalJson(json: Json): Json =
+      json.arrayOrObject[Json](json, arr => Json.fromValues(arr.map(canonicalJson)), obj => sorted(obj).asJson)
+
+    def sorted(jObj: JsonObject): JsonObject =
+      JsonObject.fromIterable(jObj.toVector.sortBy(_._1).map { case (k, v) => k -> canonicalJson(v) })
+
+    canonicalJson(json)
+  }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Main.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Main.scala
@@ -1,0 +1,93 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import java.nio.file.Paths
+import java.time.Clock
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
+import akka.util.Timeout
+import cats.effect.Effect
+import ch.epfl.bluebrain.nexus.storage.Storages.DiskStorage
+import ch.epfl.bluebrain.nexus.storage.attributes.AttributesCache
+import ch.epfl.bluebrain.nexus.storage.config.{AppConfig, Settings}
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig._
+import ch.epfl.bluebrain.nexus.storage.routes.Routes
+import com.typesafe.config.{Config, ConfigFactory}
+import kamon.Kamon
+import monix.eval.Task
+import monix.execution.Scheduler
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+//noinspection TypeAnnotation
+// $COVERAGE-OFF$
+object Main {
+
+  def loadConfig(): Config = {
+    val cfg = sys.env.get("STORAGE_CONFIG_FILE") orElse sys.props.get("storage.config.file") map { str =>
+      val file = Paths.get(str).toAbsolutePath.toFile
+      ConfigFactory.parseFile(file)
+    } getOrElse ConfigFactory.empty()
+    (cfg withFallback ConfigFactory.load()).resolve()
+  }
+
+  def setupMonitoring(config: Config): Unit = {
+    if (sys.env.getOrElse("KAMON_ENABLED", "false").toBoolean) {
+      Kamon.reconfigure(config)
+      Kamon.loadModules()
+    }
+  }
+
+  def shutdownMonitoring(): Unit = {
+    if (sys.env.getOrElse("KAMON_ENABLED", "false").toBoolean) {
+      Await.result(Kamon.stopModules(), 10.seconds)
+    }
+  }
+
+  @SuppressWarnings(Array("UnusedMethodParameter"))
+  def main(args: Array[String]): Unit = {
+    val config = loadConfig()
+    setupMonitoring(config)
+
+    implicit val appConfig: AppConfig = Settings(config).appConfig
+
+    implicit val as: ActorSystem                          = ActorSystem(appConfig.description.fullName, config)
+    implicit val ec: ExecutionContext                     = as.dispatcher
+    implicit val eff: Effect[Task]                        = Task.catsEffect(Scheduler.global)
+    implicit val iamIdentities: IamIdentitiesClient[Task] = new IamIdentitiesClient[Task](appConfig.iam)
+    implicit val timeout                                  = Timeout(1.minute)
+    implicit val clock                                    = Clock.systemUTC
+
+    val storages: Storages[Task, AkkaSource] =
+      new DiskStorage(appConfig.storage, appConfig.digest, AttributesCache[Task, AkkaSource])
+
+    val logger: LoggingAdapter = Logging(as, getClass)
+
+    logger.info("==== Cluster is Live ====")
+    val routes: Route = Routes(storages)
+
+    val httpBinding: Future[Http.ServerBinding] = {
+      Http().bindAndHandle(routes, appConfig.http.interface, appConfig.http.port)
+    }
+    httpBinding onComplete {
+      case Success(binding) =>
+        logger.info(s"Bound to ${binding.localAddress.getHostString}: ${binding.localAddress.getPort}")
+      case Failure(th)      =>
+        logger.error(th, "Failed to perform an http binding on {}:{}", appConfig.http.interface, appConfig.http.port)
+        Await.result(as.terminate(), 10.seconds)
+    }
+
+    as.registerOnTermination {
+      shutdownMonitoring()
+    }
+    // attempt to leave the cluster before shutting down
+    val _ = sys.addShutdownHook {
+      Await.result(as.terminate().map(_ => ()), 10.seconds)
+    }
+  }
+}
+// $COVERAGE-ON$

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/RdfMediaTypes.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/RdfMediaTypes.scala
@@ -1,0 +1,13 @@
+package ch.epfl.bluebrain.nexus.commons.http
+
+import akka.http.scaladsl.model.HttpCharsets._
+import akka.http.scaladsl.model.MediaType
+
+/**
+  * Collection of media types specific to RDF.
+  */
+object RdfMediaTypes {
+  final val `application/ld+json`: MediaType.WithFixedCharset =
+    MediaType.applicationWithFixedCharset("ld+json", `UTF-8`, "jsonld")
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Rejection.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Rejection.scala
@@ -1,0 +1,82 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.server.{Rejection => AkkaRejection}
+import ch.epfl.bluebrain.nexus.storage.routes.StatusFrom
+import scala.annotation.nowarn
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
+import io.circe.{Encoder, Json}
+
+/**
+  * Enumeration of resource rejection types.
+  *
+  * @param msg a descriptive message of the rejection
+  */
+sealed abstract class Rejection(val msg: String) extends AkkaRejection with Product with Serializable
+
+object Rejection {
+
+  /**
+    * Signals an attempt to interact with a bucket that doesn't exist.
+    *
+    * @param name the storage bucket name
+    */
+  final case class BucketNotFound(name: String) extends Rejection(s"The provided bucket '$name' does not exist.")
+
+  /**
+    * Signals an attempt to override a path that already exists.
+    *
+    * @param name the storage bucket name
+    * @param path the relative path to the file
+    */
+  final case class PathAlreadyExists(name: String, path: Path)
+      extends Rejection(
+        s"The provided location inside the bucket '$name' with the relative path '$path' already exists."
+      )
+
+  /**
+    * Signals an attempt to interact with a path that doesn't exist.
+    *
+    * @param name the storage bucket name
+    * @param path the relative path to the file
+    */
+  final case class PathNotFound(name: String, path: Path)
+      extends Rejection(
+        s"The provided location inside the bucket '$name' with the relative path '$path' does not exist."
+      )
+
+  /**
+    * Signals that the location contains symbolic or hard links.
+    *
+    * @param name the storage bucket name
+    * @param path the relative path to the file
+    */
+  final case class PathContainsLinks(name: String, path: Path)
+      extends Rejection(
+        s"The provided location inside the bucket '$name' with the relative path '$path' contains links. Please remove them in order to proceed with this call."
+      )
+
+  /**
+    *
+    * Signals a missing.
+    * @param name the storage bucket name
+    */
+  final case class EmptyFilename(name: String)
+
+  implicit def statusCodeFrom: StatusFrom[Rejection] =
+    StatusFrom {
+      case _: PathContainsLinks => StatusCodes.BadRequest
+      case _: PathAlreadyExists => StatusCodes.Conflict
+      case _: BucketNotFound    => StatusCodes.NotFound
+      case _: PathNotFound      => StatusCodes.NotFound
+    }
+
+  @nowarn("cat=unused")
+  implicit val rejectionEncoder: Encoder[Rejection] = {
+    implicit val rejectionConfig: Configuration = Configuration.default.withDiscriminator("@type")
+    val enc                                     = deriveConfiguredEncoder[Rejection].mapJson(jsonError)
+    Encoder.instance(r => enc(r) deepMerge Json.obj("reason" -> Json.fromString(r.msg)))
+  }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/StorageError.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/StorageError.scala
@@ -1,0 +1,104 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.Uri.Path
+import ch.epfl.bluebrain.nexus.storage.routes.StatusFrom
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
+import io.circe.{Encoder, Json}
+
+import scala.annotation.nowarn
+
+/**
+  * Enumeration of runtime errors.
+  *
+  * @param msg a description of the error
+  */
+@SuppressWarnings(Array("IncorrectlyNamedExceptions"))
+sealed abstract class StorageError(val msg: String) extends Exception with Product with Serializable {
+  override def fillInStackTrace(): StorageError = this
+  override def getMessage: String               = msg
+}
+
+@SuppressWarnings(Array("IncorrectlyNamedExceptions"))
+object StorageError {
+
+  /**
+    * Generic wrapper for kg errors that should not be exposed to clients.
+    *
+    * @param reason the underlying error reason
+    */
+  final case class InternalError(reason: String) extends StorageError(reason)
+
+  /**
+    * Signals that the provided authentication is not valid.
+    */
+  final case object AuthenticationFailed extends StorageError("The supplied authentication is invalid.")
+
+  /**
+    * Signals that the caller doesn't have access to the selected resource.
+    */
+  final case object AuthorizationFailed
+      extends StorageError("The supplied authentication is not authorized to access this resource.")
+
+  /**
+    * Signals the inability to connect to an underlying service to perform a request.
+    *
+    * @param msg a human readable description of the cause
+    */
+  final case class DownstreamServiceError(override val msg: String) extends StorageError(msg)
+
+  /**
+    * Signals an attempt to interact with a path that doesn't exist.
+    *
+    * @param name the storage bucket name
+    * @param path the relative path to the file
+    */
+  final case class PathNotFound(name: String, path: Path)
+      extends StorageError(
+        s"The provided location inside the bucket '$name' with the relative path '$path' does not exist."
+      )
+
+  /**
+    * Signals an attempt to interact with a path that is invalid.
+    *
+    * @param name the storage bucket name
+    * @param path the relative path to the file
+    */
+  final case class PathInvalid(name: String, path: Path)
+      extends StorageError(
+        s"The provided location inside the bucket '$name' with the relative path '$path' is invalid."
+      )
+
+  /**
+    * Signals that the system call to the 'nexus-fixer' binary failed.
+    *
+    * @param path    the absolute path to the file
+    * @param message the error message returned by the system call
+    */
+  final case class PermissionsFixingFailed(path: String, message: String)
+      extends StorageError(s"Fixing permissions on the path '$path' failed with an error: $message")
+
+  /**
+    * Signals an internal timeout.
+    *
+    * @param msg a descriptive message on the operation that timed out
+    */
+  final case class OperationTimedOut(override val msg: String) extends StorageError(msg)
+
+  @nowarn("cat=unused")
+  implicit private val config: Configuration = Configuration.default.withDiscriminator("@type")
+
+  private val derivedEncoder = deriveConfiguredEncoder[StorageError].mapJson(jsonError)
+
+  implicit val storageErrorEncoder: Encoder[StorageError]       =
+    Encoder.instance(r => derivedEncoder(r) deepMerge Json.obj("reason" -> Json.fromString(r.msg)))
+
+  implicit val storageErrorStatusFrom: StatusFrom[StorageError] = {
+    case _: PathNotFound      => StatusCodes.NotFound
+    case _: PathInvalid       => StatusCodes.BadRequest
+    case AuthenticationFailed => StatusCodes.Unauthorized
+    case AuthorizationFailed  => StatusCodes.Forbidden
+    case _                    => StatusCodes.InternalServerError
+  }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Storages.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Storages.scala
@@ -1,0 +1,279 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import java.net.URLDecoder
+import java.nio.file.StandardCopyOption._
+import java.nio.file.{Files, Path, Paths}
+import java.security.MessageDigest
+
+import akka.http.scaladsl.model.Uri
+import akka.stream.Materializer
+import akka.stream.alpakka.file.scaladsl.Directory
+import akka.stream.scaladsl.{FileIO, Keep, Sink}
+import cats.effect.Effect
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.storage.File._
+import ch.epfl.bluebrain.nexus.storage.Rejection.{PathAlreadyExists, PathContainsLinks, PathNotFound}
+import ch.epfl.bluebrain.nexus.storage.StorageError.{InternalError, PathInvalid, PermissionsFixingFailed}
+import ch.epfl.bluebrain.nexus.storage.Storages.BucketExistence._
+import ch.epfl.bluebrain.nexus.storage.Storages.PathExistence._
+import ch.epfl.bluebrain.nexus.storage.Storages.{BucketExistence, PathExistence}
+import ch.epfl.bluebrain.nexus.storage.attributes.AttributesCache
+import ch.epfl.bluebrain.nexus.storage.attributes.AttributesComputation._
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.{DigestConfig, StorageConfig}
+import scala.annotation.nowarn
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.sys.process._
+import scala.util.{Success, Try}
+
+trait Storages[F[_], Source] {
+
+  /**
+    * Checks that the provided bucket name exists and it is readable/writable.
+    *
+    * @param name the storage bucket name
+    */
+  def exists(name: String): BucketExistence
+
+  /**
+    * Check whether the provided path already exists.
+    *
+    * @param name         the storage bucket name
+    * @param relativePath the relative path location
+    */
+  def pathExists(name: String, relativePath: Uri.Path): PathExistence
+
+  /**
+    * Creates a file with the provided ''metadata'' and ''source'' on the provided ''filePath''.
+    *
+    * @param name         the storage bucket name
+    * @param relativePath the relative path location
+    * @param source       the file content
+    * @return The file attributes containing the metadata (bytes and location) wrapped in an F effect type
+    */
+  def createFile(name: String, relativePath: Uri.Path, source: Source)(implicit
+      @nowarn("cat=unused") bucketEv: BucketExists,
+      @nowarn("cat=unused") pathEv: PathDoesNotExist
+  ): F[FileAttributes]
+
+  /**
+    * Moves a path from the provided ''sourceRelativePath'' to ''destRelativePath'' inside the nexus folder.
+    *
+    * @param name               the storage bucket name
+    * @param sourceRelativePath the source relative path location
+    * @param destRelativePath   the destination relative path location inside the nexus folder
+    * @return Left(rejection) or Right(fileAttributes).
+    *         The file attributes contain the metadata (bytes and location) wrapped in an F effect type
+    */
+  def moveFile(name: String, sourceRelativePath: Uri.Path, destRelativePath: Uri.Path)(implicit
+      @nowarn("cat=unused") bucketEv: BucketExists
+  ): F[RejOrAttributes]
+
+  /**
+    * Retrieves the file as a Source.
+    *
+    * @param name         the storage bucket name
+    * @param relativePath the relative path to the file location
+    * @return Left(rejection),  Right(source, Some(filename)) when the path is a file and Right(source, None) when the path is a directory
+    */
+  def getFile(name: String, relativePath: Uri.Path)(implicit
+      @nowarn("cat=unused") bucketEv: BucketExists,
+      @nowarn("cat=unused") pathEv: PathExists
+  ): RejOr[(Source, Option[String])]
+
+  /**
+    * Retrieves the attributes of the file.
+    *
+    * @param name         the storage bucket name
+    * @param relativePath the relative path to the file location
+    */
+  def getAttributes(name: String, relativePath: Uri.Path)(implicit
+      @nowarn("cat=unused") bucketEv: BucketExists,
+      @nowarn("cat=unused") pathEv: PathExists
+  ): F[FileAttributes]
+
+}
+
+object Storages {
+
+  sealed trait BucketExistence
+  sealed trait PathExistence
+
+  object BucketExistence {
+    final case object BucketExists       extends BucketExistence
+    final case object BucketDoesNotExist extends BucketExistence
+    type BucketExists       = BucketExists.type
+    type BucketDoesNotExist = BucketDoesNotExist.type
+  }
+
+  object PathExistence {
+    final case object PathExists       extends PathExistence
+    final case object PathDoesNotExist extends PathExistence
+    type PathExists       = PathExists.type
+    type PathDoesNotExist = PathDoesNotExist.type
+  }
+
+  /**
+    * An Disk implementation of Storage interface.
+    */
+  final class DiskStorage[F[_]](config: StorageConfig, digestConfig: DigestConfig, cache: AttributesCache[F])(implicit
+      ec: ExecutionContext,
+      mt: Materializer,
+      F: Effect[F]
+  ) extends Storages[F, AkkaSource] {
+
+    private def decode(path: Uri.Path): String =
+      Try(URLDecoder.decode(path.toString, "UTF-8")).getOrElse(path.toString())
+
+    private def basePath(name: String, protectedDir: Boolean = true): Path = {
+      val path = config.rootVolume.resolve(name).normalize()
+      if (protectedDir) path.resolve(config.protectedDirectory).normalize() else path
+    }
+
+    private def filePath(name: String, relativePath: Uri.Path, protectedDir: Boolean = true): Path =
+      basePath(name, protectedDir).resolve(Paths.get(decode(relativePath))).normalize()
+
+    def exists(name: String): BucketExistence = {
+      val path = basePath(name)
+      if (path.getParent.getParent != config.rootVolume) BucketDoesNotExist
+      else if (Files.isDirectory(path) && Files.isReadable(path)) BucketExists
+      else BucketDoesNotExist
+    }
+
+    def pathExists(name: String, relativeFilePath: Uri.Path): PathExistence = {
+      val path = filePath(name, relativeFilePath)
+      if (Files.exists(path) && Files.isReadable(path) && path.descendantOf(basePath(name))) PathExists
+      else PathDoesNotExist
+    }
+
+    def createFile(name: String, relativeFilePath: Uri.Path, source: AkkaSource)(implicit
+        @nowarn("cat=unused") bucketEv: BucketExists,
+        @nowarn("cat=unused") pathEv: PathDoesNotExist
+    ): F[FileAttributes] = {
+      val absFilePath = filePath(name, relativeFilePath)
+      if (absFilePath.descendantOf(basePath(name)))
+        F.fromTry(Try(Files.createDirectories(absFilePath.getParent))) >>
+          F.fromTry(Try(MessageDigest.getInstance(digestConfig.algorithm))).flatMap { msgDigest =>
+            source
+              .alsoToMat(sinkDigest(msgDigest))(Keep.right)
+              .toMat(FileIO.toPath(absFilePath)) {
+                case (digFuture, ioFuture) =>
+                  digFuture.zipWith(ioFuture) {
+                    case (digest, io) if absFilePath.toFile.exists() =>
+                      Future(FileAttributes(absFilePath.toAkkaUri, io.count, digest, detectMediaType(absFilePath)))
+                    case _                                           =>
+                      Future.failed(InternalError(s"I/O error writing file to path '$relativeFilePath'"))
+                  }
+              }
+              .run()
+              .flatten
+              .to[F]
+          }
+      else
+        F.raiseError(PathInvalid(name, relativeFilePath))
+    }
+
+    def moveFile(name: String, sourceRelativePath: Uri.Path, destRelativePath: Uri.Path)(implicit
+        bucketEv: BucketExists
+    ): F[RejOrAttributes] = {
+
+      val bucketPath          = basePath(name, protectedDir = false)
+      val bucketProtectedPath = basePath(name)
+      val absSourcePath       = filePath(name, sourceRelativePath, protectedDir = false)
+      val absDestPath         = filePath(name, destRelativePath)
+
+      def fixPermissions(path: Path): F[Either[PermissionsFixingFailed, Unit]] =
+        if (config.fixerEnabled) {
+          val absPath  = path.toAbsolutePath.normalize.toString
+          val process  = Process(config.fixerCommand :+ absPath)
+          val logger   = StringProcessLogger(config.fixerCommand, absPath)
+          val exitCode = process ! logger
+          if (exitCode == 0) F.pure(Right(()))
+          else F.pure(Left(PermissionsFixingFailed(absPath, logger.toString)))
+        } else {
+          F.pure(Right(()))
+        }
+
+      def failOrComputeSize(fixPermsResult: Either[PermissionsFixingFailed, Unit], isDir: Boolean): F[RejOrAttributes] =
+        fixPermsResult match {
+          case Left(err) => F.raiseError(err)
+          case Right(_)  => computeSizeAndMove(isDir)
+        }
+
+      def computeSizeAndMove(isDir: Boolean): F[RejOrAttributes] = {
+        lazy val mediaType = detectMediaType(absDestPath, isDir)
+        size(absSourcePath).flatMap { computedSize =>
+          F.fromTry(Try(Files.createDirectories(absDestPath.getParent))) >>
+            F.fromTry(Try(Files.move(absSourcePath, absDestPath, ATOMIC_MOVE))) >>
+            F.pure(cache.asyncComputePut(absDestPath, digestConfig.algorithm)) >>
+            F.pure(Right(FileAttributes(absDestPath.toAkkaUri, computedSize, Digest.empty, mediaType)))
+        }
+      }
+
+      def dirContainsLink(path: Path): F[Boolean] =
+        Directory
+          .walk(path)
+          .map(p => Files.isSymbolicLink(p) || containsHardLink(p))
+          .takeWhile(_ == false, inclusive = true)
+          .runWith(Sink.last)
+          .to[F]
+
+      fixPermissions(absSourcePath).flatMap { fixPermsResult =>
+        if (!Files.exists(absSourcePath))
+          F.pure(Left(PathNotFound(name, sourceRelativePath)))
+        else if (!absSourcePath.descendantOf(bucketPath) || absSourcePath.descendantOf(bucketProtectedPath))
+          F.pure(Left(PathNotFound(name, sourceRelativePath)))
+        else if (!absDestPath.descendantOf(bucketProtectedPath))
+          F.raiseError(PathInvalid(name, destRelativePath))
+        else if (Files.exists(absDestPath))
+          F.pure(Left(PathAlreadyExists(name, destRelativePath)))
+        else if (Files.isSymbolicLink(absSourcePath) || containsHardLink(absSourcePath))
+          F.pure(Left(PathContainsLinks(name, sourceRelativePath)))
+        else if (Files.isRegularFile(absSourcePath))
+          failOrComputeSize(fixPermsResult, isDir = false)
+        else if (Files.isDirectory(absSourcePath))
+          dirContainsLink(absSourcePath).flatMap {
+            case true  => F.pure(Left(PathContainsLinks(name, sourceRelativePath)))
+            case false => failOrComputeSize(fixPermsResult, isDir = true)
+          }
+        else F.pure(Left(PathNotFound(name, sourceRelativePath)))
+      }
+    }
+
+    def getFile(
+        name: String,
+        relativePath: Uri.Path
+    )(implicit
+        @nowarn("cat=unused") bucketEv: BucketExists,
+        @nowarn("cat=unused") pathEv: PathExists
+    ): RejOr[(AkkaSource, Option[String])] = {
+      val absPath = filePath(name, relativePath)
+      if (Files.isRegularFile(absPath)) Right(fileSource(absPath) -> Some(absPath.getFileName.toString))
+      else if (Files.isDirectory(absPath)) Right(folderSource(absPath) -> None)
+      else Left(PathNotFound(name, relativePath))
+    }
+
+    def getAttributes(
+        name: String,
+        relativePath: Uri.Path
+    )(implicit bucketEv: BucketExists, pathEv: PathExists): F[FileAttributes] =
+      cache.get(filePath(name, relativePath))
+
+    private def containsHardLink(absPath: Path): Boolean =
+      if (Files.isDirectory(absPath)) false
+      else
+        Try(Files.getAttribute(absPath, "unix:nlink").asInstanceOf[Int]) match {
+          case Success(value) => value > 1
+          case _              => false
+        }
+
+    private def size(absPath: Path): F[Long] =
+      if (Files.isDirectory(absPath))
+        Directory.walk(absPath).filter(Files.isRegularFile(_)).runFold(0L)(_ + Files.size(_)).to[F]
+      else if (Files.isRegularFile(absPath))
+        F.pure(Files.size(absPath))
+      else
+        F.raiseError(InternalError(s"Path '$absPath' is not a file nor a directory"))
+  }
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/StringProcessLogger.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/StringProcessLogger.scala
@@ -1,0 +1,48 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import com.typesafe.scalalogging.Logger
+
+import scala.sys.process.ProcessLogger
+
+/**
+  * Simple [[scala.sys.process.ProcessLogger]] implementation backed by a [[StringBuilder]].
+  *
+  * @param cmd the command, used for logging purposes
+  * @param arg an optional command argument
+  * @note This expects a brief, single-line output.
+  */
+class StringProcessLogger(cmd: Seq[String], arg: Option[String]) extends ProcessLogger {
+
+  private val logger = Logger(cmd.mkString(" "))
+
+  private val builder = new StringBuilder
+
+  override def out(s: => String): Unit = {
+    builder.append(s)
+    logger.debug(format(s, arg))
+  }
+
+  override def err(s: => String): Unit = {
+    builder.append(s)
+    logger.error(format(s, arg))
+  }
+
+  override def buffer[T](f: => T): T = f
+
+  override def toString: String = builder.toString
+
+  private def format(s: String, arg: Option[String]): String =
+    arg match {
+      case Some(a) => s"$a $s"
+      case None    => s
+    }
+
+}
+
+object StringProcessLogger {
+
+  def apply(cmd: Seq[String], arg: String): StringProcessLogger = new StringProcessLogger(cmd, Some(arg))
+
+  def apply(cmd: Seq[String]): StringProcessLogger = new StringProcessLogger(cmd, None)
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/TarFlow.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/TarFlow.scala
@@ -1,0 +1,75 @@
+package ch.epfl.bluebrain.nexus.storage
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Path}
+
+import akka.NotUsed
+import akka.stream.scaladsl.{FileIO, Flow, Source}
+import akka.util.ByteString
+import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarConstants}
+
+/**
+  * Akka stream flows for writing tar balls.
+  */
+object TarFlow {
+  private val recordSize: Int   = 512
+  private val eofBlockSize: Int = recordSize * 2
+
+  private val terminalChunk =
+    ByteString.newBuilder.putBytes(Array.ofDim[Byte](eofBlockSize)).result
+
+  private def headerBytes(basePath: Path, path: Path): ByteString = {
+    val header  = new TarArchiveEntry(path.toFile, basePath.getParent.relativize(path).toString)
+    val buffer  = Array.ofDim[Byte](recordSize)
+    val builder = ByteString.newBuilder
+    def appendHeader(header: TarArchiveEntry): Unit = {
+      header.writeEntryHeader(buffer)
+      builder ++= buffer
+    }
+
+    def padToBoundary(): Unit = {
+      val mod = builder.length % recordSize
+      if (mod != 0) builder ++= List.fill[Byte](recordSize - mod)(0)
+    }
+
+    val nameAsBytes = header.getName.getBytes(UTF_8)
+    if (nameAsBytes.length > TarConstants.NAMELEN) {
+      val longNameHeader = new TarArchiveEntry(TarConstants.GNU_LONGLINK, TarConstants.LF_GNUTYPE_LONGNAME)
+      longNameHeader.setSize(nameAsBytes.length.toLong + 1L) // +1 for null
+      appendHeader(longNameHeader)
+      builder ++= nameAsBytes
+      builder += 0
+      padToBoundary()
+    }
+    appendHeader(header)
+    padToBoundary()
+    builder.result()
+  }
+
+  private def padToBoundary(path: Path): ByteString = {
+    val mod = (Files.size(path) % recordSize).toInt
+    if (mod == 0) ByteString.empty
+    else ByteString(Array.fill[Byte](recordSize - mod)(0))
+  }
+
+  /**
+    * Creates a Flow which deals with [[Path]]s
+    * 1. Creates the ByteString value for the [[Path]] Tar Header and wraps it in a Source
+    * 2. Creates a Source with the ByteString content of the [[Path]]
+    * 3. Creates a ByteString with padding (0s) to fill the previous Source, when needed
+    * The sources are concatenated: 1 --> 2 --> 3
+    *
+    * @param basePath the base directory from where to create the tarball
+    * @return a Flow where the input is a [[Path]] and the output is a [[ByteString]]
+    */
+  def writer(basePath: Path): Flow[Path, ByteString, NotUsed] =
+    Flow[Path]
+      .flatMapConcat {
+        case path if Files.isRegularFile(path) =>
+          val headerSource  = Source.single(headerBytes(basePath, path))
+          val paddingSource = Source.single(padToBoundary(path))
+          headerSource.concat(FileIO.fromPath(path)).concat(paddingSource)
+        case path                              =>
+          Source.single(headerBytes(basePath, path))
+      }
+      .concat(Source.single(terminalChunk))
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesCache.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesCache.scala
@@ -1,0 +1,79 @@
+package ch.epfl.bluebrain.nexus.storage.attributes
+
+import java.nio.file.Path
+import java.time.Clock
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.pattern.{ask, AskTimeoutException}
+import akka.util.Timeout
+import cats.effect.{ContextShift, Effect, IO}
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.storage.File.FileAttributes
+import ch.epfl.bluebrain.nexus.storage.StorageError.{InternalError, OperationTimedOut}
+import ch.epfl.bluebrain.nexus.storage.attributes.AttributesCacheActor.Protocol._
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.DigestConfig
+import com.typesafe.scalalogging.Logger
+
+import scala.util.control.NonFatal
+
+trait AttributesCache[F[_]] {
+
+  /**
+    * Fetches the file attributes for the provided absFilePath.
+    * If the digest is being computed or is going to be computed, a Digest.empty is returned
+    *
+    * @param filePath the absolute file path
+    * @return the file attributes wrapped in the effect type F
+    */
+  def get(filePath: Path): F[FileAttributes]
+
+  /**
+    * Computes the file attributes and stores them asynchronously on the cache
+    *
+    * @param filePath  the absolute file path
+    * @param algorithm the digest algorithm
+    */
+  def asyncComputePut(filePath: Path, algorithm: String): Unit
+}
+
+object AttributesCache {
+  private[this] val logger = Logger[this.type]
+
+  def apply[F[_], Source](implicit
+      system: ActorSystem,
+      clock: Clock,
+      tm: Timeout,
+      F: Effect[F],
+      computation: AttributesComputation[F, Source],
+      config: DigestConfig
+  ): AttributesCache[F] =
+    apply(system.actorOf(AttributesCacheActor.props(computation)))
+
+  private[attributes] def apply[F[_]](
+      underlying: ActorRef
+  )(implicit system: ActorSystem, tm: Timeout, F: Effect[F]): AttributesCache[F] =
+    new AttributesCache[F] {
+      implicit private val contextShift: ContextShift[IO] = IO.contextShift(system.dispatcher)
+
+      override def get(filePath: Path): F[FileAttributes] =
+        IO.fromFuture(IO.shift(system.dispatcher) >> IO(underlying ? Get(filePath)))
+          .to[F]
+          .flatMap[FileAttributes] {
+            case attributes: FileAttributes => F.pure(attributes)
+            case other                      =>
+              logger.error(s"Received unexpected reply from the file attributes cache: '$other'")
+              F.raiseError(InternalError("Unexpected reply from the file attributes cache"))
+          }
+          .recoverWith {
+            case _: AskTimeoutException =>
+              F.raiseError(OperationTimedOut("reply from the file attributes cache timed out"))
+            case NonFatal(th)           =>
+              logger.error("Exception caught while exchanging messages with the file attributes cache", th)
+              F.raiseError(InternalError("Exception caught while exchanging messages with the file attributes cache"))
+          }
+
+      override def asyncComputePut(filePath: Path, algorithm: String): Unit =
+        underlying ! Compute(filePath)
+
+    }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesCacheActor.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesCacheActor.scala
@@ -1,0 +1,156 @@
+package ch.epfl.bluebrain.nexus.storage.attributes
+
+import java.nio.file.Path
+import java.time.Clock
+
+import akka.NotUsed
+import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
+import akka.http.scaladsl.model.MediaTypes.`application/octet-stream`
+import akka.stream.javadsl.Sink
+import akka.stream.scaladsl.{Flow, Keep, Source}
+import akka.stream.{OverflowStrategy, QueueOfferResult}
+import cats.effect.Effect
+import cats.effect.implicits._
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage._
+import ch.epfl.bluebrain.nexus.storage.attributes.AttributesCacheActor.Protocol._
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.DigestConfig
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+/**
+  * Actor that stores a map with the attributes (value) for each path (key). The map also contains timestamps of the attributes being computed.
+  * The attributes computation is executed using a SourceQueue with parallelism defined by the ''concurrentComputations'' configuration flag.
+  * Once computed, a new message is sent back to the actor with the attributes to be stored in the map.
+  *
+  * @param computation the storage computation
+  * @tparam F the effect type
+  * @tparam S the source of the storage computation
+  */
+class AttributesCacheActor[F[_]: Effect, S](computation: AttributesComputation[F, S])(implicit
+    config: DigestConfig,
+    clock: Clock
+) extends Actor
+    with ActorLogging {
+
+  implicit private val as: ActorSystem = context.system
+
+  import context.dispatcher
+  private val map     = mutable.LinkedHashMap.empty[String, Either[Long, FileAttributes]]
+  private val selfRef = self
+
+  private val attributesComputation: Flow[Compute, Option[Put], NotUsed] =
+    Flow[Compute].mapAsyncUnordered(config.concurrentComputations) {
+      case Compute(filePath) =>
+        log.debug("Computing attributes for file '{}'.", filePath)
+        val future = computation(filePath, config.algorithm).toIO.unsafeToFuture()
+        future.map(attributes => Option(Put(filePath, attributes))).recover(logAndSkip(filePath))
+    }
+
+  private val sendMessage = Sink.foreach[Put](putMsg => selfRef ! putMsg)
+
+  private val queue =
+    Source
+      .queue[Compute](config.maxInQueue, OverflowStrategy.dropHead)
+      .via(attributesComputation)
+      .collect { case Some(putMsg) => putMsg }
+      .toMat(sendMessage)(Keep.left)
+      .run()
+
+  private def logAndSkip(filePath: Path): PartialFunction[Throwable, Option[Put]] = {
+    case e =>
+      log.error(e, "Attributes computation for file '{}' failed", filePath)
+      None
+  }
+
+  override def receive: Receive = {
+    case Get(filePath)               =>
+      map.get(filePath.toString) match {
+        case Some(Right(attributes))                   =>
+          log.debug("Attributes for file '{}' fetched from the cache.", filePath)
+          sender() ! attributes
+
+        case Some(Left(time)) if !needsReTrigger(time) =>
+          log.debug(
+            "Attributes for file '{}' is being computed. Computation started {} ms ago.",
+            filePath,
+            now() - time
+          )
+          sender() ! emptyAttributes(filePath)
+
+        case Some(Left(_))                             =>
+          log.warning(
+            "Attributes for file '{}' is being computed but the elapsed time of '{}' expired.",
+            filePath,
+            config.retriggerAfter
+          )
+          sender() ! emptyAttributes(filePath)
+          self ! Compute(filePath)
+
+        case _                                         =>
+          log.debug("Attributes for file '{}' not found in the cache.", filePath)
+          sender() ! emptyAttributes(filePath)
+          self ! Compute(filePath)
+      }
+
+    case Put(filePath, attributes)   =>
+      map += filePath.toString -> Right(attributes)
+
+      val diff = Math.max((map.size - config.maxInMemory).toInt, 0)
+      removeOldest(diff)
+      log.debug("Add computed attributes '{}' for file '{}' to the cache.", attributes, filePath)
+
+    case compute @ Compute(filePath) =>
+      if (map.contains(filePath.toString))
+        log.debug("Attributes for file '{}' already computed. Do nothing.", filePath)
+      else {
+        map += filePath.toString -> Left(now())
+        val _ = queue.offer(compute).map(logQueue(compute, _))
+      }
+
+    case msg                         =>
+      log.error("Received a message '{}' incompatible with the expected", msg)
+
+  }
+
+  private def emptyAttributes(path: Path) =
+    FileAttributes(path.toAkkaUri, 0L, Digest.empty, `application/octet-stream`)
+
+  private def removeOldest(n: Int) =
+    map --= map.take(n).keySet
+
+  private def now(): Long = clock.instant().toEpochMilli
+
+  private def needsReTrigger(time: Long): Boolean = {
+    val elapsed: FiniteDuration = (now() - time).millis
+
+    elapsed > config.retriggerAfter
+  }
+
+  private def logQueue(compute: Compute, result: QueueOfferResult): Unit =
+    result match {
+      case QueueOfferResult.Dropped     =>
+        log.error("The computation for the file '{}' was dropped from the queue.", compute.filePath)
+      case QueueOfferResult.Failure(ex) =>
+        log.error(ex, "The computation for the file '{}' failed to be enqueued.", compute.filePath)
+      case _                            => ()
+    }
+
+}
+
+object AttributesCacheActor {
+
+  def props[F[_]: Effect, S](
+      computation: AttributesComputation[F, S]
+  )(implicit config: DigestConfig, clock: Clock): Props =
+    Props(new AttributesCacheActor(computation))
+
+  sealed private[attributes] trait Protocol extends Product with Serializable
+  private[attributes] object Protocol {
+    final case class Get(filePath: Path)                             extends Protocol
+    final case class Put(filePath: Path, attributes: FileAttributes) extends Protocol
+    final case class Compute(filePath: Path)                         extends Protocol
+  }
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesComputation.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesComputation.scala
@@ -1,0 +1,96 @@
+package ch.epfl.bluebrain.nexus.storage.attributes
+
+import java.nio.file.{Files, Path}
+import java.security.MessageDigest
+
+import akka.http.scaladsl.model.HttpCharsets.`UTF-8`
+import akka.http.scaladsl.model.MediaTypes.{`application/octet-stream`, `application/x-tar`}
+import akka.http.scaladsl.model.{ContentType, MediaType, MediaTypes}
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Keep, Sink}
+import akka.util.ByteString
+import cats.effect.Effect
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage.StorageError.InternalError
+import ch.epfl.bluebrain.nexus.storage._
+import org.apache.commons.io.FilenameUtils
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+trait AttributesComputation[F[_], Source] {
+
+  /**
+    * Given a path and an algorithm, generates its FileAttributes
+    *
+    * @param path      the path to the file
+    * @param algorithm the digest algorithm
+    * @return a computed file attributes, wrapped on the effect type F
+    */
+  def apply(path: Path, algorithm: String): F[FileAttributes]
+}
+
+object AttributesComputation {
+
+  /**
+    * Detects the media type of the provided path, based on the file system detector available for a certain path or on the path extension.
+    * If the path is a directory, a application/x-tar content-type is returned
+    *
+    * @param path  the path
+    * @param isDir flag to decide whether or not the path is a directory
+    */
+  def detectMediaType(path: Path, isDir: Boolean = false): ContentType =
+    if (isDir) {
+      `application/x-tar`
+    } else {
+      lazy val fromExtension   = Try(MediaTypes.forExtension(FilenameUtils.getExtension(path.toFile.getName)))
+        .getOrElse(`application/octet-stream`)
+      val mediaType: MediaType = Try(Files.probeContentType(path)) match {
+        case Success(value) if value != null && value.nonEmpty => MediaType.parse(value).getOrElse(fromExtension)
+        case _                                                 => fromExtension
+      }
+      ContentType(mediaType, () => `UTF-8`)
+    }
+  private def sinkSize: Sink[ByteString, Future[Long]]                 = Sink.fold(0L)(_ + _.size)
+
+  def sinkDigest(msgDigest: MessageDigest)(implicit ec: ExecutionContext): Sink[ByteString, Future[Digest]] =
+    Sink
+      .fold(msgDigest) { (digest, currentBytes: ByteString) =>
+        digest.update(currentBytes.asByteBuffer)
+        digest
+      }
+      .mapMaterializedValue(_.map(dig => Digest(dig.getAlgorithm, dig.digest().map("%02x".format(_)).mkString)))
+
+  /**
+    * A computation of attributes for a source of type AkkaSource
+    *
+    * @tparam F the effect type
+    * @return a AttributesComputation implemented for a source of type AkkaSource
+    */
+  implicit def akkaAttributes[F[_]](implicit
+      ec: ExecutionContext,
+      mt: Materializer,
+      F: Effect[F]
+  ): AttributesComputation[F, AkkaSource] =
+    (path: Path, algorithm: String) => {
+      if (!Files.exists(path)) F.raiseError(InternalError(s"Path not found '$path'"))
+      else
+        Try(MessageDigest.getInstance(algorithm)) match {
+          case Success(msgDigest) =>
+            val isDir  = Files.isDirectory(path)
+            val source = if (isDir) folderSource(path) else fileSource(path)
+            source
+              .alsoToMat(sinkSize)(Keep.right)
+              .toMat(sinkDigest(msgDigest)) { (bytesF, digestF) =>
+                (bytesF, digestF).mapN {
+                  case (bytes, digest) => FileAttributes(path.toAkkaUri, bytes, digest, detectMediaType(path, isDir))
+                }
+              }
+              .run()
+              .to[F]
+          case Failure(_)         => F.raiseError(InternalError(s"Invalid algorithm '$algorithm'."))
+        }
+
+    }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/AppConfig.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/AppConfig.scala
@@ -1,0 +1,138 @@
+package ch.epfl.bluebrain.nexus.storage.config
+
+import java.nio.file.Path
+
+import akka.http.scaladsl.model.Uri
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.Identity.{Anonymous, Subject, User}
+import ch.epfl.bluebrain.nexus.storage.JsonLdCirceSupport.OrderedKeys
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig._
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Application configuration
+  *
+  * @param description service description
+  * @param http        http interface configuration
+  * @param storage     storages configuration
+  * @param subject     allowed subject to perform calls to this service
+  * @param iam         iam client configuration
+  * @param digest      the digest configuration
+  */
+final case class AppConfig(
+    description: Description,
+    http: HttpConfig,
+    storage: StorageConfig,
+    subject: SubjectConfig,
+    iam: IamClientConfig,
+    digest: DigestConfig
+)
+
+object AppConfig {
+
+  /**
+    * Service description
+    *
+    * @param name service name
+    */
+  final case class Description(name: String) {
+
+    /**
+      * @return the version of the service
+      */
+//    val version: String = BuildInfo.version
+    val version: String = "1.0.0-SNAPSHOT"
+
+    /**
+      * @return the full name of the service (name + version)
+      */
+    val fullName: String = s"$name-${version.replaceAll("\\W", "-")}"
+
+  }
+
+  /**
+    * HTTP configuration
+    *
+    * @param interface  interface to bind to
+    * @param port       port to bind to
+    * @param prefix     prefix to add to HTTP routes
+    * @param publicUri  public URI of the service
+    */
+  final case class HttpConfig(interface: String, port: Int, prefix: String, publicUri: Uri)
+
+  /**
+    * Storages configuration
+    *
+    * @param rootVolume         the base [[Path]] where the files are stored
+    * @param protectedDirectory the relative [[Path]] of the protected directory once the storage bucket is selected
+    * @param fixerEnabled       call the permissions fixer when linking files, before they are moved
+    * @param fixerCommand       the command and arguments to call the 'nexus-fixer' binary, e.g. List("sudo", "nexus-fixer")
+    */
+  final case class StorageConfig(
+      rootVolume: Path,
+      protectedDirectory: Path,
+      fixerEnabled: Boolean,
+      fixerCommand: Vector[String]
+  )
+
+  /**
+    * Allowed subject to perform calls to this service
+    *
+    * @param anonymous flag to decide whether or not the allowed subject is Anonymous or a User
+    * @param realm     the user realm. It must be present when anonymous = false and it must be removed when anonymous = true
+    * @param name      the user name. It must be present when anonymous = false and it must be removed when anonymous = true
+    */
+  final case class SubjectConfig(anonymous: Boolean, realm: Option[String], name: Option[String]) {
+    // $COVERAGE-OFF$
+    val subjectValue: Subject = (anonymous, realm, name) match {
+      case (false, Some(r), Some(s)) => User(s, r)
+      case (false, _, _)             =>
+        throw new IllegalArgumentException(
+          "subject configuration is wrong. When anonymous is set to false, a realm and a subject must be provided"
+        )
+      case (true, None, None)        => Anonymous
+      case _                         =>
+        throw new IllegalArgumentException(
+          "subject configuration is wrong. When anonymous is set to true, a realm and a subject should not be present"
+        )
+    }
+    // $COVERAGE-ON$
+  }
+
+  /**
+    * The digest configuration.
+    *
+    * @param algorithm              the digest algorithm
+    * @param maxInMemory            the maximum number of algorithms stored in memory
+    * @param concurrentComputations the maximum number of concurrent computations of digest
+    * @param maxInQueue             the maximum number of computations in queue to be computed
+    * @param retriggerAfter         the amout of time after a digest which is still in the queue to be computed can be retrigger
+    */
+  final case class DigestConfig(
+      algorithm: String,
+      maxInMemory: Long,
+      concurrentComputations: Int,
+      maxInQueue: Int,
+      retriggerAfter: FiniteDuration
+  )
+
+  implicit def toStorage(implicit config: AppConfig): StorageConfig = config.storage
+  implicit def toHttp(implicit config: AppConfig): HttpConfig       = config.http
+  implicit def toIam(implicit config: AppConfig): IamClientConfig   = config.iam
+  implicit def toDigest(implicit config: AppConfig): DigestConfig   = config.digest
+
+  val orderedKeys: OrderedKeys = OrderedKeys(
+    List(
+      "@context",
+      "@id",
+      "@type",
+      "reason",
+      "message",
+      "details",
+      "filename",
+      "location",
+      "bytes",
+      ""
+    )
+  )
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/Contexts.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/Contexts.scala
@@ -1,0 +1,13 @@
+package ch.epfl.bluebrain.nexus.storage.config
+
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import ch.epfl.bluebrain.nexus.rdf.implicits._
+
+object Contexts {
+
+  val base = url"https://bluebrain.github.io/nexus/contexts/"
+
+  val errorCtxUri: AbsoluteIri    = base + "error.json"
+  val resourceCtxUri: AbsoluteIri = base + "resource.json"
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/IamClientConfig.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/IamClientConfig.scala
@@ -1,0 +1,20 @@
+package ch.epfl.bluebrain.nexus.storage.config
+
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+
+/**
+  * Configuration for IamClient identities endpoint.
+  *
+ * @param publicIri     base URL for all the identity IDs, excluding prefix.
+  * @param internalIri   base URL for all the HTTP calls, excluding prefix.
+  * @param prefix        the prefix
+  */
+final case class IamClientConfig(
+    publicIri: AbsoluteIri,
+    internalIri: AbsoluteIri,
+    prefix: String
+) {
+  lazy val baseInternalIri            = internalIri + prefix
+  lazy val basePublicIri              = publicIri + prefix
+  lazy val identitiesIri: AbsoluteIri = baseInternalIri + "identities"
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/Settings.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/Settings.scala
@@ -1,0 +1,44 @@
+package ch.epfl.bluebrain.nexus.storage.config
+
+import java.nio.file.{Path, Paths}
+
+import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import akka.http.scaladsl.model.Uri
+import ch.epfl.bluebrain.nexus.rdf.implicits._
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import scala.annotation.nowarn
+import com.typesafe.config.Config
+import pureconfig.generic.auto._
+import pureconfig.ConvertHelpers._
+import pureconfig._
+
+/**
+  * Akka settings extension to expose application configuration.  It typically uses the configuration instance of the
+  * actor system as the configuration root.
+  *
+  * @param config the configuration instance to read
+  */
+@SuppressWarnings(Array("LooksLikeInterpolatedString", "OptionGet"))
+class Settings(config: Config) extends Extension {
+
+  @nowarn("cat=unused")
+  val appConfig: AppConfig = {
+    implicit val uriConverter: ConfigConvert[Uri]                 =
+      ConfigConvert.viaString[Uri](catchReadError(s => Uri(s)), _.toString)
+    implicit val pathConverter: ConfigConvert[Path]               =
+      ConfigConvert.viaString[Path](catchReadError(s => Paths.get(s)), _.toString)
+    implicit val absoluteIriConverter: ConfigConvert[AbsoluteIri] =
+      ConfigConvert.viaString[AbsoluteIri](catchReadError(s => url"$s"), _.toString)
+    ConfigSource.fromConfig(config).at("app").loadOrThrow[AppConfig]
+  }
+
+}
+
+object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
+
+  override def lookup(): ExtensionId[_ <: Extension] = Settings
+
+  override def createExtension(system: ExtendedActorSystem): Settings = apply(system.settings.config)
+
+  def apply(config: Config): Settings = new Settings(config)
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/package.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/package.scala
@@ -1,0 +1,94 @@
+package ch.epfl.bluebrain.nexus
+
+import java.nio.file.{Path => JavaPath}
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path
+import akka.stream.alpakka.file.scaladsl.Directory
+import akka.stream.scaladsl.{FileIO, Source}
+import akka.util.ByteString
+import cats.effect.{IO, LiftIO}
+import ch.epfl.bluebrain.nexus.storage.File.FileAttributes
+import ch.epfl.bluebrain.nexus.storage.config.Contexts.errorCtxUri
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json}
+
+import scala.annotation.tailrec
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+package object storage {
+
+  /**
+    * Source where the Output is ByteString and the Materialization is Any
+    */
+  type AkkaSource = Source[ByteString, Any]
+
+  /**
+    * Rejection or file attributes
+    */
+  type RejOrAttributes = Either[Rejection, FileAttributes]
+
+  /**
+    * Rejection or Path wrapped
+    */
+  type RejOrPath = Either[Rejection, JavaPath]
+
+  /**
+    * Rejection or Out attributes
+    */
+  type RejOr[Out] = Either[Rejection, Out]
+
+  implicit val encUriPath: Encoder[Path] = Encoder.encodeString.contramap(_.toString())
+  implicit val decUriPath: Decoder[Path] = Decoder.decodeString.emapTry(s => Try(Path(s)))
+  implicit val encUri: Encoder[Uri]      = Encoder.encodeString.contramap(_.toString)
+  implicit val decUri: Decoder[Uri]      = Decoder.decodeString.emapTry(s => Try(Uri(s)))
+
+  implicit class FutureSyntax[A](private val future: Future[A]) extends AnyVal {
+    def to[F[_]](implicit F: LiftIO[F], ec: ExecutionContext): F[A] = {
+      implicit val contextShift = IO.contextShift(ec)
+      F.liftIO(IO.fromFuture(IO(future)))
+    }
+  }
+
+  implicit class PathSyntax(private val path: JavaPath) extends AnyVal {
+    @tailrec
+    @SuppressWarnings(Array("NullParameter"))
+    private def inner(parent: JavaPath, child: JavaPath): Boolean = {
+      if (child == null) false
+      else if (parent == child) true
+      else inner(parent, child.getParent)
+    }
+
+    /**
+      * Returns true when the current path is a descendant of the provided parent.
+      * E.g.: path = /some/my/path ; parent = /some will return true
+      * E.g.: path = /some/my/path ; parent = /other will return false
+      *
+      * @param parent the ancestor path
+      */
+    def descendantOf(parent: JavaPath): Boolean =
+      inner(parent, path.getParent)
+
+    /**
+      * Converts a Java Path to an Akka [[Uri]]
+      */
+    def toAkkaUri: Uri = {
+      val pathString = path.toUri.toString
+      if (pathString.endsWith("/")) Uri(pathString.dropRight(1)) else Uri(pathString)
+    }
+  }
+
+  /**
+    * Build a Json error message that contains the keys @context and @type
+    */
+  def jsonError(json: Json): Json = {
+    val typed = json.hcursor.get[String]("@type").map(v => Json.obj("@type" -> v.asJson)).getOrElse(Json.obj())
+    typed deepMerge Json.obj("@context" -> Json.fromString(errorCtxUri.toString()))
+  }
+
+  def folderSource(path: JavaPath): AkkaSource = Directory.walk(path).via(TarFlow.writer(path))
+
+  def fileSource(path: JavaPath): AkkaSource = FileIO.fromPath(path)
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/AppInfoRoutes.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/AppInfoRoutes.scala
@@ -1,0 +1,46 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.Description
+import ch.epfl.bluebrain.nexus.storage.routes.AppInfoRoutes.ServiceDescription
+import ch.epfl.bluebrain.nexus.storage.routes.instances._
+import io.circe.generic.auto._
+import kamon.instrumentation.akka.http.TracingDirectives.operationName
+
+/**
+  * Akka HTTP route definition for service description
+  */
+class AppInfoRoutes(serviceDescription: ServiceDescription) {
+
+  def routes: Route =
+    concat(
+      (get & pathEndOrSingleSlash) {
+        operationName("/") {
+          complete(OK -> serviceDescription)
+        }
+      }
+    )
+}
+
+object AppInfoRoutes {
+
+  /**
+    * A service description.
+    *
+    * @param name    the name of the service
+    * @param version the current version of the service
+    */
+  final case class ServiceDescription(name: String, version: String)
+
+  /**
+    * Default factory method for building [[AppInfoRoutes]] instances.
+    *
+    * @param config the description service configuration
+    * @return a new [[AppInfoRoutes]] instance
+    */
+  def apply(config: Description): AppInfoRoutes =
+    new AppInfoRoutes(ServiceDescription(config.name, config.version))
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/AuthDirectives.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/AuthDirectives.scala
@@ -1,0 +1,45 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.FutureDirectives.onComplete
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.{AccessToken, Caller}
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClientError.IdentitiesClientStatusError
+import ch.epfl.bluebrain.nexus.storage.StorageError._
+import com.typesafe.scalalogging.Logger
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+
+import scala.util.{Failure, Success}
+
+object AuthDirectives {
+
+  private val logger = Logger[this.type]
+
+  /**
+    * Extracts the credentials from the HTTP Authorization Header and builds the [[AccessToken]]
+    */
+  def extractToken: Directive1[Option[AccessToken]] =
+    extractCredentials.flatMap {
+      case Some(OAuth2BearerToken(value)) => provide(Some(AccessToken(value)))
+      case Some(_)                        => failWith(AuthenticationFailed)
+      case _                              => provide(None)
+    }
+
+  /**
+    * Authenticates the requested with the provided ''token'' and returns the ''caller''
+    */
+  def extractCaller(implicit identities: IamIdentitiesClient[Task], token: Option[AccessToken]): Directive1[Caller] =
+    onComplete(identities().runToFuture).flatMap {
+      case Success(caller)                                                   => provide(caller)
+      case Failure(IdentitiesClientStatusError(StatusCodes.Unauthorized, _)) => failWith(AuthenticationFailed)
+      case Failure(IdentitiesClientStatusError(StatusCodes.Forbidden, _))    => failWith(AuthorizationFailed)
+      case Failure(err)                                                      =>
+        val message = "Error when trying to extract the subject"
+        logger.error(message, err)
+        failWith(InternalError(message))
+    }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/PrefixDirectives.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/PrefixDirectives.scala
@@ -1,0 +1,39 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.server.Directives.rawPathPrefix
+import akka.http.scaladsl.server.{Directive0, PathMatcher}
+
+import scala.annotation.tailrec
+
+/**
+  * Collection of custom directives for matching against prefix paths.
+  */
+trait PrefixDirectives {
+
+  final def stripTrailingSlashes(path: Path): Path = {
+    @tailrec
+    def strip(p: Path): Path =
+      p match {
+        case Path.Empty       => Path.Empty
+        case Path.Slash(rest) => strip(rest)
+        case other            => other
+      }
+    strip(path.reverse).reverse
+  }
+
+  /**
+    * Creates a path matcher from the argument ''uri'' by stripping the slashes at the end of its path.  The matcher
+    * is applied directly to the prefix of the unmatched path.
+    *
+   * @param uri the uri to use as a prefix
+    */
+  final def uriPrefix(uri: Uri): Directive0 =
+    rawPathPrefix(PathMatcher(stripTrailingSlashes(uri.path), ()))
+}
+
+/**
+  * Collection of custom directives for matching against prefix paths.
+  */
+object PrefixDirectives extends PrefixDirectives

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/RejectionHandling.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/RejectionHandling.scala
@@ -1,0 +1,241 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshallable}
+import akka.http.scaladsl.model.EntityStreamSizeException
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.server.AuthenticationFailedRejection.CredentialsMissing
+import akka.http.scaladsl.server.Directives.{complete, extractMaterializer, extractRequest}
+import akka.http.scaladsl.server._
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+import scala.reflect.ClassTag
+
+/**
+  * A generic rejection handling that generates json responses and consumes the request.
+  */
+object RejectionHandling {
+  // $COVERAGE-OFF$
+
+  final val errorContextIri = "https://bluebrain.github.io/nexus/contexts/error.json"
+
+  final private case class Error(`@type`: String, reason: String)
+  private object Error {
+    implicit final val genericEncoder: Encoder[Error] =
+      deriveEncoder[Error].mapJson { json =>
+        val context = Json.obj("@context" -> Json.fromString(errorContextIri))
+        json deepMerge context
+      }
+  }
+
+  /**
+    * Discards the request entity bytes and completes the request with the argument.
+    *
+   * @param m a value to be marshalled into an HttpResponse
+    */
+  final def rejectRequestEntityAndComplete(m: => ToResponseMarshallable): Route = {
+    extractRequest { request =>
+      extractMaterializer { implicit mat =>
+        request.discardEntityBytes()
+        complete(m)
+      }
+    }
+  }
+
+  /**
+    * @return a rejection handler for the NotFound rejection.
+    */
+  def notFound(implicit J: ToEntityMarshaller[Json]): RejectionHandler = {
+    implicit val errorMarshaller: ToEntityMarshaller[Error] = J.compose(_.asJson)
+    RejectionHandler
+      .newBuilder()
+      .handleNotFound {
+        rejectRequestEntityAndComplete(NotFound -> Error("NotFound", "The requested resource could not be found."))
+      }
+      .result()
+  }
+
+  /**
+    * A rejection handler for rejections of type ''A'' that uses the provided function  ''f'' to complete the request.
+    * __Note__: the request entity bytes are automatically discarded.
+    *
+   * @see [[RejectionHandling.rejectRequestEntityAndComplete()]]
+    * @param f the function to use for handling rejections of type A
+    */
+  def handle[A <: Rejection](f: A => ToResponseMarshallable)(implicit A: ClassTag[A]): RejectionHandler =
+    RejectionHandler
+      .newBuilder()
+      .handle {
+        case A(a) => rejectRequestEntityAndComplete(f(a))
+      }
+      .result()
+
+  /**
+    * A rejection handler for all the defined Akka rejections.
+    * __Note__: the request entity bytes are automatically discarded.
+    *
+   * @see [[RejectionHandling.rejectRequestEntityAndComplete()]]
+    */
+  def apply(implicit J: ToEntityMarshaller[Json]): RejectionHandler = {
+    implicit val errorMarshaller: ToEntityMarshaller[Error] = J.compose(_.asJson)
+    RejectionHandler
+      .newBuilder()
+      .handleAll[SchemeRejection] { rejections =>
+        val schemes = rejections.map(_.supported).mkString("'", "', '", "'")
+        val e       = Error("UriSchemeNotAllowed", s"Uri scheme not allowed, supported schemes: $schemes.")
+        rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handleAll[MethodRejection] { rejections =>
+        val (methods, names) = rejections.map(r => r.supported -> r.supported.name).unzip
+        val namesString      = names.mkString("'", "', '", "'")
+        val e                = Error("HttpMethodNotAllowed", s"HTTP method not allowed, supported methods: $namesString.")
+        rejectRequestEntityAndComplete((MethodNotAllowed, List(Allow(methods)), e))
+      }
+      .handle {
+        case AuthorizationFailedRejection =>
+          val e = Error("AuthorizationFailed", "The supplied authentication is not authorized to access this resource.")
+          rejectRequestEntityAndComplete(Forbidden -> e)
+      }
+      .handle {
+        case MalformedFormFieldRejection(name, msg, _) =>
+          val e = Error("MalformedFormField", s"The form field '$name' was malformed: '$msg'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case MalformedHeaderRejection(name, msg, _) =>
+          val e = Error("MalformedHeader", s"The value of HTTP header '$name' was malformed: '$msg'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case MalformedQueryParamRejection(name, msg, _) =>
+          val e = Error("MalformedQueryParam", s"The query parameter '$name' was malformed: '$msg'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case MalformedRequestContentRejection(msg, throwable) =>
+          val e      = Error("MalformedRequestContent", s"The request content was malformed: '$msg'.")
+          val status = throwable match {
+            case _: EntityStreamSizeException => PayloadTooLarge
+            case _                            => BadRequest
+          }
+          rejectRequestEntityAndComplete(status -> e)
+      }
+      .handle {
+        case MissingCookieRejection(cookieName) =>
+          val e = Error("MissingCookie", s"Request is missing required cookie '$cookieName'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case MissingFormFieldRejection(fieldName) =>
+          val e = Error("MissingFormField", s"Request is missing required form field '$fieldName'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case MissingHeaderRejection(headerName) =>
+          val e = Error("MissingHeader", s"Request is missing required HTTP header '$headerName'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case InvalidOriginRejection(allowedOrigins) =>
+          val e =
+            Error("InvalidOrigin", s"Allowed `Origin` header values: ${allowedOrigins.mkString("'", "', '", "'")}")
+          rejectRequestEntityAndComplete(Forbidden -> e)
+      }
+      .handle {
+        case MissingQueryParamRejection(paramName) =>
+          val e = Error("MissingQueryParam", s"Request is missing required query parameter '$paramName'.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case InvalidRequiredValueForQueryParamRejection(paramName, requiredValue, _) =>
+          val reason = s"Request is missing required value '$requiredValue' for query parameter '$paramName'."
+          val e      = Error("InvalidRequiredValueForQueryParam", reason)
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case RequestEntityExpectedRejection =>
+          val e = Error("RequestEntityExpected", "Request entity expected but not supplied.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case TooManyRangesRejection(_) =>
+          val e = Error("TooManyRanges", "Request contains too many ranges.")
+          rejectRequestEntityAndComplete(RangeNotSatisfiable -> e)
+      }
+      .handle {
+        case CircuitBreakerOpenRejection(_) =>
+          val e = Error("ServiceUnavailable", "The service is unavailable at this time.")
+          rejectRequestEntityAndComplete(ServiceUnavailable -> e)
+      }
+      .handle {
+        case UnsatisfiableRangeRejection(unsatisfiableRanges, actualEntityLength) =>
+          val ranges = unsatisfiableRanges.mkString("'", "', '", "'")
+          val reason =
+            s"None of the following requested Ranges were satisfiable for actual entity length '$actualEntityLength': $ranges"
+          val e      = Error("UnsatisfiableRange", reason)
+          rejectRequestEntityAndComplete(RangeNotSatisfiable -> e)
+      }
+      .handleAll[AuthenticationFailedRejection] { rejections =>
+        val reason = rejections.headOption.map(_.cause) match {
+          case Some(CredentialsMissing) =>
+            "The resource requires authentication, which was not supplied with the request."
+          case _                        => "The supplied authentication is invalid."
+        }
+        val e      = Error("AuthenticationFailed", reason)
+        val header = `WWW-Authenticate`(HttpChallenges.oAuth2("*"))
+        rejectRequestEntityAndComplete((Unauthorized, List(header), e))
+      }
+      .handleAll[UnacceptedResponseContentTypeRejection] { rejections =>
+        val supported = rejections.flatMap(_.supported).map(_.format).mkString("'", "', '", "'")
+        val reason    = s"Resource representation is only available with these types: $supported."
+        val e         = Error("UnacceptedResponseContentType", reason)
+        rejectRequestEntityAndComplete(NotAcceptable -> e)
+      }
+      .handleAll[UnacceptedResponseEncodingRejection] { rejections =>
+        val supported = rejections.flatMap(_.supported).map(_.value).mkString("'", "', '", "'")
+        val reason    = s"Resource representation is only available with these Content-Encodings: $supported."
+        val e         = Error("UnacceptedResponseEncoding", reason)
+        rejectRequestEntityAndComplete(NotAcceptable -> e)
+      }
+      .handleAll[UnsupportedRequestContentTypeRejection] { rejections =>
+        val supported = rejections.flatMap(_.supported).mkString("'", "' or '", "'")
+        val reason    = s"The request's Content-Type is not supported. Expected: $supported."
+        val e         = Error("UnsupportedRequestContentType", reason)
+        rejectRequestEntityAndComplete(UnsupportedMediaType -> e)
+      }
+      .handleAll[UnsupportedRequestEncodingRejection] { rejections =>
+        val supported = rejections.map(_.supported.value).mkString("'", "' or '", "'")
+        val reason    = s"The request's Content-Encoding is not supported. Expected: $supported."
+        val e         = Error("UnsupportedRequestEncoding", reason)
+        rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case ExpectedWebSocketRequestRejection =>
+          val e = Error("ExpectedWebSocketRequest", "Expected WebSocket Upgrade request.")
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .handle {
+        case ValidationRejection(msg, _) =>
+          val e = Error("ValidationRejection", msg)
+          rejectRequestEntityAndComplete(BadRequest -> e)
+      }
+      .result()
+  }
+
+  /**
+    * A rejection handler for all predefined akka rejections and additionally for rejections of type ''A'' (using
+    * the provided function  ''f'' to complete the request).
+    * __Note__: the request entity bytes are automatically discarded.
+    *
+   * @see [[RejectionHandling.rejectRequestEntityAndComplete()]]
+    * @param f the function to use for handling rejections of type A
+    */
+  def apply[A <: Rejection: ClassTag](
+      f: A => ToResponseMarshallable
+  )(implicit J: ToEntityMarshaller[Json]): RejectionHandler =
+    handle(f) withFallback apply
+
+  // $COVERAGE-ON$
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/Routes.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/Routes.scala
@@ -1,0 +1,98 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.headers.{`WWW-Authenticate`, HttpChallenges}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.Caller
+import ch.epfl.bluebrain.nexus.storage.StorageError._
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig._
+import ch.epfl.bluebrain.nexus.storage.routes.AuthDirectives._
+import ch.epfl.bluebrain.nexus.storage.routes.PrefixDirectives._
+import ch.epfl.bluebrain.nexus.storage.routes.instances._
+import ch.epfl.bluebrain.nexus.storage.{AkkaSource, IamIdentitiesClient, Rejection, StorageError, Storages}
+import com.typesafe.scalalogging.Logger
+import monix.eval.Task
+
+import scala.util.control.NonFatal
+
+object Routes {
+
+  private[this] val logger = Logger[this.type]
+
+  /**
+    * @return an ExceptionHandler that ensures a descriptive message is returned to the caller
+    */
+  final val exceptionHandler: ExceptionHandler = {
+    def completeGeneric(): Route =
+      complete(InternalError("The system experienced an unexpected error, please try again later."): StorageError)
+
+    ExceptionHandler {
+      case AuthenticationFailed =>
+        // suppress errors for authentication failures
+        val status = StorageError.storageErrorStatusFrom(AuthenticationFailed)
+        val header = `WWW-Authenticate`(HttpChallenges.oAuth2("*"))
+        complete((status, List(header), AuthenticationFailed: StorageError))
+      case AuthorizationFailed  =>
+        // suppress errors for authorization failures
+        complete(AuthorizationFailed: StorageError)
+      case err: PathNotFound    =>
+        complete(err: StorageError)
+      case err: PathInvalid     =>
+        complete(err: StorageError)
+      case err: StorageError    =>
+        logger.error("Exception caught during routes processing", err)
+        completeGeneric()
+      case NonFatal(err)        =>
+        logger.error("Exception caught during routes processing", err)
+        completeGeneric()
+    }
+  }
+
+  /**
+    * @return a complete RejectionHandler for all library and code rejections
+    */
+  final val rejectionHandler: RejectionHandler = {
+    val custom = RejectionHandling.apply { r: Rejection =>
+      logger.debug(s"Handling rejection '$r'")
+      r
+    }
+    custom withFallback RejectionHandling.notFound withFallback RejectionHandler.default
+  }
+
+  /**
+    * Wraps the provided route with rejection and exception handling.
+    *
+    * @param route the route to wrap
+    */
+  final def wrap(route: Route)(implicit hc: HttpConfig): Route =
+    handleExceptions(exceptionHandler) {
+      handleRejections(rejectionHandler) {
+        uriPrefix(hc.publicUri) {
+          route
+        }
+      }
+    }
+
+  /**
+    * Generates the routes for all the platform resources
+    *
+    * @param storages the storages operations
+    */
+  def apply(
+      storages: Storages[Task, AkkaSource]
+  )(implicit config: AppConfig, identities: IamIdentitiesClient[Task]): Route =
+    //TODO: Fetch Bearer token and verify identity
+    wrap {
+      concat(
+        AppInfoRoutes(config.description).routes,
+        (pathPrefix(config.http.prefix) & extractToken) { implicit token =>
+          extractCaller.apply {
+            case Caller(config.subject.subjectValue, _) => StorageRoutes(storages).routes
+            case _                                      => failWith(AuthenticationFailed)
+          }
+        }
+      )
+    }
+
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StatusFrom.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StatusFrom.scala
@@ -1,0 +1,31 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.StatusCode
+
+/**
+  * Typeclass definition for ''A''s that can be mapped into a StatusCode.
+  *
+ * @tparam A generic type parameter
+  */
+trait StatusFrom[A] {
+
+  /**
+    * Computes a [[akka.http.scaladsl.model.StatusCode]] instance from the argument value.
+    *
+   * @param value the input value
+    * @return the status code corresponding to the value
+    */
+  def apply(value: A): StatusCode
+}
+
+object StatusFrom {
+
+  /**
+    * Lifts a function ''A => StatusCode'' into a ''StatusFrom[A]'' instance.
+    *
+   * @param f function from A to StatusCode
+    * @tparam A type parameter to map to StatusCode
+    * @return a ''StatusFrom'' instance from the argument function
+    */
+  def apply[A](f: A => StatusCode): StatusFrom[A] = (value: A) => f(value)
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectives.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectives.scala
@@ -1,0 +1,106 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.Uri.Path._
+import akka.http.scaladsl.server.Directives.{extractUnmatchedPath, failWith, pass, provide, reject}
+import akka.http.scaladsl.server._
+import ch.epfl.bluebrain.nexus.storage.Rejection.{BucketNotFound, PathAlreadyExists, PathNotFound}
+import ch.epfl.bluebrain.nexus.storage.StorageError.PathInvalid
+import ch.epfl.bluebrain.nexus.storage.Storages
+import ch.epfl.bluebrain.nexus.storage.Storages.PathExistence.{PathDoesNotExist, PathExists}
+import ch.epfl.bluebrain.nexus.storage.Storages.BucketExistence.BucketExists
+
+import scala.annotation.tailrec
+
+object StorageDirectives {
+
+  /**
+    * Extracts the relative path from the unmatched segments
+    *
+    * @param name the storage bucket name
+    */
+  def extractRelativePath(name: String): Directive1[Path] =
+    extractUnmatchedPath.flatMap(p => validatePath(name, p).tmap(_ => relativize(p)))
+
+  /**
+    * Validates if the path is correct or malformed
+    *
+    * @param name the storage bucket name
+    * @param path the path to validate
+    */
+  def validatePath(name: String, path: Path): Directive0 =
+    if (path.toString.contains("//") || containsRelativeChar(path))
+      failWith(PathInvalid(name, path))
+    else
+      pass
+
+  @tailrec
+  private def containsRelativeChar(path: Path): Boolean =
+    path match {
+      case Path.Empty                                      => false
+      case Segment(head, _) if head == "." || head == ".." => true
+      case _                                               => containsRelativeChar(path.tail)
+    }
+
+  /**
+    * Returns the evidence that a storage bucket exists
+    *
+    * @param name     the storage bucket name
+    * @param storages the storages bundle api
+    * @return BucketExists when the storage bucket exists, rejection otherwise
+    */
+  def bucketExists[F[_]](name: String)(implicit storages: Storages[F, _]): Directive1[BucketExists] =
+    storages.exists(name) match {
+      case exists: BucketExists => provide(exists)
+      case _                    => reject(BucketNotFound(name))
+    }
+
+  /**
+    * Returns the evidence that a path exists
+    *
+    * @param name     the storage bucket name
+    * @param relativePath the relative path location
+    * @param storages the storages bundle api
+    * @return PathExists when the path exists inside the bucket, rejection otherwise
+    */
+  def pathExists[F[_]](name: String, relativePath: Uri.Path)(implicit
+      storages: Storages[F, _]
+  ): Directive1[PathExists] =
+    storages.pathExists(name, relativePath) match {
+      case exists: PathExists => provide(exists)
+      case _                  => reject(PathNotFound(name, relativePath))
+    }
+
+  /**
+    * Returns the evidence that a path does not exist
+    *
+    * @param name     the storage bucket name
+    * @param relativePath the relative path location
+    * @param storages the storages bundle api
+    * @return PathDoesNotExist when the path does not exist inside the bucket, rejection otherwise
+    */
+  def pathNotExists[F[_]](name: String, relativePath: Uri.Path)(implicit
+      storages: Storages[F, _]
+  ): Directive1[PathDoesNotExist] =
+    storages.pathExists(name, relativePath) match {
+      case notExists: PathDoesNotExist => provide(notExists)
+      case _                           => reject(PathAlreadyExists(name, relativePath))
+    }
+
+  /**
+    * Extracts the relative file path from the unmatched segments
+    */
+  def extractRelativeFilePath(name: String): Directive1[Path] =
+    extractRelativePath(name).flatMap {
+      case path if path.reverse.startsWithSegment => provide(path)
+      case path                                   => failWith(PathInvalid(name, path))
+    }
+
+  @tailrec
+  private def relativize(path: Path): Path =
+    path match {
+      case Slash(rest) => relativize(rest)
+      case rest        => rest
+    }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutes.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutes.scala
@@ -1,0 +1,114 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.MediaTypes._
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.{HttpEntity, StatusCode, Uri}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.HttpConfig
+import ch.epfl.bluebrain.nexus.storage.routes.StorageDirectives._
+import ch.epfl.bluebrain.nexus.storage.routes.StorageRoutes.LinkFile
+import ch.epfl.bluebrain.nexus.storage.routes.StorageRoutes.LinkFile._
+import ch.epfl.bluebrain.nexus.storage.routes.instances._
+import ch.epfl.bluebrain.nexus.storage.{AkkaSource, Storages}
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
+import kamon.instrumentation.akka.http.TracingDirectives.operationName
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+
+class StorageRoutes()(implicit storages: Storages[Task, AkkaSource], hc: HttpConfig) {
+
+  def routes: Route =
+    // Consume buckets/{name}/
+    pathPrefix("buckets" / Segment) { name =>
+      concat(
+        // Check bucket
+        (head & pathEndOrSingleSlash) {
+          operationName(s"/${hc.prefix}/buckets/{}") {
+            bucketExists(name).apply { _ =>
+              complete(OK)
+            }
+          }
+        },
+        // Consume files
+        (pathPrefix("files") & extractRelativePath(name)) { relativePath =>
+          operationName(s"/${hc.prefix}/buckets/{}/files/{}") {
+            bucketExists(name).apply {
+              implicit bucketExistsEvidence =>
+                concat(
+                  put {
+                    pathNotExists(name, relativePath).apply { implicit pathNotExistEvidence =>
+                      // Upload file
+                      fileUpload("file") {
+                        case (_, source) =>
+                          complete(Created -> storages.createFile(name, relativePath, source).runToFuture)
+                      }
+                    }
+                  },
+                  put {
+                    // Link file/dir
+                    entity(as[LinkFile]) {
+                      case LinkFile(source) =>
+                        validatePath(name, source) {
+                          complete(storages.moveFile(name, source, relativePath).runWithStatus(OK))
+                        }
+                    }
+                  },
+                  // Get file
+                  get {
+                    pathExists(name, relativePath).apply { implicit pathExistsEvidence =>
+                      storages.getFile(name, relativePath) match {
+                        case Right((source, Some(_))) => complete(HttpEntity(`application/octet-stream`, source))
+                        case Right((source, None))    => complete(HttpEntity(`application/x-tar`, source))
+                        case Left(err)                => complete(err)
+                      }
+                    }
+                  }
+                )
+            }
+          }
+        },
+        // Consume attributes
+        (pathPrefix("attributes") & extractRelativePath(name)) { relativePath =>
+          operationName(s"/${hc.prefix}/buckets/{}/attributes/{}") {
+            bucketExists(name).apply { implicit bucketExistsEvidence =>
+              // Get file attributes
+              get {
+                pathExists(name, relativePath).apply { implicit pathExistsEvidence =>
+                  val result = storages.getAttributes(name, relativePath).map[(StatusCode, FileAttributes)] {
+                    case attr @ FileAttributes(_, _, Digest.empty, _) => Accepted -> attr
+                    case attr                                         => OK       -> attr
+                  }
+                  complete(result.runToFuture)
+                }
+              }
+            }
+          }
+        }
+      )
+    }
+}
+
+object StorageRoutes {
+
+  /**
+    * Link file request.
+    *
+    * @param source    the relative location of the file/dir
+    */
+  final private[routes] case class LinkFile(source: Uri.Path)
+
+  private[routes] object LinkFile {
+    import ch.epfl.bluebrain.nexus.storage._
+    implicit val linkFileDec: Decoder[LinkFile] = deriveDecoder[LinkFile]
+    implicit val linkFileEnc: Encoder[LinkFile] = deriveEncoder[LinkFile]
+  }
+
+  final def apply(storages: Storages[Task, AkkaSource])(implicit cfg: AppConfig): StorageRoutes = {
+    implicit val s = storages
+    new StorageRoutes()
+  }
+}

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/instances.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/instances.scala
@@ -1,0 +1,122 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.marshalling.GenericMarshallers.eitherMarshaller
+import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.model.MediaTypes._
+import akka.http.scaladsl.model._
+import ch.epfl.bluebrain.nexus.commons.http.RdfMediaTypes._
+import ch.epfl.bluebrain.nexus.storage.JsonLdCirceSupport.sortKeys
+import ch.epfl.bluebrain.nexus.storage.JsonLdCirceSupport.OrderedKeys
+import ch.epfl.bluebrain.nexus.storage.Rejection
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig._
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe._
+import io.circe.syntax._
+import monix.eval.Task
+import monix.execution.Scheduler
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+
+object instances extends LowPriority {
+
+  /**
+    * `Either[Rejection,(StatusCode, A)]` => HTTP entity
+    *
+    * @tparam A type to encode
+    * @return marshaller for any `A` value
+    */
+  implicit final def eitherValueMarshaller[A: Encoder](implicit
+      printer: Printer = defaultPrinter
+  ): ToResponseMarshaller[Either[Rejection, (StatusCode, A)]] =
+    eitherMarshaller(valueWithStatusCodeFromMarshaller[Rejection], valueWithStatusCodeMarshaller[A])
+
+  /**
+    * `A, StatusCodeFrom` => HTTP response
+    *
+    * @return marshaller for value
+    */
+  implicit final def valueWithStatusCodeFromMarshaller[A: Encoder](implicit
+      statusFrom: StatusFrom[A],
+      printer: Printer = defaultPrinter,
+      ordered: OrderedKeys = orderedKeys
+  ): ToResponseMarshaller[A] =
+    jsonLdWithStatusCodeMarshaller.compose { value =>
+      statusFrom(value) -> value.asJson
+    }
+
+  implicit final class EitherFSyntax[A](f: Task[Either[Rejection, A]])(implicit scheduler: Scheduler) {
+    def runWithStatus(code: StatusCode): Future[Either[Rejection, (StatusCode, A)]] =
+      f.map(_.map(code -> _)).runToFuture
+  }
+
+}
+
+trait LowPriority extends FailFastCirceSupport {
+
+  private[routes] val defaultPrinter = Printer.noSpaces.copy(dropNullValues = true)
+
+  override def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    List(`application/json`, `application/ld+json`)
+
+  /**
+    * `StatusCode, Json` => HTTP response
+    *
+    * @return marshaller for JSON-LD value
+    */
+  implicit final def jsonLdWithStatusCodeMarshaller(implicit
+      printer: Printer = defaultPrinter,
+      keys: OrderedKeys = orderedKeys
+  ): ToResponseMarshaller[(StatusCode, Json)] =
+    onOf(contentType =>
+      Marshaller.withFixedContentType[(StatusCode, Json), HttpResponse](contentType) {
+        case (status, json) =>
+          HttpResponse(status = status, entity = HttpEntity(`application/ld+json`, printer.print(sortKeys(json))))
+      }
+    )
+
+  /**
+    * `Json` => HTTP entity
+    *
+    * @return marshaller for JSON-LD value
+    */
+  implicit final def jsonLdEntityMarshaller(implicit
+      printer: Printer = defaultPrinter,
+      keys: OrderedKeys = orderedKeys
+  ): ToEntityMarshaller[Json] =
+    onOf(contentType =>
+      Marshaller.withFixedContentType[Json, MessageEntity](contentType) { json =>
+        HttpEntity(`application/ld+json`, printer.print(sortKeys(json)))
+      }
+    )
+
+  /**
+    * `A` => HTTP entity
+    *
+    * @return marshaller for JSON-LD value
+    */
+  implicit final def valueEntityMarshaller[A: Encoder](implicit
+      printer: Printer = defaultPrinter,
+      keys: OrderedKeys = orderedKeys
+  ): ToEntityMarshaller[A] =
+    jsonLdEntityMarshaller.compose(_.asJson)
+
+  /**
+    * `StatusCode, A` => HTTP response
+    *
+    * @tparam A type to encode
+    * @return marshaller for any `A` value
+    */
+  implicit final def valueWithStatusCodeMarshaller[A: Encoder](implicit
+      printer: Printer = defaultPrinter,
+      keys: OrderedKeys = orderedKeys
+  ): ToResponseMarshaller[(StatusCode, A)] =
+    jsonLdWithStatusCodeMarshaller.compose { case (status, value) => status -> value.asJson }
+
+  private[routes] def onOf[A, Response](
+      fMarshaller: MediaType.WithFixedCharset => Marshaller[A, Response]
+  ): Marshaller[A, Response] = {
+    val marshallers = Seq(`application/ld+json`, `application/json`).map(fMarshaller)
+    Marshaller.oneOf(marshallers: _*)
+  }
+}

--- a/storage/src/test/resources/app-info.json
+++ b/storage/src/test/resources/app-info.json
@@ -1,0 +1,4 @@
+{
+  "name" : "storage",
+  "version" : "{version}"
+}

--- a/storage/src/test/resources/app.conf
+++ b/storage/src/test/resources/app.conf
@@ -1,0 +1,8 @@
+# All application specific configuration should reside here
+app {
+  # Allowed subject to perform calls
+  subject {
+    # flag to decide whether or not the allowed subject is Anonymous or a User
+    anonymous = true
+  }
+}

--- a/storage/src/test/resources/error.json
+++ b/storage/src/test/resources/error.json
@@ -1,0 +1,5 @@
+{
+  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
+  "@type": "{type}",
+  "reason": "{reason}"
+}

--- a/storage/src/test/resources/file-created.json
+++ b/storage/src/test/resources/file-created.json
@@ -1,0 +1,10 @@
+{
+  "@context" : "https://bluebrain.github.io/nexus/contexts/resource.json",
+  "_location" : "{location}",
+  "_mediaType" : "{mediaType}",
+  "_bytes" : {bytes},
+  "_digest" : {
+    "_algorithm" : "{algorithm}",
+    "_value" : "{value}"
+  }
+}

--- a/storage/src/test/resources/file-link.json
+++ b/storage/src/test/resources/file-link.json
@@ -1,0 +1,3 @@
+{
+  "source": "{source}"
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/DiskStorageSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/DiskStorageSpec.scala
@@ -1,0 +1,292 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Paths}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.MediaTypes.`application/x-tar`
+import akka.http.scaladsl.model.Uri
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestKit
+import akka.util.ByteString
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage.Rejection.{PathAlreadyExists, PathNotFound}
+import ch.epfl.bluebrain.nexus.storage.StorageError.{PathInvalid, PermissionsFixingFailed}
+import ch.epfl.bluebrain.nexus.storage.Storages.BucketExistence.{BucketDoesNotExist, BucketExists}
+import ch.epfl.bluebrain.nexus.storage.Storages.DiskStorage
+import ch.epfl.bluebrain.nexus.storage.Storages.PathExistence.{PathDoesNotExist, PathExists}
+import ch.epfl.bluebrain.nexus.storage.attributes.AttributesCache
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.{DigestConfig, StorageConfig}
+import ch.epfl.bluebrain.nexus.storage.utils.{EitherValues, IOEitherValues, Randomness}
+import org.apache.commons.io.FileUtils
+import org.mockito.IdiomaticMockito
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterAll, Inspectors, OptionValues}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class DiskStorageSpec
+    extends TestKit(ActorSystem("DiskStorageSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with Randomness
+    with IOEitherValues
+    with BeforeAndAfterAll
+    with EitherValues
+    with OptionValues
+    with Inspectors
+    with IdiomaticMockito {
+
+  implicit override def patienceConfig: PatienceConfig = PatienceConfig(3.second, 15.milliseconds)
+
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  val rootPath = Files.createTempDirectory("storage-test")
+  val sConfig  = StorageConfig(rootPath, Paths.get("nexus"), fixerEnabled = true, List("/bin/echo"))
+  val dConfig  = DigestConfig("SHA-256", 1L, 1, 1, 1.second)
+  val cache    = mock[AttributesCache[IO]]
+  val storage  = new DiskStorage[IO](sConfig, dConfig, cache)
+
+  override def afterAll(): Unit = {
+    FileUtils.deleteDirectory(rootPath.toFile)
+  }
+
+  trait AbsoluteDirectoryCreated {
+    val name         = genString()
+    val baseRootPath = rootPath.resolve(name)
+    val basePath     = baseRootPath.resolve(sConfig.protectedDirectory)
+    Files.createDirectories(rootPath.resolve(name).resolve(sConfig.protectedDirectory))
+  }
+
+  trait RelativeDirectoryCreated extends AbsoluteDirectoryCreated {
+    val relativeDir                   = s"some/${genString()}"
+    val relativeFileString            = s"$relativeDir/file.txt"
+    val relativeFilePath              = Uri.Path(relativeFileString)
+    val absoluteFilePath              = basePath.resolve(Paths.get(relativeFilePath.toString()))
+    Files.createDirectories(absoluteFilePath.getParent)
+    implicit val bucketExistsEvidence = BucketExists
+    val alg                           = "SHA-256"
+  }
+
+  "A disk storage bundle" when {
+
+    "checking storage" should {
+
+      "fail when bucket directory does not exists" in {
+        val name = genString()
+        storage.exists(name) shouldBe a[BucketDoesNotExist]
+      }
+
+      "fail when bucket is not a directory" in {
+        val name      = genString()
+        val directory = Files.createDirectories(rootPath.resolve(name))
+        Files.createFile(directory.resolve(sConfig.protectedDirectory))
+        storage.exists(name) shouldBe a[BucketDoesNotExist]
+      }
+
+      "fail when the bucket goes out of the scope" in new AbsoluteDirectoryCreated {
+        val invalid = List("one/two", "../other", "..", "one/two/three")
+        forAll(invalid) {
+          storage.exists(_) shouldBe a[BucketDoesNotExist]
+        }
+      }
+
+      "pass" in new AbsoluteDirectoryCreated {
+        storage.exists(name) shouldBe a[BucketExists]
+      }
+    }
+
+    "checking path existence" should {
+
+      "exists" in new AbsoluteDirectoryCreated {
+        val relativeFileString = "some/file.txt"
+        val relativeFilePath   = Uri.Path(relativeFileString)
+        Files.createDirectories(basePath.resolve("some"))
+        val filePath           = basePath.resolve(relativeFileString)
+        Files.createFile(filePath)
+        storage.pathExists(name, relativeFilePath) shouldBe a[PathExists]
+      }
+
+      "exists outside scope" in new AbsoluteDirectoryCreated {
+        val relativeFileString = "../some/file.txt"
+        val relativeFilePath   = Uri.Path(relativeFileString)
+        Files.createDirectories(basePath.resolve("..").resolve("some").normalize())
+        val filePath           = basePath.resolve(relativeFileString).normalize()
+        Files.createFile(filePath)
+        storage.pathExists(name, relativeFilePath) shouldBe a[PathDoesNotExist]
+      }
+
+      "not exists" in new RelativeDirectoryCreated {
+        storage.pathExists(name, relativeFilePath) shouldBe a[PathDoesNotExist]
+      }
+    }
+
+    "creating a file" should {
+
+      "fail when destination is out of bucket scope" in new RelativeDirectoryCreated {
+        val content                   = "some content"
+        val source: AkkaSource        = Source.single(ByteString(content))
+        implicit val pathDoesNotExist = PathDoesNotExist
+        val relativePath              = Uri.Path("some/../../path")
+        storage.createFile(name, relativePath, source).unsafeToFuture().failed.futureValue shouldEqual
+          PathInvalid(name, relativePath)
+      }
+
+      "pass" in new RelativeDirectoryCreated {
+        val content                   = "some content"
+        val source: AkkaSource        = Source.single(ByteString(content))
+        val digest                    = Digest("SHA-256", "290f493c44f5d63d06b374d0a5abd292fae38b92cab2fae5efefe1b0e9347f56")
+        implicit val pathDoesNotExist = PathDoesNotExist
+        storage.createFile(name, relativeFilePath, source).ioValue shouldEqual
+          FileAttributes(s"file://${absoluteFilePath.toString}", 12L, digest, `text/plain(UTF-8)`)
+      }
+    }
+
+    "linking" should {
+      implicit val bucketExistsEvidence = BucketExists
+
+      "fail when call to nexus-fixer fails" in new AbsoluteDirectoryCreated {
+        val badStorage   = new DiskStorage[IO](sConfig.copy(fixerCommand = Vector("/bin/false")), dConfig, cache)
+        val file         = "some/folder/my !file.txt"
+        val absoluteFile = baseRootPath.resolve(Paths.get(file.toString))
+        Files.createDirectories(absoluteFile.getParent)
+        Files.write(absoluteFile, "something".getBytes(StandardCharsets.UTF_8))
+
+        badStorage
+          .moveFile(name, Uri.Path(file), Uri.Path(genString()))
+          .failed[StorageError] shouldEqual PermissionsFixingFailed(absoluteFile.toString, "")
+      }
+
+      "fail when source does not exists" in new AbsoluteDirectoryCreated {
+        val source = genString()
+        storage.moveFile(name, Uri.Path(source), Uri.Path(genString())).rejected[PathNotFound] shouldEqual
+          PathNotFound(name, Uri.Path(source))
+      }
+
+      "fail when source is inside protected directory" in new AbsoluteDirectoryCreated {
+        val file         = sConfig.protectedDirectory.toString + "/other.txt"
+        val absoluteFile = baseRootPath.resolve(Paths.get(file))
+        Files.createDirectories(absoluteFile.getParent)
+        Files.write(absoluteFile, "something".getBytes(StandardCharsets.UTF_8))
+
+        storage.moveFile(name, Uri.Path(file), Uri.Path(genString())).rejected[PathNotFound] shouldEqual
+          PathNotFound(name, Uri.Path(file))
+      }
+
+      "fail when destination already exists" in new AbsoluteDirectoryCreated {
+        val file         = "some/folder/my !file.txt"
+        val absoluteFile = baseRootPath.resolve(Paths.get(file.toString))
+        Files.createDirectories(absoluteFile.getParent)
+        Files.write(absoluteFile, "something".getBytes(StandardCharsets.UTF_8))
+
+        val fileDest = basePath.resolve(Paths.get("my !file.txt"))
+        Files.write(fileDest, "something".getBytes(StandardCharsets.UTF_8))
+        storage
+          .moveFile(name, Uri.Path(file), Uri.Path("my !file.txt"))
+          .rejected[PathAlreadyExists] shouldEqual
+          PathAlreadyExists(name, Uri.Path("my !file.txt"))
+      }
+
+      "fail when destination is out of bucket scope" in new AbsoluteDirectoryCreated {
+        val file         = "some/folder/my !file.txt"
+        val dest         = Uri.Path("../some/other path.txt")
+        val absoluteFile = baseRootPath.resolve(Paths.get(file.toString))
+        Files.createDirectories(absoluteFile.getParent)
+
+        val content = "some content"
+        Files.write(absoluteFile, content.getBytes(StandardCharsets.UTF_8))
+
+        storage.moveFile(name, Uri.Path(file), dest).unsafeToFuture().failed.futureValue shouldEqual
+          PathInvalid(name, dest)
+        Files.exists(absoluteFile) shouldEqual true
+      }
+
+      "pass on file" in new AbsoluteDirectoryCreated {
+        val file         = "some/folder/my !file.txt"
+        val absoluteFile = baseRootPath.resolve(Paths.get(file.toString))
+        Files.createDirectories(absoluteFile.getParent)
+
+        val content = "some content"
+        Files.write(absoluteFile, content.getBytes(StandardCharsets.UTF_8))
+
+        storage.moveFile(name, Uri.Path(file), Uri.Path("some/other path.txt")).accepted shouldEqual
+          FileAttributes(s"file://${basePath.resolve("some/other%20path.txt")}", 12L, Digest.empty, `text/plain(UTF-8)`)
+        Files.exists(absoluteFile) shouldEqual false
+        Files.exists(basePath.resolve("some/other path.txt")) shouldEqual true
+      }
+
+      "pass on directory" in new AbsoluteDirectoryCreated {
+        val dir         = "some/folder"
+        val absoluteDir = baseRootPath.resolve(Paths.get(dir.toString))
+        Files.createDirectories(absoluteDir)
+
+        val absoluteFile = absoluteDir.resolve(Paths.get("my !file.txt"))
+        val content      = "some content"
+        Files.write(absoluteFile, content.getBytes(StandardCharsets.UTF_8))
+
+        val result      = storage.moveFile(name, Uri.Path(dir), Uri.Path("some/other")).accepted
+        val resolvedDir = basePath.resolve("some/other")
+        result shouldEqual FileAttributes(s"file://$resolvedDir", 12L, Digest.empty, `application/x-tar`)
+        Files.exists(absoluteDir) shouldEqual false
+        Files.exists(absoluteFile) shouldEqual false
+        Files.exists(resolvedDir) shouldEqual true
+        Files.exists(basePath.resolve("some/other/my !file.txt")) shouldEqual true
+      }
+    }
+
+    "fetching" should {
+
+      implicit val pathExistsEvidence = PathExists
+
+      "fail when it does not exists" in new RelativeDirectoryCreated {
+        storage.getFile(name, relativeFilePath).leftValue shouldEqual
+          PathNotFound(name, relativeFilePath)
+      }
+
+      "pass with file" in new RelativeDirectoryCreated {
+        val content                        = "some content"
+        Files.write(absoluteFilePath, content.getBytes(StandardCharsets.UTF_8))
+        val (resultSource, resultFilename) = storage.getFile(name, relativeFilePath).rightValue
+        resultFilename.value shouldEqual "file.txt"
+        resultSource.runWith(Sink.head).futureValue.decodeString(UTF_8) shouldEqual content
+      }
+
+      "pass with directory" in new RelativeDirectoryCreated {
+        val content                        = "some content"
+        Files.write(absoluteFilePath, content.getBytes(StandardCharsets.UTF_8))
+        val (resultSource, resultFilename) = storage.getFile(name, Uri.Path(relativeDir)).rightValue
+        resultFilename shouldEqual None
+        resultSource.runFold("")(_ ++ _.utf8String).futureValue should include(content)
+      }
+    }
+
+    "fetching attributes" should {
+
+      implicit val pathExistsEvidence = PathExists
+
+      "fail when it does not exists" in new RelativeDirectoryCreated {
+        storage.getFile(name, relativeFilePath).leftValue shouldEqual
+          PathNotFound(name, relativeFilePath)
+      }
+
+      "return the attributes" in new RelativeDirectoryCreated {
+        val content            = "some content"
+        Files.write(absoluteFilePath, content.getBytes(StandardCharsets.UTF_8))
+        val expectedAttributes = FileAttributes(
+          s"file://$absoluteFilePath",
+          content.size.toLong,
+          Digest(alg, genString()),
+          `text/plain(UTF-8)`
+        )
+        cache.get(absoluteFilePath) shouldReturn IO(expectedAttributes)
+        storage.getAttributes(name, relativeFilePath).ioValue shouldEqual expectedAttributes
+      }
+    }
+  }
+
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/DiskStorageSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/DiskStorageSpec.scala
@@ -47,7 +47,7 @@ class DiskStorageSpec
   implicit val ec: ExecutionContext = system.dispatcher
 
   val rootPath = Files.createTempDirectory("storage-test")
-  val sConfig  = StorageConfig(rootPath, Paths.get("nexus"), fixerEnabled = true, List("/bin/echo"))
+  val sConfig  = StorageConfig(rootPath, Paths.get("nexus"), fixerEnabled = true, Vector("/bin/echo"))
   val dConfig  = DigestConfig("SHA-256", 1L, 1, 1, 1.second)
   val cache    = mock[AttributesCache[IO]]
   val storage  = new DiskStorage[IO](sConfig, dConfig, cache)

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/StringProcessLoggerSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/StringProcessLoggerSpec.scala
@@ -1,0 +1,28 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.sys.process._
+
+class StringProcessLoggerSpec extends AnyWordSpecLike with Matchers {
+  "A StringProcessLogger" should {
+    "log stdout" in {
+      val cmd      = List("echo", "-n", "Hello", "world!")
+      val process  = Process(cmd)
+      val logger   = StringProcessLogger(cmd)
+      val exitCode = process ! logger
+      exitCode shouldEqual 0
+      logger.toString shouldEqual "Hello world!"
+    }
+
+    "log stderr" in {
+      val cmd      = List("cat", "/")
+      val process  = Process(cmd)
+      val logger   = StringProcessLogger(cmd)
+      val exitCode = process ! logger
+      exitCode should not be 0
+      logger.toString shouldEqual "cat: /: Is a directory"
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/TarFlowSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/TarFlowSpec.scala
@@ -1,0 +1,84 @@
+package ch.epfl.bluebrain.nexus.storage
+
+import java.io.ByteArrayInputStream
+import java.nio.file.{Files, Path, Paths}
+
+import akka.actor.ActorSystem
+import akka.stream.alpakka.file.scaladsl.Directory
+import akka.stream.scaladsl.{FileIO, Source}
+import akka.testkit.TestKit
+import akka.util.ByteString
+import ch.epfl.bluebrain.nexus.storage.utils.{EitherValues, IOEitherValues, Randomness}
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.io.FileUtils
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterAll, Inspectors, OptionValues}
+
+import scala.annotation.tailrec
+
+class TarFlowSpec
+    extends TestKit(ActorSystem("TarFlowSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with IOEitherValues
+    with Randomness
+    with EitherValues
+    with OptionValues
+    with Inspectors
+    with BeforeAndAfterAll {
+
+  val basePath = Files.createTempDirectory("tarflow")
+  val dir1     = basePath.resolve("one")
+  val dir2     = basePath.resolve("two")
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    FileUtils.cleanDirectory(basePath.toFile)
+    ()
+  }
+
+  type PathAndContent = (Path, String)
+
+  "A TarFlow" should {
+
+    Files.createDirectories(dir1)
+    Files.createDirectories(dir2)
+
+    def relativize(path: Path): String = basePath.getParent().relativize(path).toString
+
+    "generate the byteString for a tar file correctly" in {
+      val file1        = dir1.resolve("file1.txt")
+      val file1Content = genString()
+      val file2        = dir1.resolve("file3.txt")
+      val file2Content = genString()
+      val file3        = dir2.resolve("file3.txt")
+      val file3Content = genString()
+      val files        = List(file1 -> file1Content, file2 -> file2Content, file3 -> file3Content)
+      forAll(files) {
+        case (file, content) => Source.single(ByteString(content)).runWith(FileIO.toPath(file)).futureValue
+      }
+      val byteString   = Directory.walk(basePath).via(TarFlow.writer(basePath)).runReduce(_ ++ _).futureValue
+      val bytes        = new ByteArrayInputStream(byteString.toArray)
+      val tar          = new TarArchiveInputStream(bytes)
+
+      @tailrec def readEntries(
+          tar: TarArchiveInputStream,
+          entries: List[PathAndContent] = Nil
+      ): List[PathAndContent] = {
+        val entry = tar.getNextTarEntry
+        if (entry == null) entries
+        else {
+          val data = Array.ofDim[Byte](entry.getSize.toInt)
+          tar.read(data)
+          readEntries(tar, (Paths.get(entry.getName) -> ByteString(data).utf8String) :: entries)
+        }
+      }
+      val directories = List(relativize(basePath) -> "", relativize(dir1) -> "", relativize(dir2) -> "")
+      val untarred    = readEntries(tar).map { case (path, content) => path.toString -> content }
+      val expected    = files.map { case (path, content) => relativize(path) -> content } ++ directories
+      untarred should contain theSameElementsAs expected
+    }
+  }
+
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesCacheSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesCacheSpec.scala
@@ -1,0 +1,169 @@
+package ch.epfl.bluebrain.nexus.storage.attributes
+
+import java.nio.file.{Path, Paths}
+import java.time.{Clock, Instant, ZoneId}
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import akka.util.Timeout
+import ch.epfl.bluebrain.nexus.storage._
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.DigestConfig
+import monix.eval.Task
+import org.mockito.{IdiomaticMockito, Mockito}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{BeforeAndAfter, Inspectors}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import monix.execution.Scheduler.Implicits.global
+import akka.http.scaladsl.model.MediaTypes.{`application/octet-stream`, `image/jpeg`}
+import ch.epfl.bluebrain.nexus.storage.utils.Randomness
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class AttributesCacheSpec
+    extends TestKit(ActorSystem("AttributesCacheSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with IdiomaticMockito
+    with BeforeAndAfter
+    with Inspectors
+    with Randomness
+    with Eventually
+    with ScalaFutures {
+
+  implicit override def patienceConfig: PatienceConfig = PatienceConfig(12.second, 100.milliseconds)
+
+  implicit val config                                           = DigestConfig("SHA-256", maxInMemory = 10, concurrentComputations = 3, 20, 5.seconds)
+  implicit val computation: AttributesComputation[Task, String] = mock[AttributesComputation[Task, String]]
+  implicit val timeout                                          = Timeout(1.minute)
+
+  before {
+    Mockito.reset(computation)
+  }
+
+  trait Ctx {
+    val path: Path                      = Paths.get(genString())
+    val digest                          = Digest(config.algorithm, genString())
+    val attributes                      = FileAttributes(s"file://$path", genInt().toLong, digest, `image/jpeg`)
+    def attributesEmpty(p: Path = path) = FileAttributes(p.toAkkaUri, 0L, Digest.empty, `application/octet-stream`)
+    val counter                         = new AtomicInteger(0)
+
+    implicit val clock: Clock = new Clock {
+      override def getZone: ZoneId                 = ZoneId.systemDefault()
+      override def withZone(zoneId: ZoneId): Clock = Clock.systemUTC()
+      // For every attribute computation done, it passes one second
+      override def instant(): Instant              = Instant.ofEpochSecond(counter.get + 1L)
+    }
+    val attributesCache       = AttributesCache[Task, String]
+    computation(path, config.algorithm) shouldReturn
+      Task { counter.incrementAndGet(); attributes }
+  }
+
+  "An AttributesCache" should {
+
+    "trigger a computation and fetch file after" in new Ctx {
+      attributesCache.asyncComputePut(path, config.algorithm)
+      eventually(counter.get shouldEqual 1)
+      computation(path, config.algorithm) wasCalled once
+      attributesCache.get(path).runToFuture.futureValue shouldEqual attributes
+      computation(path, config.algorithm) wasCalled once
+    }
+
+    "get file that triggers attributes computation" in new Ctx {
+      attributesCache.get(path).runToFuture.futureValue shouldEqual attributesEmpty()
+      eventually(counter.get shouldEqual 1)
+      computation(path, config.algorithm) wasCalled once
+      attributesCache.get(path).runToFuture.futureValue shouldEqual attributes
+      computation(path, config.algorithm) wasCalled once
+    }
+
+    "verify 2 concurrent computations" in new Ctx {
+      val list = List.tabulate(10) { i =>
+        val path   = Paths.get(i.toString)
+        val digest = Digest(config.algorithm, i.toString)
+        path -> FileAttributes(path.toAkkaUri, i.toLong, digest, `image/jpeg`)
+      }
+      val time = System.currentTimeMillis()
+
+      forAll(list) {
+        case (path, attr) =>
+          computation(path, config.algorithm) shouldReturn
+            Task.deferFuture(Future {
+              Thread.sleep(1000)
+              counter.incrementAndGet()
+              attr
+            })
+          attributesCache.get(path).runToFuture.futureValue shouldEqual attributesEmpty(path)
+      }
+
+      eventually(counter.get() shouldEqual 10)
+
+      forAll(list) {
+        case (path, _) =>
+          eventually(computation(path, config.algorithm) wasCalled once)
+      }
+
+      val diff = System.currentTimeMillis() - time
+      diff should be > 4000L
+      diff should be < 6500L
+
+      forAll(list) {
+        case (path, attr) =>
+          attributesCache.get(path).runToFuture.futureValue shouldEqual attr
+      }
+    }
+
+    "verify remove oldest" in new Ctx {
+      val list = List.tabulate(20) { i =>
+        val path   = Paths.get(i.toString)
+        val digest = Digest(config.algorithm, i.toString)
+        path -> FileAttributes(path.toAkkaUri, i.toLong, digest, `image/jpeg`)
+      }
+
+      forAll(list) {
+        case (path, attr) =>
+          computation(path, config.algorithm) shouldReturn
+            Task { counter.incrementAndGet(); attr }
+          attributesCache.get(path).runToFuture.futureValue shouldEqual attributesEmpty(path)
+      }
+
+      eventually(counter.get() shouldEqual 20)
+
+      forAll(list.takeRight(10)) {
+        case (path, attr) =>
+          attributesCache.get(path).runToFuture.futureValue shouldEqual attr
+      }
+
+      forAll(list.take(10)) {
+        case (path, _) =>
+          attributesCache.get(path).runToFuture.futureValue shouldEqual attributesEmpty(path)
+      }
+    }
+
+    "verify failure is skipped" in new Ctx {
+      val list = List.tabulate(5) { i =>
+        val path   = Paths.get(i.toString)
+        val digest = Digest(config.algorithm, i.toString)
+        path -> FileAttributes(path.toAkkaUri, i.toLong, digest, `image/jpeg`)
+      }
+
+      forAll(list) {
+        case (path, attr) =>
+          if (attr.bytes == 0L)
+            computation(path, config.algorithm) shouldReturn Task.raiseError(new RuntimeException)
+          else
+            computation(path, config.algorithm) shouldReturn Task(attr)
+
+          attributesCache.get(path).runToFuture.futureValue shouldEqual attributesEmpty(path)
+      }
+
+      forAll(list.drop(1)) {
+        case (path, attr) =>
+          eventually(attributesCache.get(path).runToFuture.futureValue shouldEqual attr)
+      }
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesComputationSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/attributes/AttributesComputationSpec.scala
@@ -1,0 +1,55 @@
+package ch.epfl.bluebrain.nexus.storage.attributes
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
+import akka.testkit.TestKit
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage.StorageError.InternalError
+import ch.epfl.bluebrain.nexus.storage.utils.IOValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.ExecutionContextExecutor
+
+class AttributesComputationSpec
+    extends TestKit(ActorSystem("AttributesComputationSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with IOValues {
+
+  implicit private val ec: ExecutionContextExecutor = system.dispatcher
+
+  private trait Ctx {
+    val path           = Files.createTempFile("storage-test", ".txt")
+    val (text, digest) = "something" -> "3fc9b689459d738f8c88a3a48aa9e33542016b7a4052e001aaa536fca74813cb"
+  }
+
+  "Attributes computation computation" should {
+    val computation = AttributesComputation.akkaAttributes[IO]
+    val alg         = "SHA-256"
+
+    "succeed" in new Ctx {
+      Files.write(path, text.getBytes(StandardCharsets.UTF_8))
+      computation(path, alg).ioValue shouldEqual FileAttributes(
+        s"file://$path",
+        Files.size(path),
+        Digest(alg, digest),
+        `text/plain(UTF-8)`
+      )
+      Files.deleteIfExists(path)
+    }
+
+    "fail when algorithm is wrong" in new Ctx {
+      Files.write(path, text.getBytes(StandardCharsets.UTF_8))
+      computation(path, "wrong-alg").failed[InternalError]
+    }
+
+    "fail when file does not exists" in new Ctx {
+      computation(Paths.get("/tmp/non/existing"), alg).failed[InternalError]
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/AppInfoRoutesSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/AppInfoRoutesSpec.scala
@@ -1,0 +1,39 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import java.util.regex.Pattern.quote
+
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.epfl.bluebrain.nexus.storage.config.{AppConfig, Settings}
+import ch.epfl.bluebrain.nexus.storage.routes.instances._
+import ch.epfl.bluebrain.nexus.storage.utils.Resources
+import ch.epfl.bluebrain.nexus.storage.{AkkaSource, IamIdentitiesClient, Storages}
+import io.circe.Json
+import monix.eval.Task
+import org.mockito.IdiomaticMockito
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class AppInfoRoutesSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with ScalatestRouteTest
+    with IdiomaticMockito
+    with Resources {
+
+  "the app info routes" should {
+
+    implicit val config: AppConfig                        = Settings(system).appConfig
+    implicit val iamIdentities: IamIdentitiesClient[Task] = mock[IamIdentitiesClient[Task]]
+    val route: Route                                      = Routes(mock[Storages[Task, AkkaSource]])
+
+    "return application information" in {
+      Get("/") ~> route ~> check {
+        status shouldEqual OK
+        responseAs[Json] shouldEqual
+          jsonContentOf("/app-info.json", Map(quote("{version}") -> config.description.version))
+      }
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/AuthDirectivesSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/AuthDirectivesSpec.scala
@@ -1,0 +1,102 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.epfl.bluebrain.nexus.storage.{IamIdentitiesClient, IamIdentitiesClientError}
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.Identity.Anonymous
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.{AccessToken, Caller}
+import ch.epfl.bluebrain.nexus.storage.config.AppConfig.HttpConfig
+import ch.epfl.bluebrain.nexus.storage.config.Settings
+import ch.epfl.bluebrain.nexus.storage.routes.AuthDirectives._
+import ch.epfl.bluebrain.nexus.storage.utils.EitherValues
+import monix.eval.Task
+import org.mockito.matchers.MacroBasedMatchers
+import org.mockito.{IdiomaticMockito, Mockito}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+//noinspection NameBooleanParameters
+class AuthDirectivesSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with EitherValues
+    with MacroBasedMatchers
+    with IdiomaticMockito
+    with BeforeAndAfter
+    with ScalatestRouteTest {
+
+  implicit private val hc: HttpConfig = Settings(system).appConfig.http
+
+  implicit private val iamIdentities: IamIdentitiesClient[Task] = mock[IamIdentitiesClient[Task]]
+
+  before {
+    Mockito.reset(iamIdentities)
+  }
+
+  "The AuthDirectives" should {
+
+    "extract the token" in {
+      val expected = "token"
+      val route    = extractToken {
+        case Some(AccessToken(`expected`)) => complete("")
+        case Some(_)                       => fail("Token was not extracted correctly.")
+        case None                          => fail("Token was not extracted.")
+      }
+      Get("/").addCredentials(OAuth2BearerToken(expected)) ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+    "extract no token" in {
+      val route = extractToken {
+        case None        => complete("")
+        case t @ Some(_) => fail(s"Extracted unknown token '$t'.")
+      }
+      Get("/") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
+    "extract the caller" in {
+      implicit val token: Option[AccessToken] = None
+      iamIdentities()(any[Option[AccessToken]]) shouldReturn Task(Caller(Anonymous, Set.empty))
+      val route                               = Routes.wrap(extractCaller.apply(_ => complete("")))
+      Get("/") ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
+    "fail the route" when {
+
+      "the client throws an error for caller" in {
+        implicit val token: Option[AccessToken] = None
+        iamIdentities()(any[Option[AccessToken]]) shouldReturn
+          Task.raiseError(IamIdentitiesClientError.IdentitiesServerStatusError(StatusCodes.InternalServerError, ""))
+        val route                               = Routes.wrap(extractCaller.apply(_ => complete("")))
+        Get("/") ~> route ~> check {
+          status shouldEqual StatusCodes.InternalServerError
+        }
+      }
+      "the client returns Unauthorized for caller" in {
+        implicit val token: Option[AccessToken] = None
+        iamIdentities()(any[Option[AccessToken]]) shouldReturn
+          Task.raiseError(IamIdentitiesClientError.IdentitiesClientStatusError(StatusCodes.Unauthorized, ""))
+        val route                               = Routes.wrap(extractCaller.apply(_ => complete("")))
+        Get("/") ~> route ~> check {
+          status shouldEqual StatusCodes.Unauthorized
+        }
+      }
+      "the client returns Forbidden for caller" in {
+        implicit val token: Option[AccessToken] = None
+        iamIdentities()(any[Option[AccessToken]]) shouldReturn
+          Task.raiseError(IamIdentitiesClientError.IdentitiesClientStatusError(StatusCodes.Forbidden, ""))
+        val route                               = Routes.wrap(extractCaller.apply(_ => complete("")))
+        Get("/") ~> route ~> check {
+          status shouldEqual StatusCodes.Forbidden
+        }
+      }
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectivesSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectivesSpec.scala
@@ -1,0 +1,90 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import java.util.regex.Pattern.quote
+
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.epfl.bluebrain.nexus.storage.JsonLdCirceSupport._
+import ch.epfl.bluebrain.nexus.storage.routes.Routes.exceptionHandler
+import ch.epfl.bluebrain.nexus.storage.routes.StorageDirectives._
+import ch.epfl.bluebrain.nexus.storage.utils.Resources
+import io.circe.Json
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class StorageDirectivesSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with ScalatestRouteTest
+    with Inspectors
+    with Resources {
+
+  "the storage directives" when {
+
+    def pathInvalidJson(path: Uri.Path): Json =
+      jsonContentOf(
+        "/error.json",
+        Map(
+          quote("{type}") -> "PathInvalid",
+          quote(
+            "{reason}"
+          )               -> s"The provided location inside the bucket 'name' with the relative path '$path' is invalid."
+        )
+      )
+
+    "dealing with file path extraction" should {
+      val route = handleExceptions(exceptionHandler) {
+        (extractRelativeFilePath("name") & get) { path =>
+          complete(s"$path")
+        }
+      }
+
+      "reject when path contains 2 slashes" in {
+        Get("///") ~> route ~> check {
+          status shouldEqual StatusCodes.BadRequest
+          responseAs[Json] shouldEqual pathInvalidJson(Uri.Path.Empty)
+        }
+      }
+
+      "reject when path does not end with a segment" in {
+        Get("/some/path/") ~> route ~> check {
+          status shouldEqual StatusCodes.BadRequest
+          responseAs[Json] shouldEqual pathInvalidJson(Uri.Path("some/path/"))
+        }
+      }
+
+      "return path" in {
+        Get("/some/path/file.txt") ~> route ~> check {
+          responseAs[String] shouldEqual "some/path/file.txt"
+        }
+      }
+    }
+
+    "dealing with path validation" should {
+      def route(path: Uri.Path) =
+        handleExceptions(exceptionHandler) {
+          (validatePath("name", path) & get) {
+            complete(s"$path")
+          }
+        }
+
+      "reject when some of the segments is . or .." in {
+        val paths = List(Uri.Path("/./other/file.txt"), Uri.Path("/some/../file.txt"))
+        forAll(paths) { path =>
+          Get(path.toString()) ~> route(path) ~> check {
+            status shouldEqual StatusCodes.BadRequest
+            responseAs[Json] shouldEqual pathInvalidJson(path)
+          }
+        }
+      }
+
+      "pass" in {
+        Get("/some/path") ~> route(Uri.Path("/some/path")) ~> check {
+          handled shouldEqual true
+        }
+      }
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutesSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutesSpec.scala
@@ -1,0 +1,443 @@
+package ch.epfl.bluebrain.nexus.storage.routes
+
+import java.nio.file.Paths
+import java.util.regex.Pattern.quote
+
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.MediaRanges._
+import akka.http.scaladsl.model.MediaTypes.{`application/octet-stream`, `image/jpeg`}
+import akka.http.scaladsl.model.Multipart.FormData
+import akka.http.scaladsl.model.Multipart.FormData.BodyPart
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.{HttpEntity, Uri}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
+import ch.epfl.bluebrain.nexus.rdf.implicits._
+import ch.epfl.bluebrain.nexus.storage.File.{Digest, FileAttributes}
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.Caller
+import ch.epfl.bluebrain.nexus.storage.IamIdentitiesClient.Identity.Anonymous
+import ch.epfl.bluebrain.nexus.storage.Rejection.PathNotFound
+import ch.epfl.bluebrain.nexus.storage.StorageError.InternalError
+import ch.epfl.bluebrain.nexus.storage.Storages.BucketExistence.{BucketDoesNotExist, BucketExists}
+import ch.epfl.bluebrain.nexus.storage.Storages.PathExistence.{PathDoesNotExist, PathExists}
+import ch.epfl.bluebrain.nexus.storage.config.{AppConfig, Settings}
+import ch.epfl.bluebrain.nexus.storage.routes.instances._
+import ch.epfl.bluebrain.nexus.storage.utils.{Randomness, Resources}
+import ch.epfl.bluebrain.nexus.storage.{AkkaSource, IamIdentitiesClient, Storages}
+import io.circe.Json
+import monix.eval.Task
+import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.duration._
+
+class StorageRoutesSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with ScalatestRouteTest
+    with IdiomaticMockito
+    with Randomness
+    with Resources
+    with ArgumentMatchersSugar
+    with OptionValues
+    with ScalaFutures {
+
+  implicit override def patienceConfig: PatienceConfig = PatienceConfig(3.second, 15.milliseconds)
+
+  implicit val appConfig: AppConfig                     = Settings(system).appConfig
+  implicit val iamIdentities: IamIdentitiesClient[Task] = mock[IamIdentitiesClient[Task]]
+  val storages: Storages[Task, AkkaSource]              = mock[Storages[Task, AkkaSource]]
+  val route: Route                                      = Routes(storages)
+
+  iamIdentities()(None) shouldReturn Task(Caller(Anonymous, Set.empty))
+
+  trait Ctx {
+    val name                     = genString()
+    val resourceCtx: AbsoluteIri = url"https://bluebrain.github.io/nexus/contexts/resource.json"
+  }
+
+  trait RandomFile extends Ctx {
+    val filename              = s"${genString()}.json"
+    val content               = Json.obj("key" -> Json.fromString(genString())).noSpaces
+    val source: AkkaSource    = Source.single(ByteString(content))
+    implicit val bucketExists = BucketExists
+    implicit val pathExists   = PathExists
+  }
+
+  trait RandomFileCreate extends RandomFile {
+    val entity: HttpEntity.Strict = HttpEntity(`application/json`, content)
+    val multipartForm             = FormData(BodyPart.Strict("file", entity, Map("filename" -> filename))).toEntity()
+    val filePathString            = s"path/to/file/$filename"
+    val filePath                  = Paths.get(filePathString)
+    val filePathUri               = Uri.Path(s"path/to/file/$filename")
+  }
+
+  "the storage routes" when {
+
+    "accessing the check bucket endpoint" should {
+
+      "fail when bucket check returns a rejection" in new Ctx {
+        storages.exists(name) shouldReturn BucketDoesNotExist
+
+        Head(s"/v1/buckets/$name") ~> route ~> check {
+          status shouldEqual NotFound
+          storages.exists(name) wasCalled once
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}")   -> "BucketNotFound",
+              quote("{reason}") -> s"The provided bucket '$name' does not exist."
+            )
+          )
+        }
+      }
+
+      "pass" in new Ctx {
+        storages.exists(name) shouldReturn BucketExists
+
+        Head(s"/v1/buckets/$name") ~> route ~> check {
+          status shouldEqual OK
+          storages.exists(name) wasCalled once
+        }
+      }
+    }
+
+    "uploading a file" should {
+
+      "fail when bucket does not exists" in new Ctx {
+        storages.exists(name) shouldReturn BucketDoesNotExist
+
+        Put(s"/v1/buckets/$name/files/path/to/file/") ~> route ~> check {
+          status shouldEqual NotFound
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}")   -> "BucketNotFound",
+              quote("{reason}") -> s"The provided bucket '$name' does not exist."
+            )
+          )
+          storages.exists(name) wasCalled once
+        }
+      }
+
+      "fail when path already exists" in new RandomFileCreate {
+        storages.exists(name) shouldReturn BucketExists
+        storages.pathExists(name, filePathUri) shouldReturn PathExists
+
+        Put(s"/v1/buckets/$name/files/path/to/file/$filename", multipartForm) ~> route ~> check {
+          status shouldEqual Conflict
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}") -> "PathAlreadyExists",
+              quote(
+                "{reason}"
+              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' already exists."
+            )
+          )
+          storages.exists(name) wasCalled once
+          storages.pathExists(name, filePathUri) wasCalled once
+        }
+      }
+
+      "fail when create file returns a exception" in new RandomFileCreate {
+        storages.exists(name) shouldReturn BucketExists
+        storages.pathExists(name, filePathUri) shouldReturn PathDoesNotExist
+        storages.createFile(eqTo(name), eqTo(filePathUri), any[AkkaSource])(
+          eqTo(BucketExists),
+          eqTo(PathDoesNotExist)
+        ) shouldReturn
+          Task.raiseError(InternalError("something went wrong"))
+
+        Put(s"/v1/buckets/$name/files/path/to/file/$filename", multipartForm) ~> route ~> check {
+          status shouldEqual InternalServerError
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}")   -> "InternalError",
+              quote("{reason}") -> s"The system experienced an unexpected error, please try again later."
+            )
+          )
+          storages.createFile(eqTo(name), eqTo(filePathUri), any[AkkaSource])(
+            eqTo(BucketExists),
+            eqTo(PathDoesNotExist)
+          ) wasCalled once
+        }
+      }
+
+      "pass" in new RandomFileCreate {
+        val absoluteFilePath = appConfig.storage.rootVolume.resolve(filePath)
+        val digest           = Digest("SHA-256", genString())
+        val attributes       = FileAttributes(s"file://$absoluteFilePath", 12L, digest, `application/octet-stream`)
+        storages.exists(name) shouldReturn BucketExists
+        storages.pathExists(name, filePathUri) shouldReturn PathDoesNotExist
+        storages.createFile(eqTo(name), eqTo(filePathUri), any[AkkaSource])(
+          eqTo(BucketExists),
+          eqTo(PathDoesNotExist)
+        ) shouldReturn Task(
+          attributes
+        )
+
+        Put(s"/v1/buckets/$name/files/path/to/file/$filename", multipartForm) ~> route ~> check {
+          status shouldEqual Created
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/file-created.json",
+            Map(
+              quote("{location}")  -> attributes.location.toString,
+              quote("{mediaType}") -> attributes.mediaType.value,
+              quote("{bytes}")     -> attributes.bytes.toString,
+              quote("{algorithm}") -> attributes.digest.algorithm,
+              quote("{value}")     -> attributes.digest.value
+            )
+          )
+          storages.createFile(eqTo(name), eqTo(filePathUri), any[AkkaSource])(
+            eqTo(BucketExists),
+            eqTo(PathDoesNotExist)
+          ) wasCalled once
+        }
+      }
+    }
+
+    "linking a file" should {
+
+      "fail when bucket does not exists" in new Ctx {
+        storages.exists(name) shouldReturn BucketDoesNotExist
+
+        Put(s"/v1/buckets/$name/files/path/to/myfile.txt", jsonContentOf("/file-link.json")) ~> route ~> check {
+          status shouldEqual NotFound
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}")   -> "BucketNotFound",
+              quote("{reason}") -> s"The provided bucket '$name' does not exist."
+            )
+          )
+          storages.exists(name) wasCalled once
+        }
+      }
+
+      "fail when move file returns a exception" in new Ctx {
+        storages.exists(name) shouldReturn BucketExists
+        val source = "source/dir"
+        val dest   = "dest/dir"
+        storages.moveFile(name, Uri.Path(source), Uri.Path(dest))(BucketExists) shouldReturn
+          Task.raiseError(InternalError("something went wrong"))
+
+        val json = jsonContentOf("/file-link.json", Map(quote("{source}") -> source))
+
+        Put(s"/v1/buckets/$name/files/$dest", json) ~> route ~> check {
+          status shouldEqual InternalServerError
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}")   -> "InternalError",
+              quote("{reason}") -> s"The system experienced an unexpected error, please try again later."
+            )
+          )
+
+          storages.moveFile(name, Uri.Path(source), Uri.Path(dest))(BucketExists) wasCalled once
+        }
+      }
+
+      "fail with invalid source path" in new Ctx {
+        storages.exists(name) shouldReturn BucketExists
+        val source = "../dir"
+        val dest   = "dest/dir"
+
+        val json = jsonContentOf("/file-link.json", Map(quote("{source}") -> source))
+
+        Put(s"/v1/buckets/$name/files/$dest", json) ~> route ~> check {
+          status shouldEqual BadRequest
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}") -> "PathInvalid",
+              quote(
+                "{reason}"
+              )               -> s"The provided location inside the bucket '$name' with the relative path '$source' is invalid."
+            )
+          )
+        }
+      }
+
+      "pass" in new Ctx {
+        storages.exists(name) shouldReturn BucketExists
+        val source     = "source/dir"
+        val dest       = "dest/dir"
+        val attributes = FileAttributes(s"file://some/prefix/$dest", 12L, Digest.empty, `application/octet-stream`)
+        storages.moveFile(name, Uri.Path(source), Uri.Path(dest))(BucketExists) shouldReturn
+          Task.pure(Right(attributes))
+
+        val json = jsonContentOf("/file-link.json", Map(quote("{source}") -> source))
+
+        Put(s"/v1/buckets/$name/files/$dest", json) ~> route ~> check {
+          status shouldEqual OK
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/file-created.json",
+            Map(
+              quote("{location}")  -> attributes.location.toString,
+              quote("{mediaType}") -> attributes.mediaType.value,
+              quote("{bytes}")     -> attributes.bytes.toString,
+              quote("{algorithm}") -> "",
+              quote("{value}")     -> ""
+            )
+          )
+
+          storages.moveFile(name, Uri.Path(source), Uri.Path(dest))(BucketExists) wasCalled once
+        }
+      }
+    }
+
+    "downloading a file" should {
+
+      "fail when the path does not exists" in new RandomFile {
+        val filePathUri = Uri.Path(s"$filename")
+        storages.exists(name) shouldReturn BucketExists
+        storages.pathExists(name, filePathUri) shouldReturn PathDoesNotExist
+
+        Get(s"/v1/buckets/$name/files/$filename") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual NotFound
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}") -> "PathNotFound",
+              quote(
+                "{reason}"
+              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' does not exist."
+            )
+          )
+          storages.pathExists(name, filePathUri) wasCalled once
+        }
+      }
+
+      "fail when get file returns a rejection" in new RandomFile {
+        val filePathUri = Uri.Path(s"$filename")
+        storages.exists(name) shouldReturn BucketExists
+        storages.pathExists(name, filePathUri) shouldReturn PathExists
+        storages.getFile(name, filePathUri) shouldReturn Left(PathNotFound(name, filePathUri))
+
+        Get(s"/v1/buckets/$name/files/$filename") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual NotFound
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}") -> "PathNotFound",
+              quote(
+                "{reason}"
+              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' does not exist."
+            )
+          )
+          storages.getFile(name, filePathUri) wasCalled once
+        }
+      }
+
+      "pass on file" in new RandomFile {
+        val filePathUri = Uri.Path(s"$filename")
+        storages.exists(name) shouldReturn BucketExists
+        storages.getFile(name, filePathUri) shouldReturn Right(source -> Option(filename))
+        storages.pathExists(name, filePathUri) shouldReturn PathExists
+
+        Get(s"/v1/buckets/$name/files/$filename") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual OK
+          contentType.value shouldEqual "application/octet-stream"
+          responseEntity.dataBytes.runFold("")(_ ++ _.utf8String).futureValue shouldEqual content
+          storages.getFile(name, filePathUri) wasCalled once
+        }
+      }
+
+      "pass on directory" in new RandomFile {
+        val directory    = "some/dir/"
+        val directoryUri = Uri.Path(s"$directory")
+        storages.exists(name) shouldReturn BucketExists
+        storages.getFile(name, directoryUri) shouldReturn Right(source -> None)
+        storages.pathExists(name, directoryUri) shouldReturn PathExists
+
+        Get(s"/v1/buckets/$name/files/$directory") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual OK
+          contentType.value shouldEqual "application/x-tar"
+          responseEntity.dataBytes.runFold("")(_ ++ _.utf8String).futureValue shouldEqual content
+          storages.getFile(name, directoryUri) wasCalled once
+        }
+      }
+    }
+
+    "fetching the file attributes" should {
+
+      "fail when the path does not exists" in new RandomFile {
+        val filePathUri = Uri.Path(s"$filename")
+        storages.exists(name) shouldReturn BucketExists
+        storages.pathExists(name, filePathUri) shouldReturn PathDoesNotExist
+
+        Get(s"/v1/buckets/$name/attributes/$filename") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual NotFound
+          responseAs[Json] shouldEqual jsonContentOf(
+            "/error.json",
+            Map(
+              quote("{type}") -> "PathNotFound",
+              quote(
+                "{reason}"
+              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' does not exist."
+            )
+          )
+          storages.pathExists(name, filePathUri) wasCalled once
+        }
+      }
+
+      "return attributes" in new RandomFile {
+        val filePathUri = Uri.Path(s"$filename")
+        storages.exists(name) shouldReturn BucketExists
+        val attributes  =
+          FileAttributes(s"file://$filePathUri", genInt().toLong, Digest("SHA-256", genString()), `image/jpeg`)
+        storages.getAttributes(name, filePathUri) shouldReturn Task(attributes)
+        storages.pathExists(name, filePathUri) shouldReturn PathExists
+
+        Get(s"/v1/buckets/$name/attributes/$filename") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual OK
+          val digestJson = Json.obj(
+            "_algorithm" -> Json.fromString(attributes.digest.algorithm),
+            "_value"     -> Json.fromString(attributes.digest.value)
+          )
+          responseAs[Json] shouldEqual Json
+            .obj(
+              "_bytes"     -> Json.fromLong(attributes.bytes),
+              "_digest"    -> digestJson,
+              "_location"  -> Json.fromString(attributes.location.toString()),
+              "_mediaType" -> Json.fromString(attributes.mediaType.toString)
+            )
+            .addContext(resourceCtx)
+          storages.getAttributes(name, filePathUri) wasCalled once
+        }
+      }
+
+      "return empty attributes" in new RandomFile {
+        val filePathUri = Uri.Path(s"$filename")
+        storages.exists(name) shouldReturn BucketExists
+        storages.getAttributes(name, filePathUri) shouldReturn Task(
+          FileAttributes(s"file://$filePathUri", 0L, Digest.empty, `application/octet-stream`)
+        )
+        storages.pathExists(name, filePathUri) shouldReturn PathExists
+
+        Get(s"/v1/buckets/$name/attributes/$filename") ~> Accept(`*/*`) ~> route ~> check {
+          status shouldEqual Accepted
+          val digestJson = Json.obj("_algorithm" -> Json.fromString(""), "_value" -> Json.fromString(""))
+          responseAs[Json] shouldEqual Json
+            .obj(
+              "_bytes"     -> Json.fromLong(0L),
+              "_digest"    -> digestJson,
+              "_location"  -> Json.fromString(s"file://${filePathUri.toString().toLowerCase}"),
+              "_mediaType" -> Json.fromString(`application/octet-stream`.toString())
+            )
+            .addContext(resourceCtx)
+          storages.getAttributes(name, filePathUri) wasCalled once
+        }
+      }
+    }
+  }
+}

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/EitherValues.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/EitherValues.scala
@@ -1,0 +1,37 @@
+package ch.epfl.bluebrain.nexus.storage.utils
+
+import org.scalactic.source
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+
+trait EitherValues {
+
+  class EitherValuable[L, R](either: Either[L, R], pos: source.Position) {
+    def rightValue: R =
+      either match {
+        case Right(value) => value
+        case Left(_)      =>
+          throw new TestFailedException(
+            (_: StackDepthException) => Some("The Either value is not a Right(_)"),
+            None,
+            pos
+          )
+      }
+
+    def leftValue: L =
+      either match {
+        case Left(value) => value
+        case Right(_)    =>
+          throw new TestFailedException(
+            (_: StackDepthException) => Some("The Either value is not a Left(_)"),
+            None,
+            pos
+          )
+      }
+  }
+
+  implicit def convertEitherToValuable[L, R](either: Either[L, R])(implicit p: source.Position): EitherValuable[L, R] =
+    new EitherValuable(either, p)
+
+}
+
+object EitherValues extends EitherValues

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/IOEitherValues.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/IOEitherValues.scala
@@ -1,0 +1,31 @@
+package ch.epfl.bluebrain.nexus.storage.utils
+
+import cats.effect.IO
+import org.scalactic.source
+import org.scalatest.matchers.should.Matchers.fail
+
+import scala.reflect.ClassTag
+
+trait IOEitherValues extends IOValues with EitherValues {
+
+  implicit final def ioEitherValues[E, A](io: IO[Either[E, A]]): IOEitherValuesSyntax[E, A] =
+    new IOEitherValuesSyntax(io)
+
+  protected class IOEitherValuesSyntax[E, A](io: IO[Either[E, A]]) {
+    def accepted(implicit config: PatienceConfig, pos: source.Position): A =
+      io.ioValue(config, pos).rightValue
+
+    def rejected[EE <: E: ClassTag](implicit config: PatienceConfig, pos: source.Position): EE = {
+      val EE = implicitly[ClassTag[EE]]
+      io.ioValue(config, pos).leftValue match {
+        case EE(value) => value
+        case other     =>
+          fail(
+            s"Wrong throwable type caught, expected: '${EE.runtimeClass.getName}', actual: '${other.getClass.getName}'"
+          )
+      }
+    }
+  }
+}
+
+object IOEitherValues extends IOEitherValues

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/IOValues.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/IOValues.scala
@@ -1,0 +1,37 @@
+package ch.epfl.bluebrain.nexus.storage.utils
+
+import cats.effect.IO
+import org.scalactic.source
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.reflect.ClassTag
+
+trait IOValues extends ScalaFutures {
+  implicit final def ioValues[A](io: IO[A]): IOValuesSyntax[A] =
+    new IOValuesSyntax(io)
+
+  protected class IOValuesSyntax[A](io: IO[A]) {
+    def failed[Ex <: Throwable: ClassTag](implicit config: PatienceConfig, pos: source.Position): Ex = {
+      val Ex = implicitly[ClassTag[Ex]]
+      io.redeemWith(
+          {
+            case Ex(ex) => IO.pure(ex)
+            case other  =>
+              IO(
+                fail(
+                  s"Wrong throwable type caught, expected: '${Ex.runtimeClass.getName}', actual: '${other.getClass.getName}'"
+                )
+              )
+          },
+          a => IO(fail(s"The IO did not fail as expected, but computed the value '$a'"))
+        )
+        .ioValue(config, pos)
+    }
+
+    def ioValue(implicit config: PatienceConfig, pos: source.Position): A =
+      io.unsafeToFuture().futureValue(config, pos)
+  }
+}
+
+object IOValues extends IOValues

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/Randomness.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/Randomness.scala
@@ -1,0 +1,13 @@
+package ch.epfl.bluebrain.nexus.storage.utils
+
+import scala.util.Random
+
+trait Randomness {
+
+  def genString(size: Int = 10): String = Random.alphanumeric.take(size).mkString
+
+  final def genInt(max: Int = 100): Int = Random.nextInt(max)
+
+}
+
+object Randomness extends Randomness

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/Resources.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/utils/Resources.scala
@@ -1,0 +1,62 @@
+package ch.epfl.bluebrain.nexus.storage.utils
+
+import io.circe.Json
+import io.circe.parser.parse
+
+import scala.io.Source
+
+/**
+  * Utility trait that facilitates operating on classpath resources.
+  */
+trait Resources {
+
+  /**
+    * Loads the content of the argument classpath resource as a string.
+    *
+   * @param resourcePath the path of a resource available on the classpath
+    * @return the content of the referenced resource as a string
+    */
+  final def contentOf(resourcePath: String): String = {
+    val fromClass       = Option(getClass.getResourceAsStream(resourcePath))
+    val fromClassLoader = Option(getClass.getClassLoader.getResourceAsStream(resourcePath))
+    val is              = (fromClass orElse fromClassLoader).getOrElse(
+      throw new IllegalArgumentException(s"Unable to load resource '$resourcePath' from classpath.")
+    )
+    Source.fromInputStream(is).mkString
+  }
+
+  /**
+    * Loads the content of the argument classpath resource as a string and replaces all the key matches of
+    * the ''replacements'' with their values.
+    *
+   * @param resourcePath the path of a resource available on the classpath
+    * @return the content of the referenced resource as a string
+    */
+  final def contentOf(resourcePath: String, replacements: Map[String, String]): String =
+    replacements.foldLeft(contentOf(resourcePath)) {
+      case (value, (regex, replacement)) => value.replaceAll(regex, replacement)
+    }
+
+  /**
+    * Loads the content of the argument classpath resource as a json value.
+    *
+   * @param resourcePath the path of a resource available on the classpath
+    * @return the content of the referenced resource as a json value
+    */
+  @SuppressWarnings(Array("TryGet"))
+  final def jsonContentOf(resourcePath: String): Json =
+    parse(contentOf(resourcePath)).toTry.get
+
+  /**
+    * Loads the content of the argument classpath resource as a string and replaces all the key matches of
+    * the ''replacements'' with their values.  The resulting string is parsed into a json value.
+    *
+   * @param resourcePath the path of a resource available on the classpath
+    * @return the content of the referenced resource as a json value
+    */
+  @SuppressWarnings(Array("TryGet"))
+  final def jsonContentOf(resourcePath: String, replacements: Map[String, String]): Json =
+    parse(contentOf(resourcePath, replacements)).toTry.get
+}
+
+object Resources extends Resources


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/1220

I've removed the dependency from storage service to the iamClient and I've implemented a simplified version of the `IamClient` called `IamIdentitiesClient` (which is the only part we need in the storage service).

Besides that, I had to duplicate some classes (`StatusFrom`, `RejectionHandling`, `PrefixDirectives` and `JsonLdCirceSupport`) but now it does not depend on anything else (for now on rdf but eventually we will remove that too).

It should be in a different module because:
- Easier to deploy separately
- Depends on java 1.8 and not 11
- Has the cargo stuff...