### PR TITLE
Added Akka HTTP Marshalling support using JsonLdEncoder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -404,7 +404,9 @@ lazy val app = project
   .dependsOn(sourcing, rdf, sdk, sdkTestkit, service, testkit % "test->compile", sdkTestkit % "test->compile")
   .settings(
     libraryDependencies ++= Seq(
-      scalaTest % Test
+      akkaHttpTestKit % Test,
+      akkaTestKit     % Test,
+      scalaTest       % Test
     )
   )
 

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/DeltaMarshalling.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/DeltaMarshalling.scala
@@ -1,0 +1,53 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.model.{ContentType, HttpEntity}
+import akka.util.ByteString
+import ch.epfl.bluebrain.nexus.delta.RdfMediaTypes._
+import ch.epfl.bluebrain.nexus.delta.rdf.graph.{Dot, NTriples}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import io.circe.Printer
+
+/**
+  * Marshallings that allow Akka Http to convert a type ''A'' to an [[HttpEntity]].
+  */
+trait DeltaMarshalling {
+
+  private val defaultPrinter: Printer = Printer(dropNullValues = true, indent = "")
+
+  /**
+    * JsonLd -> HttpEntity
+    */
+  implicit def jsonLdMarshaller[A <: JsonLd](implicit
+      ordering: JsonKeyOrdering,
+      printer: Printer = defaultPrinter
+  ): ToEntityMarshaller[A] =
+    Marshaller.withFixedContentType(ContentType(`application/ld+json`)) { jsonLd =>
+      HttpEntity(
+        `application/ld+json`,
+        ByteString(printer.printToByteBuffer(jsonLd.json.sort, `application/ld+json`.charset.nioCharset()))
+      )
+    }
+
+  /**
+    * NTriples -> HttpEntity
+    */
+  implicit val ntriplesMarshaller: ToEntityMarshaller[NTriples] =
+    Marshaller.withFixedContentType(ContentType(`application/n-triples`)) {
+      case NTriples(value, _) =>
+        HttpEntity(`application/n-triples`, value)
+    }
+
+  /**
+    * Dot -> HttpEntity
+    */
+  implicit val dotMarshaller: ToEntityMarshaller[Dot] =
+    Marshaller.withFixedContentType(ContentType(`application/vnd.graphviz`)) {
+      case Dot(value, _) =>
+        HttpEntity(`application/vnd.graphviz`, value)
+    }
+}
+
+object DeltaMarshalling extends DeltaMarshalling

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/DeltaRouteDirectives.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/DeltaRouteDirectives.scala
@@ -1,0 +1,157 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.model.{MediaType, StatusCode}
+import akka.http.scaladsl.server.ContentNegotiator.Alternative
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import ch.epfl.bluebrain.nexus.delta.RdfMediaTypes._
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import monix.bio.{IO, UIO}
+import monix.execution.Scheduler
+
+trait DeltaDirectives {
+
+  private val mediaTypes =
+    Seq(`application/ld+json`, `application/n-triples`, `application/vnd.graphviz`)
+
+  /**
+    * Extracts the [[JsonLdFormat]] from the ''format'' query parameter
+    */
+  private def jsonLdFormat: Directive1[JsonLdFormat] =
+    parameter("format".?).flatMap {
+      case Some("compacted") => provide(JsonLdFormat.Compacted)
+      case Some("expanded")  => provide(JsonLdFormat.Expanded)
+      case Some(other)       => reject(InvalidRequiredValueForQueryParamRejection("format", "compacted|expanded", other))
+      case None              => provide(JsonLdFormat.Compacted)
+    }
+
+  /**
+    * Converts the passed value wrapped in an [[UIO]] to the appropriate [[JsonLdFormat]] depending on the ''format'' query param.
+    *
+    * @param io            the value to convert to JSON-LD wrapped on an [[IO]]
+    * @param successStatus the status code to return
+    * @return a [[JsonLd]] with its status code wrapped on an [[IO]]
+    */
+  def jsonldFormat[A: JsonLdEncoder](
+      io: UIO[A],
+      successStatus: => StatusCode
+  )(implicit cr: RemoteContextResolution): Directive1[IO[RdfError, (StatusCode, JsonLd)]] =
+    jsonLdFormat.map {
+      case JsonLdFormat.Compacted => io.flatMap(_.toCompactedJsonLd).map(v => successStatus -> v)
+      case JsonLdFormat.Expanded  => io.flatMap(_.toExpandedJsonLd).map(v => successStatus -> v)
+    }
+
+  /**
+    * Converts the passed value wrapped in an [[IO]] to the appropriate [[JsonLdFormat]] depending on the ''format'' query param.
+    * The error channel and the regular channel are converted to [[JsonLd]] with their respective status codes
+    *
+    * @param io            the value to convert to JSON-LD wrapped on an [[IO]]
+    * @param successStatus the status code to return when the IO is successful
+    * @return a [[JsonLd]] with its status code wrapped on an [[IO]]
+    */
+  def jsonldFormat[A: JsonLdEncoder, E: JsonLdEncoder](
+      io: IO[E, A],
+      successStatus: => StatusCode
+  )(implicit cr: RemoteContextResolution, statusFrom: StatusFrom[E]): Directive1[IO[RdfError, (StatusCode, JsonLd)]] =
+    jsonLdFormat.map {
+      case JsonLdFormat.Compacted =>
+        io.attempt.flatMap {
+          case Left(err)    => err.toCompactedJsonLd.map(v => statusFrom(err) -> v)
+          case Right(value) => value.toCompactedJsonLd.map(v => successStatus -> v)
+        }
+      case JsonLdFormat.Expanded  =>
+        io.attempt.flatMap {
+          case Left(err)    => err.toExpandedJsonLd.map(v => statusFrom(err) -> v)
+          case Right(value) => value.toExpandedJsonLd.map(v => successStatus -> v)
+        }
+    }
+
+  /**
+    * Extracts the first mediaType found in the ''Accept'' Http request header that matches the delta service ''mediaTypes''.
+    * If the Accept header does not match any of the service supported ''mediaTypes'',
+    * an [[UnacceptedResponseContentTypeRejection]] is returned
+    */
+  def requestMediaType: Directive1[MediaType] =
+    extractRequest.flatMap { req =>
+      val ct = new MediaTypeNegotiator(req.headers)
+      ct.acceptedMediaRanges.foldLeft[Option[MediaType]](None) {
+        case (s @ Some(_), _) => s
+        case (None, mr)       => mediaTypes.find(mt => mr.matches(mt))
+      } match {
+        case Some(value) => provide(value)
+        case None        => reject(UnacceptedResponseContentTypeRejection(mediaTypes.map(mt => Alternative(mt)).toSet))
+      }
+    }
+}
+
+object DeltaDirectives extends DeltaDirectives
+
+trait DeltaRouteDirectives extends DeltaDirectives with DeltaMarshalling {
+
+  private val jsonMediaTypes =
+    Seq(`application/ld+json`, `application/json`)
+
+  /**
+    * Completes a passed [[UIO]] of ''A'' with the desired output format using the implicitly available [[JsonLdEncoder]].
+    *
+    * @param status the returned HTTP status code
+    * @param io     the value to be returned, wrapped in an [[UIO]]
+    */
+  def completeUIO[A: JsonLdEncoder](
+      status: StatusCode,
+      io: UIO[A]
+  )(implicit s: Scheduler, cr: RemoteContextResolution, ordering: JsonKeyOrdering): Route =
+    requestMediaType {
+      case mediaType if jsonMediaTypes.contains(mediaType)   =>
+        jsonldFormat(io, status).apply { formatted =>
+          onSuccess(formatted.runToFuture) { (status, jsonLd) => complete(status, jsonLd) }
+        }
+
+      case mediaType if mediaType == `application/n-triples` =>
+        val f = io.flatMap(_.toNTriples).map(a => status -> a).runToFuture
+        onSuccess(f) { (status, ntriples) => complete(status, ntriples) }
+
+      case _                                                 => // `application/vnd.graphviz`
+        val f = io.flatMap(_.toDot).map(a => status -> a).runToFuture
+        onSuccess(f) { (status, dot) => complete(status, dot) }
+    }
+
+  /**
+    * Completes a passed [[IO]] of ''E'' and ''A'' with the desired output format using the implicitly available [[JsonLdEncoder]].
+    * Both error channel and normal channel are converted to the desired output format.
+    *
+    * @param status the returned HTTP status code
+    * @param io     the value to be returned, wrapped in an [[IO]]
+    */
+  def completeIO[E: JsonLdEncoder, A: JsonLdEncoder](
+      status: StatusCode,
+      io: IO[E, A]
+  )(implicit s: Scheduler, statusFrom: StatusFrom[E], cr: RemoteContextResolution, ordering: JsonKeyOrdering): Route =
+    requestMediaType {
+      case mediaType if jsonMediaTypes.contains(mediaType)   =>
+        jsonldFormat(io, status).apply { formatted =>
+          onSuccess(formatted.runToFuture) { (status, jsonLd) => complete(status, jsonLd) }
+        }
+
+      case mediaType if mediaType == `application/n-triples` =>
+        val formatted = io.attempt.flatMap {
+          case Left(value)  => value.toNTriples.map(a => statusFrom(value) -> a)
+          case Right(value) => value.toNTriples.map(a => status -> a)
+        }
+        onSuccess(formatted.runToFuture) { (status, ntriples) => complete(status, ntriples) }
+
+      case _                                                 => // `application/vnd.graphviz`
+        val formatted = io.attempt.flatMap {
+          case Left(value)  => value.toDot.map(a => statusFrom(value) -> a)
+          case Right(value) => value.toDot.map(a => status -> a)
+        }
+        onSuccess(formatted.runToFuture) { (status, dot) => complete(status, dot) }
+    }
+}
+
+object DeltaRouteDirectives extends DeltaRouteDirectives

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/JsonLdFormat.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/JsonLdFormat.scala
@@ -1,0 +1,19 @@
+package ch.epfl.bluebrain.nexus.delta
+
+/**
+  * Enumeration of allowed Json-LD output formats on the service
+  */
+sealed trait JsonLdFormat extends Product with Serializable
+
+object JsonLdFormat {
+
+  /**
+    * Expanded JSON-LD output format as defined in https://www.w3.org/TR/json-ld-api/#expansion-algorithms
+    */
+  final case object Expanded extends JsonLdFormat
+
+  /**
+    * Compacted JSON-LD output format as defined in https://www.w3.org/TR/json-ld-api/#compaction-algorithms
+    */
+  final case object Compacted extends JsonLdFormat
+}

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/StatusFrom.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/StatusFrom.scala
@@ -1,0 +1,82 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.TokenRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.PermissionsRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.realms.RealmRejection
+
+/**
+  * Typeclass definition for ''A''s that can be mapped into a StatusCode.
+  *
+ * @tparam A generic type parameter
+  */
+trait StatusFrom[A] {
+
+  /**
+    * Computes a [[StatusCode]] instance from the argument value.
+    *
+   * @param value the input value
+    * @return the status code corresponding to the value
+    */
+  def apply(value: A): StatusCode
+}
+
+// $COVERAGE-OFF$
+object StatusFrom {
+
+  /**
+    * Lifts a function ''A => StatusCode'' into a ''StatusFrom[A]'' instance.
+    *
+    * @param f function from A to StatusCode
+    * @tparam A type parameter to map to StatusCode
+    * @return a ''StatusFrom'' instance from the argument function
+    */
+  def apply[A](f: A => StatusCode): StatusFrom[A] = (value: A) => f(value)
+
+  implicit val statusFromPermissions: StatusFrom[PermissionsRejection] = StatusFrom {
+    case PermissionsRejection.IncorrectRev(_, _)     => StatusCodes.Conflict
+    case PermissionsRejection.RevisionNotFound(_, _) => StatusCodes.NotFound
+    case _                                           => StatusCodes.BadRequest
+  }
+
+  implicit val statusFromAcls: StatusFrom[AclRejection] = StatusFrom {
+    case AclRejection.AclNotFound(_)            => StatusCodes.NotFound
+    case AclRejection.IncorrectRev(_, _, _)     => StatusCodes.Conflict
+    case AclRejection.RevisionNotFound(_, _)    => StatusCodes.NotFound
+    case AclRejection.UnexpectedInitialState(_) => StatusCodes.InternalServerError
+    case _                                      => StatusCodes.BadRequest
+  }
+
+  implicit val statusFromIdentities: StatusFrom[TokenRejection] = StatusFrom { _ =>
+    StatusCodes.Unauthorized
+  }
+
+  implicit val statusFromRealms: StatusFrom[RealmRejection] = StatusFrom {
+    case RealmRejection.RevisionNotFound(_, _)    => StatusCodes.NotFound
+    case RealmRejection.RealmNotFound(_)          => StatusCodes.NotFound
+    case RealmRejection.IncorrectRev(_, _)        => StatusCodes.Conflict
+    case RealmRejection.UnexpectedInitialState(_) => StatusCodes.InternalServerError
+    case _                                        => StatusCodes.BadRequest
+  }
+
+  implicit val statusFromOrganizations: StatusFrom[OrganizationRejection] = StatusFrom {
+    case OrganizationRejection.OrganizationNotFound(_) => StatusCodes.NotFound
+    case OrganizationRejection.IncorrectRev(_, _)      => StatusCodes.Conflict
+    case OrganizationRejection.RevisionNotFound(_, _)  => StatusCodes.NotFound
+    //case OrganizationRejection.UnexpectedInitialState(_) => StatusCodes.InternalServerError
+    case _                                             => StatusCodes.BadRequest
+  }
+
+  implicit val statusFromProjects: StatusFrom[ProjectRejection] = StatusFrom {
+    case ProjectRejection.RevisionNotFound(_, _)  => StatusCodes.NotFound
+    case ProjectRejection.ProjectNotFound(_)      => StatusCodes.NotFound
+    case ProjectRejection.OrganizationNotFound(_) => StatusCodes.NotFound
+    case ProjectRejection.IncorrectRev(_, _)      => StatusCodes.Conflict
+    //case ProjectRejection.UnexpectedInitialState(_) => StatusCodes.InternalServerError
+    case _                                        => StatusCodes.BadRequest
+  }
+}
+// $COVERAGE-ON$

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/DeltaMarshallingSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/DeltaMarshallingSpec.scala
@@ -1,0 +1,80 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import java.time.Instant
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model._
+import akka.testkit.TestKit
+import ch.epfl.bluebrain.nexus.delta.RdfMediaTypes._
+import ch.epfl.bluebrain.nexus.delta.SimpleResource.{context, contextIri}
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.delta.sdk.testkit.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.utils.RouteHelpers
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestMatchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.ExecutionContext
+
+class DeltaMarshallingSpec
+    extends TestKit(ActorSystem("DeltaMarshallingSpec"))
+    with AnyWordSpecLike
+    with Matchers
+    with CirceLiteral
+    with DeltaMarshalling
+    with IOValues
+    with RouteHelpers
+    with TestMatchers {
+
+  implicit private val ec: ExecutionContext              = system.dispatcher
+  implicit private val rcr: RemoteContextResolutionDummy = RemoteContextResolutionDummy(contextIri -> context)
+  implicit private val ordering: JsonKeyOrdering         = JsonKeyOrdering(List("@context", "@id"), List("_rev", "_createdAt"))
+
+  private val id       = nxv + "myresource"
+  private val resource = SimpleResource(id, 1L, Instant.EPOCH, "Maria", 20)
+
+  "Converting JsonLd into an HttpResponse" should {
+    val compacted = resource.toCompactedJsonLd.accepted
+    val expanded  = resource.toExpandedJsonLd.accepted
+
+    "succeed as compacted form" in {
+      val response = Marshal(StatusCodes.OK -> compacted).to[HttpResponse].futureValue
+      response.status shouldEqual StatusCodes.OK
+      response.asJson shouldEqual compacted.json
+      response.entity.contentType shouldEqual `application/ld+json`.toContentType
+    }
+
+    "succeed as expanded form" in {
+      val response = Marshal(StatusCodes.OK -> expanded).to[HttpResponse].futureValue
+      response.status shouldEqual StatusCodes.OK
+      response.asJson shouldEqual expanded.json
+      response.entity.contentType shouldEqual `application/ld+json`.toContentType
+    }
+  }
+
+  "Converting Dot into an HttpResponse" should {
+    val dot = resource.toDot.accepted
+
+    "succeed" in {
+      val response = Marshal(StatusCodes.OK -> dot).to[HttpResponse].futureValue
+      response.status shouldEqual StatusCodes.OK
+      response.asString should equalLinesUnordered(dot.value)
+      response.entity.contentType shouldEqual `application/vnd.graphviz`.toContentType
+    }
+  }
+
+  "Converting NTriples into an HttpResponse" should {
+    val ntriples = resource.toNTriples.accepted
+
+    "succeed" in {
+      val response = Marshal(StatusCodes.OK -> ntriples).to[HttpResponse].futureValue
+      response.status shouldEqual StatusCodes.OK
+      response.asString should equalLinesUnordered(ntriples.value)
+      response.entity.contentType shouldEqual `application/n-triples`.toContentType
+    }
+  }
+
+}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/DeltaRouteDirectivesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/DeltaRouteDirectivesSpec.scala
@@ -1,0 +1,203 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import java.time.Instant
+
+import akka.http.scaladsl.model.MediaRanges.{`*/*`, `application/*`, `audio/*`}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{InvalidRequiredValueForQueryParamRejection, Route, UnacceptedResponseContentTypeRejection}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.epfl.bluebrain.nexus.delta.RdfMediaTypes._
+import ch.epfl.bluebrain.nexus.delta.SimpleRejection.{badRequestRejection, conflictRejection}
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.delta.sdk.testkit.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.utils.RouteHelpers
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestMatchers}
+import monix.bio.{IO, UIO}
+import monix.execution.Scheduler
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class DeltaRouteDirectivesSpec
+    extends AnyWordSpecLike
+    with ScalatestRouteTest
+    with Matchers
+    with CirceLiteral
+    with DeltaRouteDirectives
+    with IOValues
+    with RouteHelpers
+    with TestMatchers
+    with Inspectors {
+
+  implicit private val rcr: RemoteContextResolutionDummy =
+    RemoteContextResolutionDummy(
+      SimpleResource.contextIri  -> SimpleResource.context,
+      SimpleRejection.contextIri -> SimpleRejection.context
+    )
+
+  implicit private val ordering: JsonKeyOrdering = JsonKeyOrdering(List("@context", "@id"), List("_rev", "_createdAt"))
+  implicit private val s: Scheduler              = Scheduler.global
+
+  private val id       = nxv + "myresource"
+  private val resource = SimpleResource(id, 1L, Instant.EPOCH, "Maria", 20)
+
+  private val route: Route =
+    get {
+      concat(
+        path("uio") {
+          completeUIO(StatusCodes.Accepted, UIO.pure(resource))
+        },
+        path("io") {
+          completeIO(StatusCodes.Accepted, IO.fromEither[SimpleRejection, SimpleResource](Right(resource)))
+        },
+        path("bad-request") {
+          completeIO(StatusCodes.Accepted, IO.fromEither[SimpleRejection, SimpleResource](Left(badRequestRejection)))
+        },
+        path("conflict") {
+          completeIO(StatusCodes.Accepted, IO.fromEither[SimpleRejection, SimpleResource](Left(conflictRejection)))
+        }
+      )
+    }
+
+  "A route" should {
+
+    "return payload in compacted JSON-LD format" in {
+      val compacted = resource.toCompactedJsonLd.accepted
+
+      forAll(List("/uio?format=compacted", "/uio", "/io?format=compacted", "/io")) { endpoint =>
+        forAll(List(Accept(`*/*`), Accept(`application/*`, `application/ld+json`))) { accept =>
+          Get(endpoint) ~> accept ~> route ~> check {
+            response.asJson shouldEqual compacted.json
+            response.status shouldEqual StatusCodes.Accepted
+          }
+        }
+      }
+    }
+
+    "return payload in expanded JSON-LD format" in {
+      val expanded = resource.toExpandedJsonLd.accepted
+
+      forAll(List("/uio?format=expanded", "/io?format=expanded")) { endpoint =>
+        forAll(List(Accept(`*/*`), Accept(`application/*`, `application/ld+json`))) { accept =>
+          Get(endpoint) ~> accept ~> route ~> check {
+            response.asJson shouldEqual expanded.json
+            response.status shouldEqual StatusCodes.Accepted
+          }
+        }
+      }
+    }
+
+    "return payload in Dot format" in {
+      val dot = resource.toDot.accepted
+
+      forAll(List("/uio", "/io")) { endpoint =>
+        Get(endpoint) ~> Accept(`application/vnd.graphviz`) ~> route ~> check {
+          response.asString should equalLinesUnordered(dot.value)
+          response.status shouldEqual StatusCodes.Accepted
+        }
+      }
+    }
+
+    "return payload in NTriples format" in {
+      val ntriples = resource.toNTriples.accepted
+
+      forAll(List("/uio", "/io")) { endpoint =>
+        Get(endpoint) ~> Accept(`application/n-triples`) ~> route ~> check {
+          response.asString should equalLinesUnordered(ntriples.value)
+          response.status shouldEqual StatusCodes.Accepted
+        }
+      }
+    }
+
+    "return rejection payload in compacted JSON-LD format" in {
+      val badRequestCompacted = badRequestRejection.toCompactedJsonLd.accepted
+      val conflictCompacted   = conflictRejection.toCompactedJsonLd.accepted
+
+      forAll(List("/bad-request?format=compacted", "/bad-request")) { endpoint =>
+        forAll(List(Accept(`*/*`), Accept(`application/*`, `application/ld+json`))) { accept =>
+          Get(endpoint) ~> accept ~> route ~> check {
+            response.asJson shouldEqual badRequestCompacted.json
+            response.status shouldEqual StatusCodes.BadRequest
+          }
+        }
+      }
+
+      forAll(List("/conflict?format=compacted", "/conflict")) { endpoint =>
+        forAll(List(Accept(`*/*`), Accept(`application/*`, `application/ld+json`))) { accept =>
+          Get(endpoint) ~> accept ~> route ~> check {
+            response.asJson shouldEqual conflictCompacted.json
+            response.status shouldEqual StatusCodes.Conflict
+          }
+        }
+      }
+    }
+
+    "return rejection payload in expanded JSON-LD format" in {
+      val badRequestExpanded = badRequestRejection.toExpandedJsonLd.accepted
+      val conflictExpanded   = conflictRejection.toExpandedJsonLd.accepted
+
+      forAll(List(Accept(`*/*`), Accept(`application/*`, `application/ld+json`))) { accept =>
+        Get("/bad-request?format=expanded") ~> accept ~> route ~> check {
+          response.asJson shouldEqual badRequestExpanded.json
+          response.status shouldEqual StatusCodes.BadRequest
+        }
+      }
+
+      forAll(List(Accept(`*/*`), Accept(`application/*`, `application/ld+json`))) { accept =>
+        Get("/conflict?format=expanded") ~> accept ~> route ~> check {
+          response.asJson shouldEqual conflictExpanded.json
+          response.status shouldEqual StatusCodes.Conflict
+        }
+      }
+    }
+
+    "return rejection payload in Dot format" in {
+      Get("/bad-request") ~> Accept(`application/vnd.graphviz`) ~> route ~> check {
+        val dot = badRequestRejection.toDot.accepted
+        response.asString should equalLinesUnordered(dot.value)
+        response.status shouldEqual StatusCodes.BadRequest
+      }
+
+      Get("/conflict") ~> Accept(`application/vnd.graphviz`) ~> route ~> check {
+        val dot = conflictRejection.toDot.accepted
+        response.asString should equalLinesUnordered(dot.value)
+        response.status shouldEqual StatusCodes.Conflict
+      }
+    }
+
+    "return rejection payload in NTriples format" in {
+      Get("/bad-request") ~> Accept(`application/n-triples`) ~> route ~> check {
+        val ntriples = badRequestRejection.toNTriples.accepted
+        response.asString should equalLinesUnordered(ntriples.value)
+        response.status shouldEqual StatusCodes.BadRequest
+      }
+
+      Get("/conflict") ~> Accept(`application/n-triples`) ~> route ~> check {
+        val ntriples = conflictRejection.toNTriples.accepted
+        response.asString should equalLinesUnordered(ntriples.value)
+        response.status shouldEqual StatusCodes.Conflict
+      }
+    }
+
+    "reject when unaccepted Accept Header provided" in {
+      forAll(List("/uio", "/io")) { endpoint =>
+        Get(endpoint) ~> Accept(`audio/*`) ~> route ~> check {
+          rejection shouldBe a[UnacceptedResponseContentTypeRejection]
+        }
+      }
+    }
+
+    "reject when invalid query parameter provided" in {
+      forAll(List("/uio?format=fake", "/io?format=fake")) { endpoint =>
+        Get(endpoint) ~> Accept(`*/*`) ~> route ~> check {
+          rejection shouldBe a[InvalidRequiredValueForQueryParamRejection]
+        }
+      }
+    }
+  }
+
+}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/SimpleRejection.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/SimpleRejection.scala
@@ -1,0 +1,57 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import akka.http.scaladsl.model.StatusCodes
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.CirceLiteral
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+import monix.bio.IO
+
+import scala.annotation.nowarn
+
+sealed trait SimpleRejection {
+  def reason: String
+}
+
+object SimpleRejection extends CirceLiteral {
+
+  final case class BadRequestRejection(reason: String) extends SimpleRejection
+  final case class ConflictRejection(reason: String)   extends SimpleRejection
+
+  final val conflictRejection: SimpleRejection   = ConflictRejection("default conflict rejection")
+  final val badRequestRejection: SimpleRejection = BadRequestRejection("default bad request rejection")
+
+  val contextIri: Iri = iri"http://example.com/contexts/simple-rejection.json"
+
+  val context: Json = json"""{ "@context": {"@vocab": "${nxv.base}"} }"""
+
+  val bNode = BNode.random
+
+  implicit val jsonLdEncoderSimpleRejection: JsonLdEncoder[SimpleRejection] =
+    new JsonLdEncoder[SimpleRejection] {
+
+      @nowarn("cat=unused")
+      implicit val cfg: Configuration =
+        Configuration.default.withDiscriminator("@type")
+
+      implicit private val simpleRejectionEncoder: Encoder.AsObject[SimpleRejection] =
+        deriveConfiguredEncoder[SimpleRejection]
+
+      override def apply(v: SimpleRejection): IO[RdfError, JsonLd] =
+        IO.pure(JsonLd.compactedUnsafe(v.asJsonObject, defaultContext, bNode))
+
+      override val defaultContext: RawJsonLdContext = RawJsonLdContext(contextIri.asJson)
+    }
+
+  implicit val statusFromSimpleRejection: StatusFrom[SimpleRejection] = StatusFrom {
+    case _: BadRequestRejection => StatusCodes.BadRequest
+    case _: ConflictRejection   => StatusCodes.Conflict
+  }
+}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/SimpleResource.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/SimpleResource.scala
@@ -1,0 +1,44 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import java.time.Instant
+
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
+import monix.bio.IO
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.CirceLiteral
+import io.circe.{Json, JsonObject}
+import io.circe.syntax._
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+
+final case class SimpleResource(id: Iri, rev: Long, createdAt: Instant, name: String, age: Int)
+
+object SimpleResource extends CirceLiteral {
+
+  val contextIri: Iri =
+    iri"http://example.com/contexts/simple-resource.json"
+
+  val context: Json =
+    json"""{ "@context": {"_rev": "${nxv + "rev"}", "_createdAt": "${nxv + "createdAt"}", "@vocab": "${nxv.base}"} }"""
+
+  implicit val jsonLdEncoder: JsonLdEncoder[SimpleResource] = new JsonLdEncoder[SimpleResource] {
+
+    override def apply(v: SimpleResource): IO[RdfError, JsonLd] =
+      IO.pure {
+        JsonLd.compactedUnsafe(
+          JsonObject.empty
+            .add("@id", v.id.asJson)
+            .add("name", v.name.asJson)
+            .add("age", v.name.asJson)
+            .add("_rev", v.rev.asJson)
+            .add("_createdAt", v.createdAt.asJson),
+          defaultContext,
+          v.id
+        )
+      }
+
+    override val defaultContext: RawJsonLdContext = RawJsonLdContext(contextIri.asJson)
+  }
+}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/utils/RouteHelpers.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/utils/RouteHelpers.scala
@@ -1,0 +1,39 @@
+package ch.epfl.bluebrain.nexus.delta.utils
+
+import akka.http.scaladsl.model.HttpResponse
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import ch.epfl.bluebrain.nexus.testkit.EitherValuable
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.duration._
+
+trait RouteHelpers extends ScalaFutures with EitherValuable {
+
+  implicit def httpResponseSyntax(http: HttpResponse): HttpResponseOps = new HttpResponseOps(http)
+
+  implicit override def patienceConfig: PatienceConfig = PatienceConfig(10.second, 10.milliseconds)
+
+  private def consume(source: Source[ByteString, Any])(implicit mt: Materializer): String =
+    source.runFold("")(_ ++ _.utf8String).futureValue
+
+  def asString(source: Source[ByteString, Any])(implicit mt: Materializer): String =
+    consume(source)
+
+  def asJson(source: Source[ByteString, Any])(implicit mt: Materializer): Json =
+    parse(consume(source)).rightValue
+
+}
+
+object RouteHelpers extends RouteHelpers
+
+final class HttpResponseOps(private val http: HttpResponse) extends AnyVal {
+  def asString(implicit mt: Materializer): String =
+    RouteHelpers.asString(http.entity.dataBytes)
+
+  def asJson(implicit mt: Materializer): Json =
+    RouteHelpers.asJson(http.entity.dataBytes)
+}

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/Vocabulary.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/Vocabulary.scala
@@ -126,6 +126,7 @@ object Vocabulary {
     def +(suffix: String) = iri"$base$suffix"
 
     val acls        = contexts + "acls.json"
+    val error       = contexts + "error.json"
     val identities  = contexts + "identities.json"
     val permissions = contexts + "permissions.json"
     val realms      = contexts + "realms.json"

--- a/delta/sdk/src/main/resources/contexts/error.json
+++ b/delta/sdk/src/main/resources/contexts/error.json
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@vocab": "https://bluebrain.github.io/nexus/vocabulary/"
+  }
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/identities/TokenRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/identities/TokenRejection.scala
@@ -1,5 +1,16 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.model.identities
 
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
+import io.circe.{Encoder, JsonObject}
+import io.circe.syntax._
+import monix.bio.{IO, UIO}
+
 /**
   * Enumeration of token rejections.
   *
@@ -41,5 +52,20 @@ object TokenRejection {
       extends TokenRejection(
         "The token is invalid; possible causes are: incorrect signature, the token is expired or the 'nbf' value was not met."
       )
+  implicit final val tokenRejectionJsonLdEncoder: JsonLdEncoder[TokenRejection] =
+    new JsonLdEncoder[TokenRejection] {
+      private val bnode = BNode.random
+
+      implicit private val tokenRejectionEncoder: Encoder.AsObject[TokenRejection] =
+        Encoder.AsObject.instance { r =>
+          val tpe = r.getClass.getSimpleName.split('$').head
+          JsonObject.empty.add(keywords.tpe, tpe.asJson).add("reason", r.reason.asJson)
+        }
+
+      override def apply(value: TokenRejection): IO[RdfError, JsonLd] =
+        JsonLd.compactedUnsafe(value.asJsonObject, defaultContext, bnode).pure[UIO]
+
+      override val defaultContext: RawJsonLdContext = RawJsonLdContext(contexts.error.asJson)
+    }
 
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/OrganizationRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/OrganizationRejection.scala
@@ -2,7 +2,17 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.organizations
 
 import java.util.UUID
 
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import io.circe.syntax._
+import io.circe.{Encoder, JsonObject}
+import monix.bio.{IO, UIO}
 
 /**
   * Enumeration of organization rejection types.
@@ -59,5 +69,21 @@ object OrganizationRejection {
     */
   final case class OrganizationIsDeprecated(label: Label)
       extends OrganizationRejection(s"Organization '$label' is deprecated.")
+
+  implicit final val orgRejectionJsonLdEncoder: JsonLdEncoder[OrganizationRejection] =
+    new JsonLdEncoder[OrganizationRejection] {
+      private val bnode = BNode.random
+
+      implicit private val orgRejectionEncoder: Encoder.AsObject[OrganizationRejection] =
+        Encoder.AsObject.instance { r =>
+          val tpe = r.getClass.getSimpleName.split('$').head
+          JsonObject.empty.add(keywords.tpe, tpe.asJson).add("reason", r.reason.asJson)
+        }
+
+      override def apply(value: OrganizationRejection): IO[RdfError, JsonLd] =
+        JsonLd.compactedUnsafe(value.asJsonObject, defaultContext, bnode).pure[UIO]
+
+      override val defaultContext: RawJsonLdContext = RawJsonLdContext(contexts.error.asJson)
+    }
 
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsRejection.scala
@@ -1,5 +1,16 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.model.permissions
 
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import io.circe.syntax._
+import io.circe.{Encoder, JsonObject}
+import monix.bio.{IO, UIO}
+
 /**
   * Enumeration of Permissions rejection types.
   *
@@ -78,4 +89,19 @@ object PermissionsRejection {
   final case class RevisionNotFound(provided: Long, current: Long)
       extends PermissionsRejection(s"Revision requested '$provided' not found, last known revision is '$current'.")
 
+  implicit final val permissionsRejectionJsonLdEncoder: JsonLdEncoder[PermissionsRejection] =
+    new JsonLdEncoder[PermissionsRejection] {
+      private val bnode = BNode.random
+
+      implicit private val permissionsRejectionEncoder: Encoder.AsObject[PermissionsRejection] =
+        Encoder.AsObject.instance { r =>
+          val tpe = r.getClass.getSimpleName.split('$').head
+          JsonObject.empty.add(keywords.tpe, tpe.asJson).add("reason", r.reason.asJson)
+        }
+
+      override def apply(value: PermissionsRejection): IO[RdfError, JsonLd] =
+        JsonLd.compactedUnsafe(value.asJsonObject, defaultContext, bnode).pure[UIO]
+
+      override val defaultContext: RawJsonLdContext = RawJsonLdContext(contexts.error.asJson)
+    }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejection.scala
@@ -2,7 +2,17 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.projects
 
 import java.util.UUID
 
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import io.circe.{Encoder, JsonObject}
+import io.circe.syntax._
+import monix.bio.{IO, UIO}
 
 /**
   * Enumeration of Project rejection types.
@@ -83,4 +93,20 @@ object ProjectRejection {
       extends ProjectRejection(
         s"Incorrect revision '$provided' provided, expected '$expected', the project may have been updated since last seen."
       )
+
+  implicit final val projectRejectionJsonLdEncoder: JsonLdEncoder[ProjectRejection] =
+    new JsonLdEncoder[ProjectRejection] {
+      private val bnode = BNode.random
+
+      implicit private val projectRejectionEncoder: Encoder.AsObject[ProjectRejection] =
+        Encoder.AsObject.instance { r =>
+          val tpe = r.getClass.getSimpleName.split('$').head
+          JsonObject.empty.add(keywords.tpe, tpe.asJson).add("reason", r.reason.asJson)
+        }
+
+      override def apply(value: ProjectRejection): IO[RdfError, JsonLd] =
+        JsonLd.compactedUnsafe(value.asJsonObject, defaultContext, bnode).pure[UIO]
+
+      override val defaultContext: RawJsonLdContext = RawJsonLdContext(contexts.error.asJson)
+    }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmRejection.scala
@@ -1,7 +1,17 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.model.realms
 
 import akka.http.scaladsl.model.Uri
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RawJsonLdContext
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import io.circe.{Encoder, JsonObject}
+import io.circe.syntax._
+import monix.bio.{IO, UIO}
 
 /**
   * Enumeration of Realm rejection types.
@@ -144,5 +154,21 @@ object RealmRejection {
     */
   final case class UnexpectedInitialState(label: Label)
       extends RealmRejection(s"Unexpected initial state for realm '$label'.")
+
+  implicit final val realmRejectionJsonLdEncoder: JsonLdEncoder[RealmRejection] =
+    new JsonLdEncoder[RealmRejection] {
+      private val bnode = BNode.random
+
+      implicit private val realmRejectionEncoder: Encoder.AsObject[RealmRejection] =
+        Encoder.AsObject.instance { r =>
+          val tpe = r.getClass.getSimpleName.split('$').head
+          JsonObject.empty.add(keywords.tpe, tpe.asJson).add("reason", r.reason.asJson)
+        }
+
+      override def apply(value: RealmRejection): IO[RdfError, JsonLd] =
+        JsonLd.compactedUnsafe(value.asJsonObject, defaultContext, bnode).pure[UIO]
+
+      override val defaultContext: RawJsonLdContext = RawJsonLdContext(contexts.error.asJson)
+    }
 
 }

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/identities/TokenRejectionSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/identities/TokenRejectionSpec.scala
@@ -1,0 +1,49 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.identities
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.dummies.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.TokenRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestHelpers}
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class TokenRejectionSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with Inspectors
+    with CirceLiteral
+    with TestHelpers
+    with IOValues {
+
+  "A TokenRejection" should {
+
+    implicit val rcr: RemoteContextResolutionDummy =
+      RemoteContextResolutionDummy(contexts.error -> jsonContentOf("/contexts/error.json"))
+
+    val invalidFormat                              = InvalidAccessTokenFormat
+    val noIssuer                                   = AccessTokenDoesNotContainSubject
+
+    "be converted to compacted JSON-LD" in {
+      val list = List(
+        noIssuer      -> json"""{"@type": "AccessTokenDoesNotContainSubject", "reason": "${noIssuer.reason}"}""",
+        invalidFormat -> json"""{"@type": "InvalidAccessTokenFormat", "reason": "${invalidFormat.reason}"}"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toCompactedJsonLd.accepted.json shouldEqual json.addContext(contexts.error)
+      }
+    }
+
+    "be converted to expanded JSON-LD" in {
+      val list = List(
+        noIssuer      -> json"""[{"@type": ["${nxv + "AccessTokenDoesNotContainSubject"}"], "${nxv + "reason"}": [{"@value": "${noIssuer.reason}"} ] } ]""",
+        invalidFormat -> json"""[{"@type": ["${nxv + "InvalidAccessTokenFormat"}"], "${nxv + "reason"}": [{"@value": "${invalidFormat.reason}"} ] } ]"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toExpandedJsonLd.accepted.json shouldEqual json
+      }
+    }
+  }
+
+}

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/OrganizationRejectionsSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/OrganizationRejectionsSpec.scala
@@ -1,0 +1,50 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.organizations
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.dummies.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestHelpers}
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class OrganizationRejectionsSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with Inspectors
+    with CirceLiteral
+    with TestHelpers
+    with IOValues {
+
+  "An OrganizationRejection" should {
+
+    implicit val rcr: RemoteContextResolutionDummy =
+      RemoteContextResolutionDummy(contexts.error -> jsonContentOf("/contexts/error.json"))
+
+    val incorrectRev                               = IncorrectRev(3L, 2L)
+    val alreadyExists                              = OrganizationAlreadyExists(Label.unsafe("org"))
+
+    "be converted to compacted JSON-LD" in {
+      val list = List(
+        alreadyExists -> json"""{"@type": "OrganizationAlreadyExists", "reason": "${alreadyExists.reason}"}""",
+        incorrectRev  -> json"""{"@type": "IncorrectRev", "reason": "${incorrectRev.reason}"}"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toCompactedJsonLd.accepted.json shouldEqual json.addContext(contexts.error)
+      }
+    }
+
+    "be converted to expanded JSON-LD" in {
+      val list = List(
+        alreadyExists -> json"""[{"@type": ["${nxv + "OrganizationAlreadyExists"}"], "${nxv + "reason"}": [{"@value": "${alreadyExists.reason}"} ] } ]""",
+        incorrectRev  -> json"""[{"@type": ["${nxv + "IncorrectRev"}"], "${nxv + "reason"}": [{"@value": "${incorrectRev.reason}"} ] } ]"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toExpandedJsonLd.accepted.json shouldEqual json
+      }
+    }
+  }
+
+}

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsRejectionSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsRejectionSpec.scala
@@ -1,0 +1,49 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.permissions
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.dummies.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.PermissionsRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestHelpers}
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class PermissionsRejectionSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with Inspectors
+    with CirceLiteral
+    with TestHelpers
+    with IOValues {
+
+  "A PermissionsRejection" should {
+
+    implicit val rcr: RemoteContextResolutionDummy =
+      RemoteContextResolutionDummy(contexts.error -> jsonContentOf("/contexts/error.json"))
+
+    val incorrectRev                               = IncorrectRev(3L, 2L)
+    val cannotReplace                              = CannotReplaceWithEmptyCollection
+
+    "be converted to compacted JSON-LD" in {
+      val list = List(
+        cannotReplace -> json"""{"@type": "CannotReplaceWithEmptyCollection", "reason": "${cannotReplace.reason}"}""",
+        incorrectRev  -> json"""{"@type": "IncorrectRev", "reason": "${incorrectRev.reason}"}"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toCompactedJsonLd.accepted.json shouldEqual json.addContext(contexts.error)
+      }
+    }
+
+    "be converted to expanded JSON-LD" in {
+      val list = List(
+        cannotReplace -> json"""[{"@type": ["${nxv + "CannotReplaceWithEmptyCollection"}"], "${nxv + "reason"}": [{"@value": "${cannotReplace.reason}"} ] } ]""",
+        incorrectRev  -> json"""[{"@type": ["${nxv + "IncorrectRev"}"], "${nxv + "reason"}": [{"@value": "${incorrectRev.reason}"} ] } ]"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toExpandedJsonLd.accepted.json shouldEqual json
+      }
+    }
+  }
+
+}

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejectionSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejectionSpec.scala
@@ -1,0 +1,50 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.projects
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.dummies.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestHelpers}
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class ProjectRejectionSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with Inspectors
+    with CirceLiteral
+    with TestHelpers
+    with IOValues {
+
+  "A ProjectRejection" should {
+
+    implicit val rcr: RemoteContextResolutionDummy =
+      RemoteContextResolutionDummy(contexts.error -> jsonContentOf("/contexts/error.json"))
+
+    val incorrectRev                               = IncorrectRev(3L, 2L)
+    val alreadyExists                              = ProjectAlreadyExists(ProjectRef(Label.unsafe("org"), Label.unsafe("proj")))
+
+    "be converted to compacted JSON-LD" in {
+      val list = List(
+        alreadyExists -> json"""{"@type": "ProjectAlreadyExists", "reason": "${alreadyExists.reason}"}""",
+        incorrectRev  -> json"""{"@type": "IncorrectRev", "reason": "${incorrectRev.reason}"}"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toCompactedJsonLd.accepted.json shouldEqual json.addContext(contexts.error)
+      }
+    }
+
+    "be converted to expanded JSON-LD" in {
+      val list = List(
+        alreadyExists -> json"""[{"@type": ["${nxv + "ProjectAlreadyExists"}"], "${nxv + "reason"}": [{"@value": "${alreadyExists.reason}"} ] } ]""",
+        incorrectRev  -> json"""[{"@type": ["${nxv + "IncorrectRev"}"], "${nxv + "reason"}": [{"@value": "${incorrectRev.reason}"} ] } ]"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toExpandedJsonLd.accepted.json shouldEqual json
+      }
+    }
+  }
+
+}

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmsRejectionSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmsRejectionSpec.scala
@@ -1,0 +1,50 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.realms
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.dummies.RemoteContextResolutionDummy
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import ch.epfl.bluebrain.nexus.delta.sdk.model.realms.RealmRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestHelpers}
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class RealmsRejectionSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with Inspectors
+    with CirceLiteral
+    with TestHelpers
+    with IOValues {
+
+  "A RealmsRejection" should {
+
+    implicit val rcr: RemoteContextResolutionDummy =
+      RemoteContextResolutionDummy(contexts.error -> jsonContentOf("/contexts/error.json"))
+
+    val incorrectRev                               = IncorrectRev(3L, 2L)
+    val alreadyExists                              = RealmAlreadyExists(Label.unsafe("name"))
+
+    "be converted to compacted JSON-LD" in {
+      val list = List(
+        alreadyExists -> json"""{"@type": "RealmAlreadyExists", "reason": "${alreadyExists.reason}"}""",
+        incorrectRev  -> json"""{"@type": "IncorrectRev", "reason": "${incorrectRev.reason}"}"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toCompactedJsonLd.accepted.json shouldEqual json.addContext(contexts.error)
+      }
+    }
+
+    "be converted to expanded JSON-LD" in {
+      val list = List(
+        alreadyExists -> json"""[{"@type": ["${nxv + "RealmAlreadyExists"}"], "${nxv + "reason"}": [{"@value": "${alreadyExists.reason}"} ] } ]""",
+        incorrectRev  -> json"""[{"@type": ["${nxv + "IncorrectRev"}"], "${nxv + "reason"}": [{"@value": "${incorrectRev.reason}"} ] } ]"""
+      )
+      forAll(list) {
+        case (rejection, json) => rejection.toExpandedJsonLd.accepted.json shouldEqual json
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Two options to use on the routes:
```scala
val uio: UIO[A] = ???
// if you have a JsonLdEncoder[A], you can
completeUIO(StatusCodes.OK, uio)
```

```scala
val io: IO[E, A] = ???
// if you have a JsonLdEncoder[A], JsonLdEncoder[E] and a StatusFrom[E], you can
completeIO(StatusCodes.OK, io)
```

Response format is managed under the hood using content negotiation (Accept header). For the discrimination between compacted and expanded JSON-LD, a query parameter `format` is used to select the response format.
