### PR TITLE
Enable pubsub for event-by-tag queries

### DIFF
--- a/delta/src/main/resources/akka.conf
+++ b/delta/src/main/resources/akka.conf
@@ -199,7 +199,8 @@ akka {
         keyspace = ${akka.persistence.cassandra.journal.keyspace}"_snapshot"
       }
       query {
-        refresh-interval = 3s
+        refresh-interval = 30s
+        refresh-interval = ${?override.refresh.interval}
       }
       events-by-tag {
         first-time-bucket = "20181213T00:00"
@@ -223,6 +224,20 @@ akka {
         # avoid unecessary load. The tag_scanning table keeps track of a starting point for tag
         # scanning during recovery of persistent actor.
         scanning-flush-interval = 30s
+
+        # Enable DistributedPubSub to announce events for a specific tag have
+        # been written. These announcements cause any ongoing getEventsByTag to immediately re-poll, rather than
+        # wait. In order enable this feature, make the following settings:
+        #
+        #    - enable clustering for your actor system
+        #    - akka.persistence.cassandra.pubsub-notification=on              (send real-time announcements at most every sec)
+        #
+        # Setting pubsub-notification to "off" will disable the journal sending these announcements.
+        # When enabled with `on` it will throttle the number of notfication messages per tag to at most 10 per second.
+        # Alternatively a duration can be defined, such as pubsub-notification=300ms, which will be throttling interval
+        # for sending the notifications.
+        pubsub-notification = 2s
+        pubsub-notification = ${?override.pubsub.notification}
       }
     }
   }


### PR DESCRIPTION
Enable pubsub and increase the poll interval to limit the load on Cassandra 
#1304