### PR TITLE
Improved processor with more behaviors

### DIFF
--- a/delta/sourcing/src/main/resources/reference.conf
+++ b/delta/sourcing/src/main/resources/reference.conf
@@ -25,7 +25,8 @@ akka {
     }
     serialization-bindings {
       "ch.epfl.bluebrain.nexus.sourcing.processor.ProcessorCommand" = kryo
-      "ch.epfl.bluebrain.nexus.sourcing.processor.AggregateReply" = kryo
+      "ch.epfl.bluebrain.nexus.sourcing.processor.ChildActorRequest" = kryo
+      "ch.epfl.bluebrain.nexus.sourcing.processor.AggregateResponse" = kryo
     }
   }
 }

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/EventSourceProcessor.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/EventSourceProcessor.scala
@@ -1,13 +1,12 @@
 package ch.epfl.bluebrain.nexus.sourcing.processor
 
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors, LoggerOps}
+import akka.actor.typed.scaladsl.{Behaviors, LoggerOps}
 import akka.actor.typed.{ActorRef, Behavior}
 import akka.persistence.typed._
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior, RetentionCriteria, SnapshotCountRetentionCriteria}
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UrlUtils
 import ch.epfl.bluebrain.nexus.sourcing.SnapshotStrategy.{NoSnapshot, SnapshotCombined, SnapshotEvery, SnapshotPredicate}
-import ch.epfl.bluebrain.nexus.sourcing.processor.AggregateReply.{LastSeqNr, StateReply}
 import ch.epfl.bluebrain.nexus.sourcing.processor.EventSourceProcessor._
 import ch.epfl.bluebrain.nexus.sourcing.processor.ProcessorCommand._
 import ch.epfl.bluebrain.nexus.sourcing.{EventDefinition, PersistentEventDefinition, SnapshotStrategy, TransientEventDefinition}
@@ -46,24 +45,22 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
     import persistentEventDefinition._
     val persistenceId = PersistenceId.ofUniqueId(id)
 
-    Behaviors.setup[EventSourceCommand] { context =>
+    Behaviors.setup[ChildActorRequest] { context =>
       context.log.info2("Starting event source processor for type '{}' and id '{}'", entityType, entityId)
-      EventSourcedBehavior[EventSourceCommand, Event, State](
+      EventSourcedBehavior[ChildActorRequest, Event, State](
         persistenceId,
         emptyState = initialState,
         // Command handler
         { (state, command) =>
           command match {
-            case RequestState(_, replyTo: ActorRef[StateReply[_]])                     =>
-              Effect.reply(replyTo)(StateReply(state))
-            case RequestStateInternal(id, replyTo: ActorRef[ResponseStateInternal[_]]) =>
-              Effect.reply(replyTo)(ResponseStateInternal(id, state))
-            case RequestLastSeqNr(_, replyTo: ActorRef[LastSeqNr])                     =>
-              Effect.reply(replyTo)(
-                LastSeqNr(EventSourcedBehavior.lastSequenceNumber(context))
-              )
-            case Append(id, Event(event), replyTo: ActorRef[AppendSuccess[_, _]])      =>
-              Effect.persist(event).thenReply(replyTo)(state => AppendSuccess(id, event, state))
+            case ChildActorRequest.RequestState(replyTo)     =>
+              Effect.reply(replyTo)(AggregateResponse.StateResponse(state))
+            case ChildActorRequest.RequestLastSeqNr(replyTo) =>
+              Effect.reply(replyTo)(AggregateResponse.LastSeqNr(EventSourcedBehavior.lastSequenceNumber(context)))
+            case ChildActorRequest.RequestStateInternal      =>
+              Effect.reply(parent)(ChildActorResponse.StateResponseInternal(state))
+            case ChildActorRequest.Append(Event(event))      =>
+              Effect.persist(event).thenReply(parent)(state => ChildActorResponse.AppendResult(event, state))
           }
         },
         // Event handler
@@ -115,22 +112,23 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
     * The behavior of the underlying state actor when we opted for NOT persisting the events
     */
   private def transientBehavior(
-      t: TransientEventDefinition[State, Command, Event, Rejection]
-  ): Behavior[EventSourceCommand] = {
-    def behavior(state: State): Behaviors.Receive[EventSourceCommand] =
-      Behaviors.receive[EventSourceCommand] { (_, cmd) =>
+      t: TransientEventDefinition[State, Command, Event, Rejection],
+      parent: ActorRef[ProcessorCommand]
+  ): Behavior[ChildActorRequest] = {
+    def behavior(state: State): Behaviors.Receive[ChildActorRequest] =
+      Behaviors.receive[ChildActorRequest] { (_, cmd) =>
         cmd match {
-          case RequestState(_, replyTo: ActorRef[StateReply[_]])                     =>
-            replyTo ! StateReply(state)
+          case ChildActorRequest.RequestState(replyTo) =>
+            replyTo ! AggregateResponse.StateResponse(state)
             Behaviors.same
-          case RequestStateInternal(id, replyTo: ActorRef[ResponseStateInternal[_]]) =>
-            replyTo ! ResponseStateInternal(id, state)
+          case ChildActorRequest.RequestLastSeqNr(_)   =>
             Behaviors.same
-          case _: RequestLastSeqNr                                                   =>
+          case ChildActorRequest.RequestStateInternal  =>
+            parent ! ChildActorResponse.StateResponseInternal(state)
             Behaviors.same
-          case Append(id, Event(event), replyTo: ActorRef[AppendSuccess[_, _]])      =>
+          case ChildActorRequest.Append(Event(event))  =>
             val newState = t.next(state, event)
-            replyTo ! AppendSuccess(id, event, newState)
+            parent ! ChildActorResponse.AppendResult(event, newState)
             behavior(newState)
         }
       }
@@ -138,7 +136,19 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
   }
 
   /**
-    * Behavior of the actor responsible for handling commands and events
+    * Behavior of the actor responsible for handling commands and events.
+    * There are multiple behaviours, each of them responsible for a different stage of a command evaluation.
+    *
+    * The following is a diagram of the different behaviors and their order:
+    *
+    * ┌--------┐        ┌-------------------┐        ┌------------┐         ┌-----------┐
+    * │        │        │                   │        │            │ !druRun │           │
+    * │ active +--------> waitingToEvaluate │--------> evaluating │---------> appending │---┐
+    * │        │        │                   │        │            │---┐     │           │   │
+    * └---^----┘        └-------------------┘        └------------┘   │     └-----------┘   │
+    *     │                                                           │                     │
+    *     └-----------------------------------------------------------┴---------------------┘
+    *                                        dryRun
     */
   def behavior(): Behavior[ProcessorCommand] =
     Behaviors.setup[ProcessorCommand] { context =>
@@ -146,84 +156,192 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
       Behaviors.withStash(config.stashSize) { buffer =>
         // We create a child actor to apply (and maybe persist) events
         // according to the definition that has been provided
-        val behavior   = definition match {
+        val behavior = definition match {
           case p: PersistentEventDefinition[State, Command, Event, Rejection] =>
             persistentBehavior(p, context.self)
           case t: TransientEventDefinition[State, Command, Event, Rejection]  =>
-            transientBehavior(t)
+            transientBehavior(t, context.self)
         }
-        val stateActor = context.spawn(
-          behavior,
-          s"${UrlUtils.encode(entityId)}_state"
-        )
+
+        val stateActor = context.spawn(behavior, s"${UrlUtils.encode(entityId)}_state")
 
         // Make sure that the message has been correctly routed to the appropriated actor
-        def checkEntityId(
-            onSuccess: (ActorContext[ProcessorCommand], ProcessorCommand) => Behavior[ProcessorCommand]
+        def checkEntityId(onSuccess: ProcessorCommand => Behavior[ProcessorCommand]): Behavior[ProcessorCommand] =
+          Behaviors.receive {
+            case (_, command: AggregateRequest) if command.id == entityId =>
+              onSuccess(command)
+            case (_, command: AggregateRequest)                           =>
+              context.log.warn(s"Unexpected message id '${command.id}' received in actor with id '$id''")
+              Behaviors.unhandled
+            case (_, command)                                             =>
+              onSuccess(command)
+          }
+
+        def toChildActorRequest(readOnly: AggregateRequest.ReadOnlyRequest): ChildActorRequest =
+          readOnly match {
+            case AggregateRequest.RequestState(_, replyTo)     => ChildActorRequest.RequestState(replyTo)
+            case AggregateRequest.RequestLastSeqNr(_, replyTo) => ChildActorRequest.RequestLastSeqNr(replyTo)
+          }
+
+        def toAggregateResponse(result: EvaluationResult): AggregateResponse.EvaluationResult =
+          result match {
+            case EvaluationResult.EvaluationSuccess(Event(event), State(state)) =>
+              AggregateResponse.EvaluationSuccess(event, state)
+            case EvaluationResult.EvaluationRejection(Rejection(rej))           =>
+              AggregateResponse.EvaluationRejection(rej)
+            case EvaluationResult.EvaluationTimeout(Command(cmd), timeoutAfter) =>
+              AggregateResponse.EvaluationTimeout(cmd, timeoutAfter)
+            case EvaluationResult.EvaluationFailure(Command(cmd), message)      =>
+              AggregateResponse.EvaluationFailure(cmd, message)
+          }
+
+        // Evaluates the command and sends a message to self with the evaluation result
+        def evaluateCommand(state: State, cmd: Command, dryRun: Boolean): Unit = {
+          val scope = if (dryRun) "testing" else "evaluating"
+          val eval  = for {
+            _    <- IO.shift(config.evaluationExecutionContext)
+            r    <- definition.evaluate(state, cmd).attempt
+            _    <- IO.shift(context.executionContext)
+            evRes = r.map(e => EvaluationResult.EvaluationSuccess(e, definition.next(state, e)))
+                      .valueOr(EvaluationResult.EvaluationRejection(_))
+            _    <- IO.delay(context.self ! evRes)
+          } yield ()
+          val io    = eval
+            .timeoutTo(
+              config.evaluationMaxDuration, {
+                IO.shift(context.executionContext) >>
+                  IO.delay(context.log.error2(s"Timed out while $scope command '{}' on actor '{}'", cmd, id)) >>
+                  IO.delay(context.self ! EvaluationResult.EvaluationTimeout(cmd, config.evaluationMaxDuration))
+              }
+            )
+            .onError { case NonFatal(th) =>
+              IO.shift(context.executionContext) >>
+                IO.delay(context.log.error2(s"Error while $scope command '{}' on actor '{}'", cmd, id)) >>
+                IO.delay(context.self ! EvaluationResult.EvaluationFailure(cmd, Option(th.getMessage)))
+            }
+
+          io.runAsyncAndForget
+        }
+
+        /**
+          * Initial behavior, ready to process ''Evaluate'' and ''DryRun'' messages.
+          * Before evaluating a command we need the state, so we ask the stateActor for it and move our behavior to waitingToEvaluate.
+          * ''RequestState'' and ''RequestLastSeqNr'' messages will be processed by forwarding them to the state actor.
+          */
+        def active(): Behavior[ProcessorCommand] =
+          checkEntityId {
+            case AggregateRequest.Evaluate(_, Command(subCommand), replyTo) =>
+              stateActor ! ChildActorRequest.RequestStateInternal
+              waitingToEvaluate(subCommand, replyTo, dryRun = false)
+            case AggregateRequest.DryRun(_, Command(subCommand), replyTo)   =>
+              stateActor ! ChildActorRequest.RequestStateInternal
+              waitingToEvaluate(subCommand, replyTo, dryRun = true)
+            case readOnly: AggregateRequest.ReadOnlyRequest                 =>
+              stateActor ! toChildActorRequest(readOnly)
+              Behaviors.same
+            case Idle                                                       =>
+              stopAfterInactivity(context.self)
+            case ChildActorResponse.AppendResult(_, _)                      =>
+              context.log.error("Getting an append result should happen within the 'appending' behavior")
+              Behaviors.same
+            case ChildActorResponse.StateResponseInternal(_)                =>
+              context.log.error("Getting the state from within should happen within the 'waitingToEvaluate' behavior")
+              Behaviors.same
+          }
+
+        /**
+          * The second behavior, ready to process ''StateResponseInternal'' messages.
+          * Once received, we trigger command Evaluation/DryRun and move our behavior to evaluating.
+          * ''RequestState'' and ''RequestLastSeqNr'' messages will be processed by forwarding them to the state actor,
+          * while any other ''Evaluate'' or ''DryRun'' will be stashed.
+          */
+        def waitingToEvaluate(
+            subCommand: Command,
+            replyTo: ActorRef[AggregateResponse.EvaluationResult],
+            dryRun: Boolean
         ): Behavior[ProcessorCommand] =
-          Behaviors.receive { (context, command) =>
-            command match {
-              case i: InputCommand =>
-                if (i.id == entityId) {
-                  onSuccess(context, command)
-                } else {
-                  context.log.warn(s"Unexpected message id ${i.id} received in actor with id $id")
-                  Behaviors.unhandled
-                }
-              case _               => onSuccess(context, command)
-            }
+          checkEntityId {
+            case ChildActorResponse.StateResponseInternal(State(state)) =>
+              evaluateCommand(state, subCommand, dryRun)
+              evaluating(replyTo, dryRun)
+            case readOnly: AggregateRequest.ReadOnlyRequest             =>
+              stateActor ! toChildActorRequest(readOnly)
+              Behaviors.same
+            case req: AggregateRequest                                  =>
+              buffer.stash(req)
+              Behaviors.same
+            case Idle                                                   =>
+              stopAfterInactivity(context.self)
+            case _: EvaluationResult                                    =>
+              context.log.error("Getting an evaluation result should happen within the 'evaluating' behavior")
+              Behaviors.same
+            case ChildActorResponse.AppendResult(_, _)                  =>
+              context.log.error("Getting an append result should happen within the 'appending' behavior")
+              Behaviors.same
           }
 
-        // The actor is not currently evaluating anything
-        def active(state: State): Behavior[ProcessorCommand] =
-          checkEntityId { (c, cmd) =>
-            cmd match {
-              case ese: EventSourceCommand                                               =>
-                stateActor ! ese
-                Behaviors.same
-              case Evaluate(_, Command(subCommand), replyTo: ActorRef[EvaluationResult]) =>
-                evaluateCommand(state, subCommand, c)
-                stash(state, replyTo.unsafeUpcast[RunResult])
-              case DryRun(_, Command(subCommand), replyTo: ActorRef[DryRunResult])       =>
-                evaluateCommand(state, subCommand, c, dryRun = true)
-                stash(state, replyTo.unsafeUpcast[RunResult])
-              case _: EvaluationResult                                                   =>
-                context.log.error("Getting an evaluation result should happen within a stashing behavior")
-                Behaviors.same
-              case Idle                                                                  =>
-                stopAfterInactivity(context.self)
-            }
+        /**
+          * The third behavior, ready to process evaluation results ''EvaluationResult'' messages.
+          * If the evaluation succeeded and we are not on a ''DryRun'', we will send an ''Append'' message to the stateActor
+          * with the computed event and move to the appending behavior.
+          * Otherwise we return the ''EvaluationResult'' to the client and unstash other messages while moving to active behavior.
+          * ''RequestState'' and ''RequestLastSeqNr'' messages will be processed by forwarding them to the state actor,
+          * while any other ''Evaluate'' or ''DryRun'' will be stashed.
+          */
+        def evaluating(
+            replyTo: ActorRef[AggregateResponse.EvaluationResult],
+            dryRun: Boolean
+        ): Behavior[ProcessorCommand] =
+          checkEntityId {
+            case EvaluationResult.EvaluationSuccess(Event(event), _) if !dryRun =>
+              stateActor ! ChildActorRequest.Append(event)
+              appending(replyTo)
+            case r: EvaluationResult                                            =>
+              replyTo ! toAggregateResponse(r)
+              buffer.unstashAll(active())
+            case readOnly: AggregateRequest.ReadOnlyRequest                     =>
+              stateActor ! toChildActorRequest(readOnly)
+              Behaviors.same
+            case req: AggregateRequest                                          =>
+              buffer.stash(req)
+              Behaviors.same
+            case Idle                                                           =>
+              buffer.stash(Idle)
+              Behaviors.same
+            case ChildActorResponse.AppendResult(_, _)                          =>
+              context.log.error("Getting an append result should happen within the 'appending' behavior")
+              Behaviors.same
+            case ChildActorResponse.StateResponseInternal(_)                    =>
+              context.log.error("Getting the state from within should happen within the 'waitingToEvaluate' behavior")
+              Behaviors.same
           }
 
-        // The actor is evaluating a command so we stash commands
-        // until we get a result for the current evaluation
-        def stash(state: State, replyTo: ActorRef[RunResult]): Behavior[ProcessorCommand] =
-          checkEntityId { (_, cmd) =>
-            cmd match {
-              case ro: ReadonlyCommand                           =>
-                stateActor ! ro
-                Behaviors.same
-              case AppendSuccess(_, Event(event), State(state))  =>
-                replyTo ! EvaluationSuccess(event, state)
-                buffer.unstashAll(active(state))
-              case EvaluationSuccessInternal(Event(event))       =>
-                stateActor ! Append(entityId, event, context.self)
-                Behaviors.same
-              case rejection @ EvaluationRejection(Rejection(_)) =>
-                replyTo ! rejection
-                buffer.unstashAll(active(state))
-              case error: EvaluationError                        =>
-                replyTo ! error
-                buffer.unstashAll(active(state))
-              case dryRun: DryRunResult                          =>
-                replyTo ! dryRun
-                buffer.unstashAll(active(state))
-              case Idle                                          =>
-                stopAfterInactivity(context.self)
-              case c                                             =>
-                buffer.stash(c)
-                Behaviors.same
-            }
+        /**
+          * The fourth behavior, ready to process ''AppendResult'' messages, which confirm correct append on the event log from the stateActor.
+          * After that we reply to the client and unstash other messages while moving to active behavior.
+          * ''RequestState'' and ''RequestLastSeqNr'' messages will be processed by forwarding them to the state actor,
+          * while any other ''Evaluate'' or ''DryRun'' will be stashed.
+          */
+        def appending(replyTo: ActorRef[AggregateResponse.EvaluationResult]): Behavior[ProcessorCommand] =
+          checkEntityId {
+            case ChildActorResponse.AppendResult(Event(event), State(state)) =>
+              replyTo ! AggregateResponse.EvaluationSuccess(event, state)
+              buffer.unstashAll(active())
+            case readOnly: AggregateRequest.ReadOnlyRequest                  =>
+              stateActor ! toChildActorRequest(readOnly)
+              Behaviors.same
+            case req: AggregateRequest                                       =>
+              buffer.stash(req)
+              Behaviors.same
+            case Idle                                                        =>
+              buffer.stash(Idle)
+              Behaviors.same
+            case _: EvaluationResult                                         =>
+              context.log.error("Getting an evaluation result should happen within the 'evaluating' behavior")
+              Behaviors.same
+            case ChildActorResponse.StateResponseInternal(_)                 =>
+              context.log.error("Getting the state from within should happen within the 'waitingToEvaluate' behavior")
+              Behaviors.same
           }
 
         // The actor will be stopped if it doesn't receive any message
@@ -232,79 +350,11 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
           context.setReceiveTimeout(duration, Idle)
         }
 
-        // On initial cmd evaluation, before evaluating,
-        // the initial state is being retrieved from the child actor
-        def initialState: Behavior[ProcessorCommand] =
-          checkEntityId { (_, cmd) =>
-            cmd match {
-              case ResponseStateInternal(_, State(state)) =>
-                buffer.unstashAll(active(state))
-              case ese: EventSourceCommand                =>
-                stateActor ! ese
-                Behaviors.same
-              case Idle                                   =>
-                stopAfterInactivity(context.self)
-              case c                                      =>
-                buffer.stash(c)
-                stateActor ! RequestStateInternal(entityId, context.self)
-                Behaviors.same
-            }
-          }
-
-        initialState
+        active()
       }
     }
 
   implicit private val scheduler: Scheduler = Scheduler(config.evaluationExecutionContext)
-
-  /**
-    * Runs asynchronously the given command and sends
-    * the result back to the same actor which is stashing messages during this period
-    * @param state the current state
-    * @param cmd the command to run
-    * @param context the context of the current actor
-    * @param dryRun if we run as
-    */
-  private def evaluateCommand(
-      state: State,
-      cmd: Command,
-      context: ActorContext[ProcessorCommand],
-      dryRun: Boolean = false
-  ): Unit = {
-    def tellResult(evaluateResult: EvaluationResult) = {
-      val result = if (dryRun) { DryRunResult(evaluateResult) }
-      else { evaluateResult }
-      IO(context.self ! result)
-    }
-
-    val scope = if (dryRun) "testing" else "evaluating"
-    val eval  = for {
-      _ <- IO.shift(config.evaluationExecutionContext)
-      r <- definition.evaluate(state, cmd).attempt
-      _ <- IO.shift(context.executionContext)
-      _ <- tellResult(
-             r.map {
-               case e if dryRun => EvaluationSuccess(e, definition.next(state, e))
-               case e           => EvaluationSuccessInternal(e)
-             }.valueOr(EvaluationRejection(_))
-           )
-    } yield ()
-    val io    = eval
-      .timeoutTo(
-        config.evaluationMaxDuration, {
-          IO.shift(context.executionContext) >>
-            IO.delay(context.log.error2(s"Timed out while $scope command '{}' on actor '{}'", cmd, id)) >>
-            tellResult(EvaluationCommandTimeout(cmd, config.evaluationMaxDuration))
-        }
-      )
-      .onError { case NonFatal(th) =>
-        IO.shift(context.executionContext) >>
-          IO.delay(context.log.error2(s"Error while $scope command '{}' on actor '{}'", cmd, id)) >>
-          tellResult(EvaluationCommandError(cmd, Option(th.getMessage)))
-      }
-
-    io.runAsyncAndForget
-  }
 }
 
 object EventSourceProcessor {
@@ -352,10 +402,11 @@ object EventSourceProcessor {
   /**
     * Event source processor relying on akka-persistence
     * so than its state can be recovered
-    * @param entityId the entity identifier
-    * @param definition the event definition
+    *
+    * @param entityId            the entity identifier
+    * @param definition          the event definition
     * @param stopAfterInactivity the behavior to adopt when we stop the actor
-    * @param config the config
+    * @param config              the config
     */
   def persistent[State: ClassTag, Command: ClassTag, Event: ClassTag, Rejection: ClassTag](
       entityId: String,
@@ -372,10 +423,11 @@ object EventSourceProcessor {
 
   /**
     * Event source processor without persistence: if the processor is lost, so is its state
-    * @param entityId the entity identifier
-    * @param definition the event definition
+    *
+    * @param entityId            the entity identifier
+    * @param definition          the event definition
     * @param stopAfterInactivity the behavior to adopt when we stop the actor
-    * @param config the config
+    * @param config              the config
     */
   def transient[State: ClassTag, Command: ClassTag, Event: ClassTag, Rejection: ClassTag](
       entityId: String,

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/EventSourceProcessor.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/EventSourceProcessor.scala
@@ -242,10 +242,10 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
               stopAfterInactivity(context.self)
             case ChildActorResponse.AppendResult(_, _)                      =>
               context.log.error("Getting an append result should happen within the 'appending' behavior")
-              Behaviors.same
+              Behaviors.unhandled
             case ChildActorResponse.StateResponseInternal(_)                =>
               context.log.error("Getting the state from within should happen within the 'fetchingState' behavior")
-              Behaviors.same
+              Behaviors.unhandled
           }
 
         /**
@@ -273,10 +273,10 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
               stopAfterInactivity(context.self)
             case _: EvaluationResult                                    =>
               context.log.error("Getting an evaluation result should happen within the 'evaluating' behavior")
-              Behaviors.same
+              Behaviors.unhandled
             case ChildActorResponse.AppendResult(_, _)                  =>
               context.log.error("Getting an append result should happen within the 'appending' behavior")
-              Behaviors.same
+              Behaviors.unhandled
           }
 
         /**
@@ -309,10 +309,10 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
               Behaviors.same
             case ChildActorResponse.AppendResult(_, _)                          =>
               context.log.error("Getting an append result should happen within the 'appending' behavior")
-              Behaviors.same
+              Behaviors.unhandled
             case ChildActorResponse.StateResponseInternal(_)                    =>
               context.log.error("Getting the state from within should happen within the 'fetchingState' behavior")
-              Behaviors.same
+              Behaviors.unhandled
           }
 
         /**
@@ -337,10 +337,10 @@ private[processor] class EventSourceProcessor[State, Command, Event, Rejection](
               Behaviors.same
             case _: EvaluationResult                                         =>
               context.log.error("Getting an evaluation result should happen within the 'evaluating' behavior")
-              Behaviors.same
+              Behaviors.unhandled
             case ChildActorResponse.StateResponseInternal(_)                 =>
               context.log.error("Getting the state from within should happen within the 'fetchingState' behavior")
-              Behaviors.same
+              Behaviors.unhandled
           }
 
         // The actor will be stopped if it doesn't receive any message

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/ProcessorCommand.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/ProcessorCommand.scala
@@ -49,12 +49,12 @@ object ProcessorCommand {
   /**
     * Messages issued from within the [[EventSourceProcessor]] as an evaluation result
     */
-  sealed private[processor] trait EvaluationResult extends ProcessorCommand
-  private[processor] object EvaluationResult {
-    final case class EvaluationSuccess[Event, State](event: Event, state: State) extends EvaluationResult
-    final case class EvaluationRejection[Rejection](value: Rejection)            extends EvaluationResult
+  sealed private[processor] trait EvaluationResultInternal extends ProcessorCommand
+  private[processor] object EvaluationResultInternal {
+    final case class EvaluationSuccess[Event, State](event: Event, state: State) extends EvaluationResultInternal
+    final case class EvaluationRejection[Rejection](value: Rejection)            extends EvaluationResultInternal
 
-    sealed trait EvaluationError extends Exception with EvaluationResult
+    sealed trait EvaluationError extends Exception with EvaluationResultInternal
     final case class EvaluationTimeout[Command](value: Command, timeoutAfter: FiniteDuration) extends EvaluationError
     final case class EvaluationFailure[Command](value: Command, message: Option[String]) extends EvaluationError
   }

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/ProcessorCommand.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/ProcessorCommand.scala
@@ -1,139 +1,92 @@
 package ch.epfl.bluebrain.nexus.sourcing.processor
 
 import akka.actor.typed.ActorRef
-import akka.routing.ConsistentHashingRouter.ConsistentHashable
-import ch.epfl.bluebrain.nexus.sourcing.processor.AggregateReply.{LastSeqNr, StateReply}
 
 import scala.concurrent.duration.FiniteDuration
 
 /**
-  * Command used in [[EventSourceProcessor]]
+  * Incoming messages to [[EventSourceProcessor]] actor
   */
 sealed trait ProcessorCommand extends Product with Serializable
 
+// format: off
 object ProcessorCommand {
 
   /**
-    * Event sent when the [[EventSourceProcessor]] has been idling for too long
-    * according to a defined [[StopStrategy]]
+    * Incoming messages from the outside to [[EventSourceProcessor]] actor
     */
-  private[processor] case object Idle extends ProcessorCommand
-
-  /**
-    * Command sent to the [[EventSourceProcessor]] by an other component.
-    * The id has to match the entity id of the instance of the eventProcessor
-    */
-  sealed trait InputCommand extends ConsistentHashable with ProcessorCommand {
+  sealed trait AggregateRequest extends ProcessorCommand  {
 
     /**
-      * @return the persistence id
-      */
+     * @return the persistence id
+     */
     def id: String
+  }
 
-    override def consistentHashKey: String = id
+  object AggregateRequest {
+    final case class Evaluate[Command](id: String, command: Command, replyTo: ActorRef[AggregateResponse.EvaluationResult]) extends AggregateRequest
+    final case class DryRun[Command](id: String, command: Command, replyTo: ActorRef[AggregateResponse.EvaluationResult]) extends AggregateRequest
+
+    sealed trait ReadOnlyRequest extends AggregateRequest
+    final case class RequestState[State](id: String, replyTo: ActorRef[AggregateResponse.StateResponse[State]]) extends ReadOnlyRequest
+    final case class RequestLastSeqNr(id: String, replyTo: ActorRef[AggregateResponse.LastSeqNr]) extends ReadOnlyRequest
   }
 
   /**
-    * Command that can be forwarded from the [[EventSourceProcessor]] to its child actor stateActor
+    * Message issued when when passivation is triggered
     */
-  sealed trait EventSourceCommand extends InputCommand
+  final private[processor] case object Idle extends ProcessorCommand
 
   /**
-    * Read only commands that don't need to be stashed when a [[Evaluate]] is running
+    * Outgoing messages from child actor to the [[EventSourceProcessor]] actor
     */
-  sealed trait ReadonlyCommand                                                               extends EventSourceCommand
-  final case class RequestState[State](id: String, replyTo: ActorRef[StateReply[State]])     extends ReadonlyCommand
-  final case class RequestLastSeqNr(id: String, replyTo: ActorRef[LastSeqNr])                extends ReadonlyCommand
-  final private[processor] case class RequestStateInternal[State](
-      id: String,
-      replyTo: ActorRef[ResponseStateInternal[State]]
-  )                                                                                          extends ReadonlyCommand
-  final private[processor] case class ResponseStateInternal[State](id: String, value: State) extends ReadonlyCommand
+  sealed private[processor] trait ChildActorResponse extends ProcessorCommand
+  private[processor] object ChildActorResponse {
+    final case class AppendResult[Event, State](event: Event, state: State) extends ChildActorResponse
+    final case class StateResponseInternal[State](value: State)             extends ChildActorResponse
+  }
 
   /**
-    * Internal message sent by the [[EventSourceProcessor]] to its state actor.
-    *
-    * @param event   the event to persist
-    * @param replyTo the actor to send the reply to (the [[EventSourceProcessor]] actor)
+    * Messages issued from within the [[EventSourceProcessor]] as an evaluation result
     */
-  final case class Append[Event, State] private[processor] (
-      id: String,
-      event: Event,
-      replyTo: ActorRef[AppendSuccess[Event, State]]
-  ) extends EventSourceCommand
+  sealed private[processor] trait EvaluationResult extends ProcessorCommand
+  private[processor] object EvaluationResult {
+    final case class EvaluationSuccess[Event, State](event: Event, state: State) extends EvaluationResult
+    final case class EvaluationRejection[Rejection](value: Rejection)            extends EvaluationResult
 
-  /**
-    * Internal message sent by the state actor to the [[EventSourceProcessor]] signaling a successful append of an Event
-    *
-    * @param event the appended
-    * @param state the state generated from the appended event
-    */
-  final case class AppendSuccess[Event, State] private[processor] (id: String, event: Event, state: State)
-      extends EventSourceCommand
+    sealed trait EvaluationError extends Exception with EvaluationResult
+    final case class EvaluationTimeout[Command](value: Command, timeoutAfter: FiniteDuration) extends EvaluationError
+    final case class EvaluationFailure[Command](value: Command, message: Option[String]) extends EvaluationError
+  }
+}
+// format: on
 
-  /**
-    * Defines a command to evaluate the command giving a [[EvaluationResult]]
-    * which is sent back to the replyTo
-    *
-    * @param command the command to evaluate
-    * @param replyTo the actor to send the result to
-    */
-  final case class Evaluate[Command](id: String, command: Command, replyTo: ActorRef[EvaluationResult])
-      extends InputCommand
-
-  /**
-    * Same thing as [[Evaluate]] but the result is never appended to the event log
-    * @param command the command to test
-    * @param replyTo the actor to send the result to
-    */
-  final case class DryRun[Command](id: String, command: Command, replyTo: ActorRef[DryRunResult]) extends InputCommand
-
-  // Evaluation results
-  sealed trait RunResult        extends ProcessorCommand
-  sealed trait EvaluationResult extends RunResult
-
-  /**
-    * Describes the event and the state computed when an an [[Evaluate]] or a [[DryRun]]
-    * has been successfully evaluated
-    *
-    * @param event the generated event
-    * @param state the new state
-    */
-  final case class EvaluationSuccess[Event, State](event: Event, state: State) extends EvaluationResult
-
-  /**
-    * Describes the event resulting from a successful evaluation.
-    *
-    * @param event the generated event
-    */
-  final private[processor] case class EvaluationSuccessInternal[Event](event: Event) extends EvaluationResult
-
-  /**
-    * Rejection that occured after running an an [[Evaluate]] or a [[DryRun]]
-    * @param value the rejection
-    */
-  final case class EvaluationRejection[Rejection](value: Rejection) extends EvaluationResult
-
-  /**
-    * Error that occured after running an [[Evaluate]] or a [[DryRun]]
-    */
-  abstract class EvaluationError                                                            extends Exception with EvaluationResult
-  final case class EvaluationCommandTimeout[Command](value: Command, timeoutAfter: FiniteDuration)
-      extends EvaluationError
-  final case class EvaluationCommandError[Command](value: Command, message: Option[String]) extends EvaluationError
-
-  /**
-    * Result of a [[DryRun]]
-    * @param result the result we got, can be a success / a rejection / an error
-    */
-  final case class DryRunResult(result: EvaluationResult) extends RunResult
-
+/**
+  * Incoming messages from within the [[EventSourceProcessor]] to child actor
+  */
+sealed private[processor] trait ChildActorRequest extends Product with Serializable
+private[processor] object ChildActorRequest {
+  final case class RequestLastSeqNr(replyTo: ActorRef[AggregateResponse.LastSeqNr]) extends ChildActorRequest
+  final case class RequestState[State](replyTo: ActorRef[AggregateResponse.StateResponse[State]])
+      extends ChildActorRequest
+  final case object RequestStateInternal                                            extends ChildActorRequest
+  final case class Append[Event](event: Event)                                      extends ChildActorRequest
 }
 
-// Replies
-sealed trait AggregateReply extends Product with Serializable
+/**
+  * Replies from [[EventSourceProcessor]] actor to the outside
+  */
+sealed trait AggregateResponse extends Product with Serializable
 
-object AggregateReply {
-  final case class LastSeqNr(value: Long)          extends AggregateReply
-  final case class StateReply[State](value: State) extends AggregateReply
+object AggregateResponse {
+  final case class LastSeqNr(value: Long)             extends AggregateResponse
+  final case class StateResponse[State](value: State) extends AggregateResponse
+
+  sealed trait EvaluationResult                                                extends AggregateResponse
+  final case class EvaluationSuccess[Event, State](event: Event, state: State) extends EvaluationResult
+  final case class EvaluationRejection[Rejection](value: Rejection)            extends EvaluationResult
+
+  sealed trait EvaluationError                                                              extends Exception with EvaluationResult
+  final case class EvaluationTimeout[Command](value: Command, timeoutAfter: FiniteDuration) extends EvaluationError
+  final case class EvaluationFailure[Command](value: Command, message: Option[String])      extends EvaluationError
 }

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/package.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/sourcing/processor/package.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.sourcing
 
-import ch.epfl.bluebrain.nexus.sourcing.processor.ProcessorCommand.{EvaluationRejection, EvaluationSuccess}
+import ch.epfl.bluebrain.nexus.sourcing.processor.AggregateResponse._
 import monix.bio.IO
 
 package object processor {


### PR DESCRIPTION
Added several behaviors to make a clear distinction between the possible stages of a command evaluation. This makes sure that no unexpected messages get received at any different behavior.

I've also moved completely the state lifecycle to the `stateActor`. Before it was the case, kind of, but the parent actor kept the state too (for dryrun and to perform computations).

Behaviors:

1. active: Ready to process `Evaluate` and `DryRun` messages. Before evaluating a command we need the state, so we ask the stateActor for it and move our behavior to waitingToEvaluate. `RequestState` and `RequestLastSeqNr` messages will be processed by forwarding them to the state actor.
2. waitingToEvaluate: Ready to process `StateResponseInternal`. Once received, we trigger command evaluation/dryrun and move our behavior to evaluating. `RequestState` and `RequestLastSeqNr` messages will be processed by forwarding them to the state actor, while any other `Evaluate` or `DryRun` will be stashed.
3. evaluating: Ready to process evaluation `EvaluationResult` messages. If the evaluation succeeded and we are not on a `DryRun`, we will send an `Append` message to the stateActor with the computed event and move to the appending behavior. Otherwise we return the `EvaluationResult` to the client and unstash other messages while moving to active behavior. `RequestState` and `RequestLastSeqNr` messages will be processed by forwarding them to the state actor, while any other `Evaluate` or `DryRun` will be stashed.
4. appending: Ready to process `AppendResult` messages, to confirm correct append on the event log from the stateActor. After that we reply to the client and unstash other messages while moving to active behavior. `RequestState` and `RequestLastSeqNr` messages will be processed by forwarding them to the state actor, while any other `Evaluate` or `DryRun` will be stashed.