### PR TITLE
Changed S3 location from Path-Styled to Virtual Host Styled

### DIFF
--- a/.github/workflows/ci-delta.yml
+++ b/.github/workflows/ci-delta.yml
@@ -36,7 +36,10 @@ jobs:
       - name: StaticAnalysis
         run: sbt -Dsbt.color=always -Dsbt.supershell=false "project delta" clean scalafmtCheck test:scalafmtCheck scalafmtSbtCheck scapegoat
       - name: Tests
-        run: sbt -Dsbt.color=always -Dsbt.supershell=false "project delta" clean coverage test coverageReport coverageAggregate
+        run: |
+          echo "127.0.0.1 bucket.my-domain.com" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 bucket2.my-domain.com" | sudo tee -a /etc/hosts
+          sbt -Dsbt.color=always -Dsbt.supershell=false "project delta" clean coverage test coverageReport coverageAggregate
   publish:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-delta.yml
+++ b/.github/workflows/ci-delta.yml
@@ -37,8 +37,8 @@ jobs:
         run: sbt -Dsbt.color=always -Dsbt.supershell=false "project delta" clean scalafmtCheck test:scalafmtCheck scalafmtSbtCheck scapegoat
       - name: Tests
         run: |
-          echo "127.0.0.1 bucket.my-domain.com" | sudo tee -a /etc/hosts
-          echo "127.0.0.1 bucket2.my-domain.com" | sudo tee -a /etc/hosts
+          grep -qF 'bucket.my-domain.com' /etc/hosts || echo "127.0.0.1 bucket.my-domain.com" | sudo tee -a /etc/hosts
+          grep -qF 'bucket2.my-domain.com' /etc/hosts || echo "127.0.0.1 bucket2.my-domain.com" | sudo tee -a /etc/hosts
           sbt -Dsbt.color=always -Dsbt.supershell=false "project delta" clean coverage test coverageReport coverageAggregate
   publish:
     if: github.event_name == 'push'

--- a/delta/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperations.scala
+++ b/delta/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/DiskStorageOperations.scala
@@ -42,12 +42,12 @@ object DiskStorageOperations {
     */
   final class FetchDiskFile[F[_]](implicit F: Effect[F]) extends FetchFile[F, AkkaSource] {
 
-    override def apply(fileMeta: FileAttributes): F[AkkaSource] =
-      uriToPath(fileMeta.location) match {
+    override def apply(path: Uri.Path, location: Uri): F[AkkaSource] =
+      uriToPath(location) match {
         case Some(path) => F.pure(FileIO.fromPath(path))
         case None       =>
-          logger.error(s"Invalid file location: '${fileMeta.location}'")
-          F.raiseError(KgError.InternalError(s"Invalid file location: '${fileMeta.location}'"))
+          logger.error(s"Invalid file location: '$location'")
+          F.raiseError(KgError.InternalError(s"Invalid file location: '${location}'"))
       }
   }
 

--- a/delta/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperations.scala
+++ b/delta/src/main/scala/ch/epfl/bluebrain/nexus/kg/storage/RemoteDiskStorageOperations.scala
@@ -41,8 +41,8 @@ object RemoteDiskStorageOperations {
   final class Fetch[F[_]](storage: RemoteDiskStorage, client: StorageClient[F]) extends FetchFile[F, AkkaSource] {
     implicit val cred = storage.credentials.map(AccessToken)
 
-    override def apply(fileMeta: FileAttributes): F[AkkaSource] =
-      client.getFile(storage.folder, fileMeta.path)
+    override def apply(path: Uri.Path, location: Uri): F[AkkaSource] =
+      client.getFile(storage.folder, path)
 
   }
 

--- a/delta/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperationsSpec.scala
+++ b/delta/src/test/scala/ch/epfl/bluebrain/nexus/kg/storage/S3StorageOperationsSpec.scala
@@ -1,0 +1,257 @@
+package ch.epfl.bluebrain.nexus.kg.storage
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Paths
+import java.util.UUID
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.Uri
+import akka.stream.alpakka.s3.scaladsl.S3
+import akka.stream.alpakka.s3.{BucketAccess, S3Attributes}
+import akka.stream.scaladsl.{FileIO, Sink}
+import akka.stream.{Materializer, SystemMaterializer}
+import cats.effect.{ContextShift, IO, Resource}
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.iam.types.Permission
+import ch.epfl.bluebrain.nexus.kg.KgError.{DownstreamServiceError, RemoteFileNotFound}
+import ch.epfl.bluebrain.nexus.kg.resources.Id
+import ch.epfl.bluebrain.nexus.kg.resources.ProjectIdentifier.ProjectRef
+import ch.epfl.bluebrain.nexus.kg.resources.file.File.{Digest, FileAttributes, FileDescription}
+import ch.epfl.bluebrain.nexus.kg.storage.Storage.{S3Credentials, S3Settings, S3Storage}
+import ch.epfl.bluebrain.nexus.rdf.implicits._
+import ch.epfl.bluebrain.nexus.util._
+import com.typesafe.config.ConfigFactory
+import distage.ModuleDef
+import izumi.distage.docker.Docker
+import izumi.distage.docker.modules.DockerSupportModule
+import izumi.distage.effect.modules.CatsDIEffectModule
+import izumi.distage.model.definition.StandardAxis
+import izumi.distage.plugins.PluginConfig
+import izumi.distage.testkit.TestConfig
+import izumi.distage.testkit.TestConfig.ParallelLevel
+import izumi.distage.testkit.scalatest.DistageSpecScalatest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class S3StorageOperationsSpec
+    extends DistageSpecScalatest[IO]
+    with ShouldMatchers
+    with Randomness
+    with Resources
+    with DistageSpecSugar {
+
+  private val readS3     = Permission.unsafe("s3/read")
+  private val writeS3    = Permission.unsafe("s3/write")
+  private val projectRef = ProjectRef(UUID.randomUUID)
+  private val fileUuid   = UUID.randomUUID
+  private val desc       = FileDescription(fileUuid, "my s3.json", Some(`text/plain(UTF-8)`))
+  private val filePath   = "/storage/s3.json"
+  private val path       = Paths.get(getClass.getResource(filePath).toURI)
+  private val uriPath    = Uri.Path(mangle(projectRef, fileUuid, "my s3.json"))
+  private val digest     = Digest("MD5", "5d3c675f85ffb2da9a8141ccd45bd6c6")
+
+  implicit private val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  private def wrapFuture[A](future: => Future[A]): IO[A] =
+    IO.fromFuture(IO(future))
+
+  class TestFactory(port: Int)(implicit val as: ActorSystem, val mt: Materializer) {
+    val base: Uri          = s"http://${MinioDocker.virtualHost}:$port"
+    // TODO: The bucket is duplicated here due to an error on the minio response where the bucket is duplicated.
+    // I've reported it and when it is solved we should remove the duplication: https://github.com/minio/minio/issues/10054
+    val bucketBaseDup: Uri = s"http://bucket.bucket.${MinioDocker.virtualHost}:$port"
+    val bucketBase: Uri    = s"http://bucket.${MinioDocker.virtualHost}:$port"
+
+    val storage: S3Storage =
+      // format: off
+      S3Storage(projectRef, url"https://example.com", 1L, deprecated = false, default = true, "MD5", "bucket", S3Settings(Some(S3Credentials(MinioDocker.accessKey, MinioDocker.secretKey)), Some(base.toString), None), readS3, writeS3, 1024L)
+    // format: on
+
+    implicit private val attributes = S3Attributes.settings(storage.toAlpakkaSettings)
+
+    val verify = new S3StorageOperations.Verify[IO](storage)
+    val save   = new S3StorageOperations.Save[IO](storage)
+    val fetch  = new S3StorageOperations.Fetch[IO](storage)
+    val link   = new S3StorageOperations.Link[IO](storage)
+
+    def createBucket: IO[Done] =
+      wrapFuture(S3.checkIfBucketExists(storage.bucket)).flatMap {
+        case BucketAccess.NotExists => wrapFuture(S3.makeBucket(storage.bucket))
+        case _                      => IO.pure(Done)
+      }
+
+    def deleteBucket: IO[Done] =
+      wrapFuture {
+        S3.listBucket(storage.bucket, None)
+          .withAttributes(attributes)
+          .flatMapConcat { content =>
+            S3.deleteObject(storage.bucket, URLDecoder.decode(content.getKey, UTF_8.toString))
+              .withAttributes(attributes)
+          }
+          .run()
+      } >> wrapFuture(S3.deleteBucket(storage.bucket))
+
+  }
+
+  override protected def config: TestConfig =
+    TestConfig(
+      pluginConfig = PluginConfig.empty,
+      activation = StandardAxis.testDummyActivation,
+      parallelTests = ParallelLevel.Sequential,
+      moduleOverrides = new ModuleDef {
+        // add docker dependencies and override default configuration
+        include(new DockerSupportModule[IO] overridenBy new ModuleDef {
+          make[Docker.ClientConfig].from {
+            Docker.ClientConfig(
+              readTimeoutMs = 60000, // long timeout for gh actions
+              connectTimeoutMs = 500,
+              allowReuse = true,
+              useRemote = false,
+              useRegistry = true,
+              remote = None,
+              registry = None
+            )
+          }
+        })
+        include(CatsDIEffectModule)
+        include(MinioDockerModule[IO])
+
+        make[ActorSystem].fromResource {
+          val acquire = for {
+            cfg <- IO(ConfigFactory.load("test.conf").withFallback(ConfigFactory.load()))
+            as  <- IO(ActorSystem("S3StorageOperationsSpec", cfg))
+          } yield as
+          val release = (system: ActorSystem) => wrapFuture(system.terminate()) >> IO.unit
+          Resource.make(acquire)(release)
+        }
+
+        make[Materializer].from { as: ActorSystem =>
+          SystemMaterializer(as).materializer
+        }
+
+        make[TestFactory].from { (c: MinioDocker.Container, mt: Materializer, as: ActorSystem) =>
+          val port = c.availablePorts.first(MinioDocker.primaryPort)
+          new TestFactory(port.port)(as, mt)
+        }
+      },
+      configBaseName = "s3-storage-test"
+    )
+
+  "A S3StorageOperations" should {
+
+    "verify bucket exists" in { (tf: TestFactory) =>
+      for {
+        _      <- tf.createBucket
+        result <- tf.verify.apply
+        _       = result shouldEqual Right(())
+      } yield ()
+    }
+
+    "fail verifying when bucket does not exists" in { (tf: TestFactory) =>
+      import tf.as
+      val verify = new S3StorageOperations.Verify[IO](tf.storage.copy(bucket = "bucket2"))
+      for {
+        result <- verify.apply
+        _       = result shouldEqual Left("Error accessing S3 bucket 'bucket2': The specified bucket does not exist")
+      } yield ()
+    }
+
+    "save file" in { (tf: TestFactory) =>
+      val resid = Id(projectRef, url"http://example.com/id")
+      val loc   = Uri(s"${tf.bucketBaseDup}/$uriPath")
+
+      for {
+        attr <- tf.save(resid, desc, FileIO.fromPath(path))
+        _     = attr shouldEqual FileAttributes(fileUuid, loc, uriPath, "my s3.json", `text/plain(UTF-8)`, 263L, digest)
+      } yield ()
+    }
+
+    "fail saving when bucket does not exists" in { (tf: TestFactory) =>
+      import tf.as
+      val resid       = Id(projectRef, url"http://example.com/id")
+      val save        = new S3StorageOperations.Save[IO](tf.storage.copy(bucket = "bucket2"))
+      val expectedErr =
+        "Error uploading S3 object with filename 'my s3.json' in bucket 'bucket2': The specified bucket does not exist"
+
+      for {
+        _ <- save(resid, desc, FileIO.fromPath(path)).passWhenError(DownstreamServiceError(expectedErr))
+      } yield ()
+    }
+
+    "download file" in { (tf: TestFactory) =>
+      import tf.mt
+      val loc = Uri(s"${tf.bucketBaseDup}/$uriPath")
+
+      for {
+        downloaded     <- tf.fetch(uriPath, loc)
+        downloadedByte <- wrapFuture(downloaded.runWith(Sink.head))
+        _               = downloadedByte.decodeString(UTF_8) shouldEqual contentOf(filePath)
+      } yield ()
+    }
+
+    "fail downloading a file that does not exists" in { (tf: TestFactory) =>
+      val nonExistPath = Uri.Path(mangle(projectRef, fileUuid, "nonexists.json"))
+      val loc          = Uri(s"${tf.bucketBaseDup}/$nonExistPath")
+
+      for {
+        _ <- tf.fetch(nonExistPath, loc).passWhenError(RemoteFileNotFound(loc))
+      } yield ()
+
+    }
+
+    "fail downloading when bucket does not exists" in { (tf: TestFactory) =>
+      import tf.as
+      val fetch       = new S3StorageOperations.Fetch[IO](tf.storage.copy(bucket = "bucket2"))
+      val loc         = Uri(s"${tf.bucketBaseDup}/$uriPath")
+      val expectedErr =
+        s"Error fetching S3 object with key '$uriPath' in bucket 'bucket2': The specified bucket does not exist"
+
+      for {
+        _ <- fetch(uriPath, loc).passWhenError(DownstreamServiceError(expectedErr))
+      } yield ()
+    }
+
+    "link file" in { (tf: TestFactory) =>
+      val resid = Id(projectRef, url"http://example.com/linked/id")
+      val loc   = Uri(s"${tf.bucketBase}/$uriPath")
+
+      for {
+        attr <- tf.link(resid, FileDescription(fileUuid, "file.json", Some(`text/plain(UTF-8)`)), uriPath)
+        _     = attr shouldEqual FileAttributes(fileUuid, loc, uriPath, "file.json", `text/plain(UTF-8)`, 263L, digest)
+      } yield ()
+    }
+
+    "fail linking a file that does not exists" in { (tf: TestFactory) =>
+      val resid        = Id(projectRef, url"http://example.com/linked/id")
+      val nonExistPath = Uri.Path(mangle(projectRef, fileUuid, "nonexists.json"))
+      val loc          = Uri(s"${tf.bucketBase}/$nonExistPath")
+
+      for {
+        _ <- tf.link(resid, FileDescription(fileUuid, "nonexists.json", Some(`text/plain(UTF-8)`)), nonExistPath)
+               .passWhenError(RemoteFileNotFound(loc))
+      } yield ()
+    }
+
+    "fail linking when bucket does not exists" in { (tf: TestFactory) =>
+      import tf.as
+      val link        = new S3StorageOperations.Link[IO](tf.storage.copy(bucket = "bucket2"))
+      val resid       = Id(projectRef, url"http://example.com/linked/id")
+      val expectedErr =
+        s"Error fetching S3 object with key '$uriPath' in bucket 'bucket2': The specified bucket does not exist"
+
+      for {
+        _ <- link(resid, FileDescription(fileUuid, "file.json", Some(`text/plain(UTF-8)`)), uriPath)
+               .passWhenError(DownstreamServiceError(expectedErr))
+      } yield ()
+    }
+
+    "cleanup" in { (tf: TestFactory) =>
+      for {
+        _ <- tf.deleteBucket
+      } yield ()
+    }
+  }
+}

--- a/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/DistageModuleDef.scala
+++ b/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/DistageModuleDef.scala
@@ -1,0 +1,42 @@
+package ch.epfl.bluebrain.nexus.util
+
+import akka.actor.ActorSystem
+import akka.stream.{Materializer, SystemMaterializer}
+import cats.effect.{ContextShift, IO, Resource}
+import cats.implicits._
+import com.typesafe.config.ConfigFactory
+import distage.ModuleDef
+import izumi.distage.docker.Docker
+import izumi.distage.docker.modules.DockerSupportModule
+import izumi.distage.effect.modules.CatsDIEffectModule
+
+abstract class DistageModuleDef(name: String)(implicit context: ContextShift[IO]) extends ModuleDef {
+  // add docker dependencies and override default configuration
+  include(new DockerSupportModule[IO] overridenBy new ModuleDef {
+    make[Docker.ClientConfig].from {
+      Docker.ClientConfig(
+        readTimeoutMs = 60000, // long timeout for gh actions
+        connectTimeoutMs = 500,
+        allowReuse = true,
+        useRemote = false,
+        useRegistry = true,
+        remote = None,
+        registry = None
+      )
+    }
+  })
+  include(CatsDIEffectModule)
+
+  make[ActorSystem].fromResource {
+    val acquire = for {
+      cfg <- IO(ConfigFactory.load("test.conf").withFallback(ConfigFactory.load()))
+      as  <- IO(ActorSystem(name, cfg))
+    } yield as
+    val release = (system: ActorSystem) => IO.fromFuture(IO(system.terminate())) >> IO.unit
+    Resource.make(acquire)(release)
+  }
+
+  make[Materializer].from { as: ActorSystem =>
+    SystemMaterializer(as).materializer
+  }
+}

--- a/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/DistageSpecSugar.scala
+++ b/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/DistageSpecSugar.scala
@@ -1,0 +1,35 @@
+package ch.epfl.bluebrain.nexus.util
+
+import cats.effect.IO
+
+import scala.reflect.ClassTag
+
+trait DistageSpecSugar {
+  implicit final def circeJsonSyntax[A](io: IO[A]): DistageSpecOps[A] = new DistageSpecOps(io)
+}
+final class DistageSpecOps[A](private val io: IO[A]) extends AnyVal {
+
+  /**
+    * Redeem the IO when it raises an error with the passed value.
+    */
+  def passWhenError[Ex <: Throwable](value: => Ex): IO[Unit] =
+    io.redeemWith(
+      {
+        case th if th == value => IO.unit
+        case th                => IO.raiseError(new RuntimeException("Received unexpected error", th))
+      },
+      _ => IO.raiseError(new RuntimeException(s"Expected error '$value'"))
+    )
+
+  /**
+    * Redeem the IO when it raises an error on the type ''Ex''.
+    */
+  def passWhenErrorType[Ex <: Throwable](implicit Ex: ClassTag[Ex]): IO[Unit] =
+    io.redeemWith(
+      {
+        case Ex(_) => IO.unit
+        case th    => IO.raiseError(new RuntimeException("Received unexpected error", th))
+      },
+      _ => IO.raiseError(new RuntimeException(s"Expected error of type '${Ex.runtimeClass.getCanonicalName}'"))
+    )
+}

--- a/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/MinioDocker.scala
+++ b/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/MinioDocker.scala
@@ -13,7 +13,7 @@ object MinioDocker extends ContainerDef with Randomness {
 
   override def config: Config = {
     Config(
-      image = "minio/minio:latest",
+      image = "minio/minio:RELEASE.2020-07-14T19-14-30Z",
       ports = Seq(primaryPort),
       healthCheck = ContainerHealthCheck.httpGetCheck(primaryPort),
       env = Map(

--- a/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/MinioDocker.scala
+++ b/delta/src/test/scala/ch/epfl/bluebrain/nexus/util/MinioDocker.scala
@@ -1,0 +1,38 @@
+package ch.epfl.bluebrain.nexus.util
+
+import distage.{ModuleDef, TagK}
+import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.Docker.DockerPort
+import izumi.distage.docker.healthcheck.ContainerHealthCheck
+
+object MinioDocker extends ContainerDef with Randomness {
+  val primaryPort: DockerPort = DockerPort.TCP(9000)
+  val accessKey               = "my_key"
+  val secretKey               = "my_secret_key"
+  val virtualHost             = "my-domain.com"
+
+  override def config: Config = {
+    Config(
+      image = "minio/minio:latest",
+      ports = Seq(primaryPort),
+      healthCheck = ContainerHealthCheck.httpGetCheck(primaryPort),
+      env = Map(
+        "MINIO_ACCESS_KEY"  -> accessKey,
+        "MINIO_SECRET_KEY"  -> secretKey,
+        "MINIO_DOMAIN"      -> virtualHost,
+        "MINIO_REGION_NAME" -> "aws-global"
+      ),
+      cmd = List("server", sys.props.get("java.io.tmpdir").getOrElse("/tmp"))
+    )
+  }
+}
+
+class MinioDockerModule[F[_]: TagK] extends ModuleDef {
+  make[MinioDocker.Container].fromResource {
+    MinioDocker.make[F]
+  }
+}
+
+object MinioDockerModule {
+  def apply[F[_]: TagK]: MinioDockerModule[F] = new MinioDockerModule[F]
+}


### PR DESCRIPTION
Fixes #1251 

This fix is necessary due to the [deprecation of path-styles on S3](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/).

It uses Minio in a docker container which is triggered during Unit Tests. Notice that the to run this locally you'll have to run the following commands:
```
          echo "127.0.0.1 bucket.my-domain.com" | sudo tee -a /etc/hosts
          echo "127.0.0.1 bucket2.my-domain.com" | sudo tee -a /etc/hosts
```