### PR TITLE
Fix CLI global events route.

### DIFF
--- a/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/EnvConfig.scala
+++ b/cli/src/main/scala/ch/epfl/bluebrain/nexus/cli/config/EnvConfig.scala
@@ -54,7 +54,7 @@ final case class EnvConfig(
     * Computes the events endpoint.
     */
   def eventsUri: Uri =
-    endpoint / "events"
+    endpoint / "resources" / "events"
 
   /**
     * Computes the events endpoint from the arguments.

--- a/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/clients/EventStreamClientSpec.scala
+++ b/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/clients/EventStreamClientSpec.scala
@@ -52,10 +52,10 @@ class EventStreamClientSpec extends AbstractCliSpec with Http4sExtras with Optio
         val token   = cfg.env.token
         val httpApp = HttpApp[IO] {
           // global events with offset
-          case GET -> `v1` / "events" optbearer `token` lastEventId offset                                         =>
+          case GET -> `v1` / "resources" / "events" optbearer `token` lastEventId offset                           =>
             Response[IO](Status.Ok).withEntity(streamFor(Some(offset))).pure[IO]
           // global events
-          case GET -> `v1` / "events" optbearer `token`                                                            =>
+          case GET -> `v1` / "resources" / "events" optbearer `token`                                              =>
             Response[IO](Status.Ok).withEntity(streamFor(None)).pure[IO]
           // org events with offset
           case GET -> `v1` / "resources" / OrgLabelVar(`orgLabel`) / "events" optbearer `token` lastEventId offset =>


### PR DESCRIPTION
`/events` route now includes Admin and IAM events, so CLI should use `/resources/events` routes.