### PR TITLE
Made event persist ordering deterministic

### DIFF
--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/EventSourceProcessor.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/EventSourceProcessor.scala
@@ -34,7 +34,7 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
     config: EventSourceProcessorConfig
 )(implicit State: ClassTag[State], Command: ClassTag[Command], Event: ClassTag[Event], Rejection: ClassTag[Rejection]) {
 
-  protected val id = persistenceId(definition.entityType, entityId)
+  protected val id: String = persistenceId(definition.entityType, entityId)
 
   /**
     * The behavior of the underlying state actor when we opted for persisting the events
@@ -62,7 +62,8 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
               Effect.reply(replyTo)(
                 LastSeqNr(EventSourcedBehavior.lastSequenceNumber(context))
               )
-            case Append(_, event: Event)                                               => Effect.persist(event)
+            case Append(id, Event(event), replyTo: ActorRef[AppendSuccess[_, _]])      =>
+              Effect.persist(event).thenReply(replyTo)(state => AppendSuccess(id, event, state))
           }
         },
         // Event handler
@@ -127,8 +128,10 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
             Behaviors.same
           case _: RequestLastSeqNr                                                   =>
             Behaviors.same
-          case Append(_, event: Event)                                               =>
-            behavior(t.next(state, event))
+          case Append(id, Event(event), replyTo: ActorRef[AppendSuccess[_, _]])      =>
+            val newState = t.next(state, event)
+            replyTo ! AppendSuccess(id, event, newState)
+            behavior(newState)
         }
       }
     behavior(t.initialState)
@@ -197,25 +200,27 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
         def stash(state: State, replyTo: ActorRef[RunResult]): Behavior[ProcessorCommand] =
           checkEntityId { (_, cmd) =>
             cmd match {
-              case ro: ReadonlyCommand                                     =>
+              case ro: ReadonlyCommand                           =>
                 stateActor ! ro
                 Behaviors.same
-              case success @ EvaluationSuccess(Event(event), State(state)) =>
-                stateActor ! Append(entityId, event)
-                replyTo ! success
-                active(state)
-              case rejection @ EvaluationRejection(Rejection(_))           =>
+              case AppendSuccess(_, Event(event), State(state))  =>
+                replyTo ! EvaluationSuccess(event, state)
+                buffer.unstashAll(active(state))
+              case EvaluationSuccessInternal(Event(event))       =>
+                stateActor ! Append(entityId, event, context.self)
+                Behaviors.same
+              case rejection @ EvaluationRejection(Rejection(_)) =>
                 replyTo ! rejection
                 buffer.unstashAll(active(state))
-              case error: EvaluationError                                  =>
+              case error: EvaluationError                        =>
                 replyTo ! error
                 buffer.unstashAll(active(state))
-              case dryRun: DryRunResult                                    =>
+              case dryRun: DryRunResult                          =>
                 replyTo ! dryRun
                 buffer.unstashAll(active(state))
-              case Idle                                                    =>
+              case Idle                                          =>
                 stopAfterInactivity(context.self)
-              case c                                                       =>
+              case c                                             =>
                 buffer.stash(c)
                 Behaviors.same
             }
@@ -277,7 +282,12 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
       _ <- IO.shift(config.evaluationExecutionContext)
       r <- definition.evaluate(state, cmd).attempt
       _ <- IO.shift(context.executionContext)
-      _ <- tellResult(r.map { e => EvaluationSuccess(e, definition.next(state, e)) }.valueOr(EvaluationRejection(_)))
+      _ <- tellResult(
+             r.map {
+               case e if dryRun => EvaluationSuccess(e, definition.next(state, e))
+               case e           => EvaluationSuccessInternal(e)
+             }.valueOr(EvaluationRejection(_))
+           )
     } yield ()
     val io    = eval
       .timeoutTo(

--- a/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/sourcing/EventSourceProcessorSpec.scala
+++ b/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/sourcing/EventSourceProcessorSpec.scala
@@ -5,10 +5,10 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, Behavior}
 import akka.persistence.testkit.PersistenceTestKitPlugin
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
+import ch.epfl.bluebrain.nexus.sourcing.TestCommand.{Increment, IncrementAsync, Initialize}
 import ch.epfl.bluebrain.nexus.sourcing.TestEvent.{Incremented, Initialized}
 import ch.epfl.bluebrain.nexus.sourcing.TestRejection.InvalidRevision
 import ch.epfl.bluebrain.nexus.sourcing.TestState.Current
-import ch.epfl.bluebrain.nexus.sourcing.TestCommand.{Increment, IncrementAsync, Initialize}
 import ch.epfl.bluebrain.nexus.sourcing.processor.AggregateReply.{LastSeqNr, StateReply}
 import ch.epfl.bluebrain.nexus.sourcing.processor.ProcessorCommand._
 import ch.epfl.bluebrain.nexus.sourcing.processor.StopStrategy.{PersistentStopStrategy, TransientStopStrategy}
@@ -34,6 +34,13 @@ abstract class EventSourceProcessorSpec(config: Config)
 
   val entityId      = "A"
   val persistenceId = "increment-A"
+
+  val stopProbe = testKit.createTestProbe[String]()
+
+  def onStopCallback(actorRef: ActorRef[ProcessorCommand]): Behavior[ProcessorCommand] = {
+    stopProbe.ref ! s"${actorRef.path.name} got stopped"
+    Behaviors.stopped[ProcessorCommand]
+  }
 
   def processorWithoutStop: ActorRef[ProcessorCommand]
 
@@ -78,15 +85,8 @@ abstract class EventSourceProcessorSpec(config: Config)
 
   "Stop" should {
     "happen after some inactivity" in {
-      val probe = testKit.createTestProbe[String]()
-
-      def stopAfterInactivity(actorRef: ActorRef[ProcessorCommand]) = {
-        probe.ref ! s"${actorRef.path.name} got stopped"
-        Behaviors.stopped[ProcessorCommand]
-      }
-
-      val actor = processorWithStop(stopAfterInactivity)
-      probe.expectMessage(s"${actor.path.name} got stopped")
+      val actor = processorWithStop(onStopCallback)
+      stopProbe.expectMessage(s"${actor.path.name} got stopped")
     }
   }
 
@@ -148,10 +148,7 @@ class PersistentEventProcessorSpec
     with BeforeAndAfterEach {
 
   override val processorWithoutStop: ActorRef[ProcessorCommand] =
-    processor(
-      PersistentStopStrategy.never,
-      (_: ActorRef[ProcessorCommand]) => Behaviors.same
-    )
+    processor(PersistentStopStrategy.never, onStopCallback)
   private val persistenceTestKit                                = PersistenceTestKit(system)
 
   override def beforeEach(): Unit = {
@@ -197,15 +194,8 @@ class PersistentEventProcessorSpec
 
   "Stop" should {
     "happen after recovery has been completed" in {
-      val probe = testKit.createTestProbe[String]()
-
-      def stopAfterInactivity(actorRef: ActorRef[ProcessorCommand]) = {
-        probe.ref ! s"${actorRef.path.name} got stopped"
-        Behaviors.stopped[ProcessorCommand]
-      }
-
-      val actor = processor(PersistentStopStrategy(None, Some(60.millis)), stopAfterInactivity)
-      probe.expectMessage(s"${actor.path.name} got stopped")
+      val actor = processor(PersistentStopStrategy(None, Some(60.millis)), onStopCallback)
+      stopProbe.expectMessage(s"${actor.path.name} got stopped")
     }
   }
 
@@ -218,7 +208,7 @@ class TransientEventProcessorSpec
     with BeforeAndAfterEach {
 
   override val processorWithoutStop: ActorRef[ProcessorCommand] =
-    processor(TransientStopStrategy.never, (_: ActorRef[ProcessorCommand]) => Behaviors.same)
+    processor(TransientStopStrategy.never, onStopCallback)
 
   override protected def expectNothingPersisted(): Unit = {}
 


### PR DESCRIPTION
This fixes the current errors we are experiencing non deterministically on `AclsImplSpec` and others where events are not persisted in the correct order.

Now it makes sure an Event has been persisted (after its evaluation) before continuing with the next event.