### PR TITLE
Wiring resources

### DIFF
--- a/delta/app/src/main/resources/akka.conf
+++ b/delta/app/src/main/resources/akka.conf
@@ -23,7 +23,9 @@ akka {
     }
 
     serialization-bindings {
-      "ch.epfl.bluebrain.nexus.delta.sdk.model.Event" = "circe"
+      "ch.epfl.bluebrain.nexus.delta.sdk.model.Event"                              = "circe"
+      "java.nio.file.Path"                                                         = "kryo"
+      "org.apache.jena.iri.IRI"                                                    = "kryo"
       "ch.epfl.bluebrain.nexus.delta.service.cache.SubscriberCommand$Unsubscribe$" = "kryo"
     }
   }
@@ -76,4 +78,5 @@ akka-kryo-serialization {
   id-strategy = "automatic"
   implicit-registration-logging = true
   resolve-subclasses = false
+  kryo-initializer = "ch.epfl.bluebrain.nexus.delta.KryoSerializerInit"
 }

--- a/delta/app/src/main/resources/akka.conf
+++ b/delta/app/src/main/resources/akka.conf
@@ -26,6 +26,7 @@ akka {
       "ch.epfl.bluebrain.nexus.delta.sdk.model.Event"                              = "circe"
       "java.nio.file.Path"                                                         = "kryo"
       "org.apache.jena.iri.IRI"                                                    = "kryo"
+      "org.apache.jena.rdf.model.Model"                                            = "kryo"
       "ch.epfl.bluebrain.nexus.delta.service.cache.SubscriberCommand$Unsubscribe$" = "kryo"
     }
   }

--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -176,6 +176,18 @@ app {
     indexing = ${app.defaults.indexing}
   }
 
+  # Resources configuration
+  resources {
+    # the resources aggregate configuration
+    aggregate {
+      snapshot-strategy = ${app.defaults.snapshot-default}
+      stop-strategy = ${app.defaults.passivate-since-last-interaction}
+      ask-timeout = 15 seconds
+      evaluation-max-duration = 8 seconds # Increased this value since during evaluation SHACL validation can occur
+      stash-size = 10
+    }
+  }
+
   defaults {
     # default aggregate configuration
     aggregate {
@@ -268,12 +280,10 @@ app {
       lapsed-since-recovery-completed = null
     }
 
-    # passivate aggregate actor after 5 seconds have passed since last message
+    # passivate aggregate actor after 10 seconds have passed since last message
     passivate-since-last-interaction {
-      # duration since the last received message after which the aggregate actors should shut down
-      lapsed-since-last-interaction = 5 seconds
-      # duration since the aggregate actors' recovery after which they should shut down
-      lapsed-since-recovery-completed = 0 milliseconds
+      # duration since the last received message after which the aggregate actors should shut down.
+      lapsed-since-last-interaction = 10 seconds
     }
 
   }

--- a/delta/app/src/main/resources/kamon.conf
+++ b/delta/app/src/main/resources/kamon.conf
@@ -62,6 +62,17 @@ kamon {
   }
 
   modules {
+
+    host-metrics {
+      # Set to 'no' might help when running it locally with Mac Os 11
+      enabled = no
+    }
+
+    process-metrics {
+      # Set to 'no' might help when running it locally with Mac Os 11
+      enabled = no
+    }
+
     jaeger {
       enabled = ${app.monitoring.jaeger.enabled}
     }

--- a/delta/app/src/main/resources/kamon.conf
+++ b/delta/app/src/main/resources/kamon.conf
@@ -65,12 +65,12 @@ kamon {
 
     host-metrics {
       # Set to 'no' might help when running it locally with Mac Os 11
-      enabled = no
+      enabled = yes
     }
 
     process-metrics {
       # Set to 'no' might help when running it locally with Mac Os 11
-      enabled = no
+      enabled = yes
     }
 
     jaeger {

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializerInit.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializerInit.scala
@@ -1,0 +1,46 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import java.nio.file.Path
+
+import ch.epfl.bluebrain.nexus.delta.KryoSerializerInit._
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import io.altoo.akka.serialization.kryo.DefaultKryoInitializer
+import io.altoo.akka.serialization.kryo.serializer.scala.ScalaKryo
+import org.apache.jena.iri.{IRI, IRIFactory}
+
+class KryoSerializerInit extends DefaultKryoInitializer {
+
+  override def postInit(kryo: ScalaKryo): Unit = {
+    super.postInit(kryo)
+    kryo.addDefaultSerializer(classOf[IRI], classOf[IRISerializer])
+    kryo.register(classOf[IRI], new IRISerializer)
+
+    kryo.addDefaultSerializer(classOf[Path], classOf[PathSerializer])
+    kryo.register(classOf[Path], new PathSerializer)
+
+    ()
+  }
+}
+
+object KryoSerializerInit {
+
+  class IRISerializer extends Serializer[IRI] {
+    private val iriFactory = IRIFactory.iriImplementation()
+
+    override def write(kryo: Kryo, output: Output, iri: IRI): Unit =
+      output.writeString(iri.toString)
+
+    override def read(kryo: Kryo, input: Input, `type`: Class[IRI]): IRI =
+      iriFactory.create(input.readString())
+  }
+
+  class PathSerializer extends Serializer[Path] {
+
+    override def write(kryo: Kryo, output: Output, path: Path): Unit =
+      output.writeString(path.toString)
+
+    override def read(kryo: Kryo, input: Input, `type`: Class[Path]): Path =
+      Path.of(input.readString())
+  }
+}

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route, RouteResult}
 import cats.effect.ExitCode
 import ch.epfl.bluebrain.nexus.delta.config.AppConfig
-import ch.epfl.bluebrain.nexus.delta.routes.{AclsRoutes, IdentitiesRoutes, OrganizationsRoutes, PermissionsRoutes, ProjectsRoutes, RealmsRoutes}
+import ch.epfl.bluebrain.nexus.delta.routes.{AclsRoutes, IdentitiesRoutes, OrganizationsRoutes, PermissionsRoutes, ProjectsRoutes, RealmsRoutes, ResourcesRoutes}
 import ch.epfl.bluebrain.nexus.delta.wiring.DeltaModule
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives.cors
 import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
@@ -54,7 +54,8 @@ object Main extends BIOApp {
             locator.get[RealmsRoutes].routes,
             locator.get[AclsRoutes].routes,
             locator.get[OrganizationsRoutes].routes,
-            locator.get[ProjectsRoutes].routes
+            locator.get[ProjectsRoutes].routes,
+            locator.get[ResourcesRoutes].routes
           )
         }
       }

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/AppConfig.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/AppConfig.scala
@@ -23,6 +23,7 @@ import pureconfig.{ConfigReader, ConfigSource}
   * @param organizations  the organizations config
   * @param acls           the ACLs config
   * @param projects       the projects config
+  * @param resources      the resources config
   * @param serviceAccount the service account config
   */
 final case class AppConfig(
@@ -36,6 +37,7 @@ final case class AppConfig(
     organizations: OrganizationsConfig,
     acls: AclsConfig,
     projects: ProjectsConfig,
+    resources: ResourcesConfig,
     serviceAccount: ServiceAccountConfig
 )
 

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/ConfigReaderInstances.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/ConfigReaderInstances.scala
@@ -191,6 +191,9 @@ trait ConfigReaderInstances {
   implicit final val projectConfigReader: ConfigReader[ProjectsConfig] =
     deriveReader[ProjectsConfig]
 
+  implicit final val resourcesConfigReader: ConfigReader[ResourcesConfig] =
+    deriveReader[ResourcesConfig]
+
 }
 
 object ConfigReaderInstances extends ConfigReaderInstances

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/ResourcesConfig.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/ResourcesConfig.scala
@@ -1,0 +1,10 @@
+package ch.epfl.bluebrain.nexus.delta.config
+
+import ch.epfl.bluebrain.nexus.delta.service.config.AggregateConfig
+
+/**
+  * Configuration for the Resources module.
+  *
+  * @param aggregate configuration of the underlying aggregate
+  */
+final case class ResourcesConfig(aggregate: AggregateConfig)

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/models/JsonSource.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/models/JsonSource.scala
@@ -1,0 +1,41 @@
+package ch.epfl.bluebrain.nexus.delta.routes.models
+
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.UnexpectedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, JsonLd, JsonLdEncoder}
+import ch.epfl.bluebrain.nexus.delta.syntax._
+import io.circe.{Json, JsonObject}
+import monix.bio.IO
+
+/**
+  * Holds the source payload as the client posted it of a resource as [[Json]]
+  *
+  * @param value the client payload
+  * @param id    the source identifier
+  */
+final case class JsonSource(value: Json, id: Iri) {
+  def context: ContextValue = value.topContextValueOrEmpty
+}
+
+object JsonSource {
+  implicit val jsonLdEncoderJsonResource: JsonLdEncoder[JsonSource] =
+    new JsonLdEncoder[JsonSource] {
+
+      private def toObj(json: Json): Either[RdfError, JsonObject] =
+        json.arrayOrObject(
+          or = Left(UnexpectedJsonLd("Expected a Json Object or a Json Array")),
+          arr =>
+            arr.singleEntry
+              .flatMap(_.asObject)
+              .toRight(UnexpectedJsonLd("Expected Json Array with single Json Object")),
+          obj => Right(obj)
+        )
+
+      override def compact(value: JsonSource): IO[RdfError, CompactedJsonLd] =
+        IO.fromEither(toObj(value.value)).map(obj => JsonLd.compactedUnsafe(obj, value.context, value.id))
+
+      override def context(value: JsonSource): ContextValue = value.context
+    }
+}

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/models/TagFields.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/models/TagFields.scala
@@ -1,4 +1,4 @@
-package ch.epfl.bluebrain.nexus.delta.routes
+package ch.epfl.bluebrain.nexus.delta.routes.models
 
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
 import io.circe.Decoder

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/DeltaModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/DeltaModule.scala
@@ -75,6 +75,7 @@ class DeltaModule(appCfg: AppConfig, config: Config) extends ModuleDef with Clas
   include(RealmsModule)
   include(OrganizationsModule)
   include(ProjectsModule)
+  include(ResourcesModule)
   include(IdentitiesModule)
 }
 

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResourcesModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResourcesModule.scala
@@ -1,0 +1,62 @@
+package ch.epfl.bluebrain.nexus.delta.wiring
+
+import akka.actor.typed.ActorSystem
+import cats.effect.Clock
+import ch.epfl.bluebrain.nexus.delta.config.AppConfig
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.routes.ResourcesRoutes
+import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.ResourceEvent
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, ResourceRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.utils.UUIDF
+import ch.epfl.bluebrain.nexus.delta.sdk._
+import ch.epfl.bluebrain.nexus.delta.service.resources.ResourcesImpl
+import ch.epfl.bluebrain.nexus.sourcing.EventLog
+import izumi.distage.model.definition.ModuleDef
+import monix.bio.UIO
+import monix.execution.Scheduler
+
+/**
+  * Resources wiring
+  */
+object ResourcesModule extends ModuleDef {
+
+  // TODO: Change this when we have schemas implemented
+  private val fetchSchema: ResourceRef => UIO[Option[SchemaResource]] = _ => UIO.pure(None)
+
+  make[EventLog[Envelope[ResourceEvent]]].fromEffect { databaseEventLog[ResourceEvent](_, _) }
+
+  make[Resources].fromEffect {
+    (
+        config: AppConfig,
+        eventLog: EventLog[Envelope[ResourceEvent]],
+        organizations: Organizations,
+        projects: Projects,
+        cr: RemoteContextResolution,
+        as: ActorSystem[Nothing]
+    ) =>
+      ResourcesImpl(
+        organizations,
+        projects,
+        fetchSchema,
+        config.resources.aggregate,
+        eventLog
+      )(cr, UUIDF.random, as, Clock[UIO])
+  }
+
+  make[ResourcesRoutes].from {
+    (
+        identities: Identities,
+        acls: Acls,
+        organizations: Organizations,
+        projects: Projects,
+        resources: Resources,
+        baseUri: BaseUri,
+        s: Scheduler,
+        cr: RemoteContextResolution,
+        ordering: JsonKeyOrdering
+    ) =>
+      new ResourcesRoutes(identities, acls, organizations, projects, resources)(baseUri, s, cr, ordering)
+  }
+
+}

--- a/delta/app/src/test/resources/application.conf
+++ b/delta/app/src/test/resources/application.conf
@@ -1,0 +1,17 @@
+include required(classpath("default.conf"))
+
+akka.remote.artery.canonical.port=0
+
+kamon {
+  modules {
+    host-metrics {
+      # Set to 'no' might help when running it locally with Mac Os 11
+      enabled = no
+    }
+
+    process-metrics {
+      # Set to 'no' might help when running it locally with Mac Os 11
+      enabled = no
+    }
+  }
+}

--- a/delta/app/src/test/resources/kryo/expanded.json
+++ b/delta/app/src/test/resources/kryo/expanded.json
@@ -1,0 +1,84 @@
+[
+  {
+    "@id": "http://nexus.example.com/john-doé",
+    "@type": [
+      "http://schema.org/Person"
+    ],
+    "http://example.com/address": [
+      {
+        "@id": "http://nexus.example.com/myaddress",
+        "http://example.com/customid": [
+          {
+            "@id": "http://nexus.example.com/myid"
+          }
+        ],
+        "http://example.com/number": [
+          {
+            "@value": 2
+          }
+        ],
+        "http://example.com/street": [
+          {
+            "@value": "my street"
+          }
+        ]
+      }
+    ],
+    "http://schema.org/deprecated": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": false
+      }
+    ],
+    "http://example.com/otherProperty": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#other",
+        "@value": "value"
+      }
+    ],
+    "http://example.org/stringProperty": [
+      {
+        "@value": "Some \"property"
+      }
+    ],
+    "http://schema.org/birthDate": [
+      {
+        "@value": "1999-04-09T20:00Z"
+      }
+    ],
+    "http://schema.org/name": [
+      {
+        "@value": "John Doe"
+      }
+    ],
+    "http://example.com/sibling": [
+      {
+        "@id": "http://nexus.example.com/another",
+        "@type": [
+          "http://schema.org/Other"
+        ],
+        "http://schema.org/birthDate": [
+          {
+            "@value": "2000-04-12T20:00Z"
+          }
+        ],
+        "http://schema.org/birthHour": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#integer",
+            "@value": 9
+          }
+        ],
+        "http://schema.org/birthYear": [
+          {
+            "@value": 1999
+          }
+        ],
+        "http://schema.org/height": [
+          {
+            "@value": 9.223
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializationInitSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializationInitSpec.scala
@@ -5,7 +5,10 @@ import java.nio.file.Paths
 import akka.actor.ActorSystem
 import akka.serialization.SerializationExtension
 import akka.testkit.TestKit
-import com.typesafe.config.ConfigFactory
+import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
 import io.altoo.akka.serialization.kryo.KryoSerializer
 import org.apache.jena.iri.{IRI, IRIFactory}
 import org.scalatest.TryValues
@@ -13,10 +16,13 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class KryoSerializerInitSpec
-    extends TestKit(ActorSystem("KryoSerializerInitSpec", ConfigFactory.load("default.conf")))
+    extends TestKit(ActorSystem("KryoSerializerInitSpec"))
     with AnyWordSpecLike
     with Matchers
-    with TryValues {
+    with TryValues
+    with TestHelpers
+    with IOValues {
+
   private val serialization = SerializationExtension(system)
 
   "A Path Kryo serialization" should {
@@ -34,6 +40,28 @@ class KryoSerializerInitSpec
       val deserialized = serialization.deserialize(serialized.get, path.getClass)
       deserialized.isSuccess shouldEqual true
       deserialized.success.value shouldEqual path
+    }
+  }
+
+  "An Jena Model Kryo serialization" should {
+    implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed()
+    val expanded                              = JsonLd.expand(jsonContentOf("/kryo/expanded.json")).accepted
+    val graph                                 = Graph(expanded).accepted
+
+    "succeed" in {
+
+      // Find the Serializer for it
+      val serializer = serialization.findSerializerFor(graph.model)
+      serializer.getClass.equals(classOf[KryoSerializer]) shouldEqual true
+
+      // Check serialization/deserialization
+      val serialized = serialization.serialize(graph.model)
+      serialized.isSuccess shouldEqual true
+
+      val deserialized      = serialization.deserialize(serialized.get, graph.model.getClass)
+      deserialized.isSuccess shouldEqual true
+      val deserializedModel = deserialized.success.value
+      Graph(graph.rootNode, deserializedModel).triples shouldEqual graph.triples
     }
   }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializationInitSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializationInitSpec.scala
@@ -1,0 +1,60 @@
+package ch.epfl.bluebrain.nexus.delta
+
+import java.nio.file.Paths
+
+import akka.actor.ActorSystem
+import akka.serialization.SerializationExtension
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import io.altoo.akka.serialization.kryo.KryoSerializer
+import org.apache.jena.iri.{IRI, IRIFactory}
+import org.scalatest.TryValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class KryoSerializerInitSpec
+    extends TestKit(ActorSystem("KryoSerializerInitSpec", ConfigFactory.load("default.conf")))
+    with AnyWordSpecLike
+    with Matchers
+    with TryValues {
+  private val serialization = SerializationExtension(system)
+
+  "A Path Kryo serialization" should {
+    "succeed" in {
+      val path = Paths.get("resources/application.conf")
+
+      // Find the Serializer for it
+      val serializer = serialization.findSerializerFor(path)
+      serializer.getClass.equals(classOf[KryoSerializer]) shouldEqual true
+
+      // Check serialization/deserialization
+      val serialized = serialization.serialize(path)
+      serialized.isSuccess shouldEqual true
+
+      val deserialized = serialization.deserialize(serialized.get, path.getClass)
+      deserialized.isSuccess shouldEqual true
+      deserialized.success.value shouldEqual path
+    }
+  }
+
+  "An Jena IRI Kryo serialization" should {
+    val iriFactory = IRIFactory.iriImplementation()
+
+    "succeed" in {
+      val iri: IRI = iriFactory.create("http://example.com")
+
+      // Find the Serializer for it
+      val serializer = serialization.findSerializerFor(iri)
+      serializer.getClass.equals(classOf[KryoSerializer]) shouldEqual true
+
+      // Check serialization/deserialization
+      val serialized = serialization.serialize(iri)
+      serialized.isSuccess shouldEqual true
+
+      val deserialized = serialization.deserialize(serialized.get, iri.getClass)
+      deserialized.isSuccess shouldEqual true
+      deserialized.success.value shouldEqual iri
+    }
+  }
+
+}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
@@ -236,7 +236,11 @@ class ResourcesRoutesSpec
         "/v1/resources/myorg/myproject/_/myid",
         s"/v1/resources/myorg/myproject/resource/$myIdEncoded",
         "/v1/resources/myorg/myproject/_/myid?rev=3",
-        "/v1/resources/myorg/myproject/_/myid2?tag=mytag"
+        "/v1/resources/myorg/myproject/_/myid2?tag=mytag",
+        "/v1/resources/myorg/myproject/_/myid",
+        s"/v1/resources/myorg/myproject/resource/$myIdEncoded/source",
+        "/v1/resources/myorg/myproject/_/myid/source?rev=3",
+        "/v1/resources/myorg/myproject/_/myid2/source?tag=mytag"
       )
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> routes ~> check {
@@ -271,6 +275,30 @@ class ResourcesRoutesSpec
         Get(endpoint) ~> routes ~> check {
           status shouldEqual StatusCodes.OK
           response.asJson shouldEqual meta.deepMerge(payload).deepMerge(resourceCtx)
+        }
+      }
+    }
+
+    "fetch a resource original payload" in {
+      Get("/v1/resources/myorg/myproject/_/myid/source") ~> routes ~> check {
+        status shouldEqual StatusCodes.OK
+        response.asJson shouldEqual payloadUpdated
+      }
+    }
+
+    "fetch a resource original payload by rev and tag" in {
+      val endpoints = List(
+        "/v1/resources/myorg/myproject/myschema/myid2/source?rev=1",
+        "/v1/resources/myorg/myproject/_/myid2/source?rev=1",
+        s"/v1/resources/$uuidOrg/$uuidProj/_/myid2/source?rev=1",
+        "/v1/resources/myorg/myproject/myschema/myid2/source?tag=mytag",
+        s"/v1/resources/$uuidOrg/$uuidProj/_/myid2/source?tag=mytag"
+      )
+      val payload   = jsonContentOf("resources/resource.json", "id" -> myId2)
+      forAll(endpoints) { endpoint =>
+        Get(endpoint) ~> routes ~> check {
+          status shouldEqual StatusCodes.OK
+          response.asJson shouldEqual payload
         }
       }
     }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
@@ -51,13 +51,13 @@ final case class CompactedJsonLd private[jsonld] (
   def add(key: String, literal: Double): This =
     add(key, literal.asJson)
 
-  def toCompacted(context: Json)(implicit
+  def toCompacted(contextValue: ContextValue)(implicit
       opts: JsonLdOptions,
       api: JsonLdApi,
       resolution: RemoteContextResolution
   ): IO[RdfError, CompactedJsonLd] =
-    if (context.topContextValueOrEmpty == ctx) IO.pure(self)
-    else JsonLd.compact(json, context, rootId)
+    if (contextValue == ctx) IO.pure(self)
+    else JsonLd.compact(json, contextValue, rootId)
 
   override def toExpanded(implicit
       opts: JsonLdOptions,

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
@@ -73,6 +73,8 @@ final case class CompactedJsonLd private[jsonld] (
   ): IO[RdfError, Graph] =
     toExpanded.flatMap(_.toGraph)
 
+  override def isEmpty: Boolean = obj.isEmpty
+
   private def add(key: String, value: Json): This = {
     val newObj = obj(key) match {
       case Some(curr) =>

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
@@ -111,6 +111,8 @@ final case class ExpandedJsonLd private[jsonld] (obj: JsonObject, rootId: IriOrB
       resolution: RemoteContextResolution
   ): IO[RdfError, Graph] = Graph(this)
 
+  override def isEmpty: Boolean = obj.isEmpty
+
   private def add(key: String, value: Json): This =
     obj(key).flatMap(v => v.asArray) match {
       case None      => copy(obj = obj.add(key, Json.arr(value)))

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
@@ -6,7 +6,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.{IriOrBNode, RdfError}
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.syntax._
@@ -91,12 +91,12 @@ final case class ExpandedJsonLd private[jsonld] (obj: JsonObject, rootId: IriOrB
       case bNode: IriOrBNode.BNode                                           => new ExpandedJsonLd(obj.remove(keywords.id), bNode)
     }
 
-  def toCompacted(context: Json)(implicit
+  def toCompacted(contextValue: ContextValue)(implicit
       opts: JsonLdOptions,
       api: JsonLdApi,
       resolution: RemoteContextResolution
   ): IO[RdfError, CompactedJsonLd] =
-    JsonLd.compact(json, context, rootId)
+    JsonLd.compact(json, contextValue, rootId)
 
   override def toExpanded(implicit
       opts: JsonLdOptions,

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
@@ -73,10 +73,9 @@ trait JsonLd extends Product with Serializable {
   /**
     * Converts the current JsonLd into a [[CompactedJsonLd]]
     *
-    * @param context the context to use in order to compact the current JsonLd.
-    *                E.g.: {"@context": {...}}
+    * @param contextValue the context value to use in order to compact the current JsonLd.
     */
-  def toCompacted(context: Json)(implicit
+  def toCompacted(contextValue: ContextValue)(implicit
       opts: JsonLdOptions,
       api: JsonLdApi,
       resolution: RemoteContextResolution
@@ -156,16 +155,14 @@ object JsonLd {
     } yield ExpandedJsonLd(obj, idOpt.getOrElse(BNode.random))
 
   /**
-    * Create compacted JSON-LD document using the passed ''input'' and ''context''.
-    *
-    * If ContextFields.Include is passed it inspects the Context to include context fields like @base, @vocab, etc.
+    * Create compacted JSON-LD document using the passed ''input'' and ''context'' value.
     *
     * This method does NOT verify the passed ''rootId'' is present in the compacted form. It just verifies the compacted
     * form has the expected format (a Json Object without a top @graph only key)
     */
   final def compact(
       input: Json,
-      context: Json,
+      contextValue: ContextValue,
       rootId: IriOrBNode
   )(implicit
       api: JsonLdApi,
@@ -173,18 +170,18 @@ object JsonLd {
       opts: JsonLdOptions
   ): IO[RdfError, CompactedJsonLd] =
     for {
-      compacted <- api.compact(input, context)
+      compacted <- api.compact(input, contextValue)
       _         <- topGraphErr(compacted)
-    } yield CompactedJsonLd(compacted.remove(keywords.context), context.topContextValueOrEmpty, rootId)
+    } yield CompactedJsonLd(compacted.remove(keywords.context), contextValue, rootId)
 
   /**
-    * Create compacted JSON-LD document using the passed ''input'' and ''context''.
+    * Create compacted JSON-LD document using the passed ''input'' and ''context'' value.
     *
     * The ''rootId'' is enforced using a framing on it.
     */
   final def frame(
       input: Json,
-      context: Json,
+      contextValue: ContextValue,
       rootId: IriOrBNode
   )(implicit
       api: JsonLdApi,
@@ -192,11 +189,11 @@ object JsonLd {
       opts: JsonLdOptions
   ): IO[RdfError, CompactedJsonLd] = {
     val jsonId = rootId.asIri.fold(Json.obj())(rootIri => Json.obj(keywords.id -> rootIri.asJson))
-    val frame  = context.arrayOrObject(jsonId, arr => (arr :+ jsonId).asJson, _.asJson.deepMerge(jsonId))
+    val frame  = contextValue.contextObj.arrayOrObject(jsonId, arr => (arr :+ jsonId).asJson, _.asJson.deepMerge(jsonId))
     for {
       compacted <- api.frame(input, frame)
       _         <- topGraphErr(compacted)
-    } yield CompactedJsonLd(compacted.remove(keywords.context), context.topContextValueOrEmpty, rootId)
+    } yield CompactedJsonLd(compacted.remove(keywords.context), contextValue, rootId)
   }
 
   private def topGraphErr(obj: JsonObject): IO[RdfError, Unit] =

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
@@ -92,6 +92,11 @@ trait JsonLd extends Product with Serializable {
       api: JsonLdApi,
       resolution: RemoteContextResolution
   ): IO[RdfError, Graph]
+
+  /**
+    * Checks if the current [[JsonLd]] is empty
+    */
+  def isEmpty: Boolean
 }
 object JsonLd {
 

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLdEncoder.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLdEncoder.scala
@@ -51,7 +51,7 @@ trait JsonLdEncoder[A] {
     for {
       expanded <- expand(value)
       graph    <- expanded.toGraph
-      dot      <- graph.toDot(context(value).contextObj)
+      dot      <- graph.toDot(context(value))
     } yield dot
 
   /**

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApi.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApi.scala
@@ -1,7 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api
 
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{JsonLdContext, RemoteContextResolution}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, JsonLdContext, RemoteContextResolution}
 import io.circe.{Json, JsonObject}
 import monix.bio.IO
 import org.apache.jena.rdf.model.Model
@@ -12,7 +12,7 @@ import org.apache.jena.rdf.model.Model
   * Interface definition for frame: https://www.w3.org/TR/json-ld11-framing/#jsonldprocessor
   */
 trait JsonLdApi {
-  private[rdf] def compact(input: Json, ctx: Json)(implicit
+  private[rdf] def compact(input: Json, ctx: ContextValue)(implicit
       opts: JsonLdOptions,
       resolution: RemoteContextResolution
   ): IO[RdfError, JsonObject]
@@ -36,7 +36,7 @@ trait JsonLdApi {
       opts: JsonLdOptions
   ): IO[RdfError, Seq[JsonObject]]
 
-  private[rdf] def context(value: Json)(implicit
+  private[rdf] def context(value: ContextValue)(implicit
       opts: JsonLdOptions,
       resolution: RemoteContextResolution
   ): IO[RdfError, JsonLdContext]

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/context/JsonLdContext.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/context/JsonLdContext.scala
@@ -206,12 +206,12 @@ object JsonLdContext {
   }
 
   /**
-    * Construct a [[JsonLdContext]] from the passed ''context'' using the JsonLd api
+    * Construct a [[JsonLdContext]] from the passed ''context'' value using the JsonLd api
     */
   def apply(
-      context: Json
+      contextValue: ContextValue
   )(implicit api: JsonLdApi, resolution: RemoteContextResolution, opts: JsonLdOptions): IO[RdfError, JsonLdContext] =
-    api.context(context)
+    api.context(contextValue)
 
   /**
     * @return the value of the top @context key when found, an empty Json otherwise

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReport.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReport.scala
@@ -4,9 +4,7 @@ import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.predicate
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, sh}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
-import io.circe.syntax._
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import io.circe.{Encoder, Json}
 import monix.bio.IO
 import org.apache.jena.rdf.model.Resource
@@ -31,7 +29,7 @@ final case class ValidationReport private (conforms: Boolean, targetedNodes: Int
 
 object ValidationReport {
 
-  private val shaclCtx: Json = Json.obj(keywords.context -> contexts.shacl.asJson)
+  private val shaclCtx: ContextValue = ContextValue(contexts.shacl)
 
   final def apply(report: Resource)(implicit rcr: RemoteContextResolution): IO[String, ValidationReport] = {
     val tmpGraph = Graph.unsafe(report.getModel)

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/GraphSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/GraphSpec.scala
@@ -92,14 +92,14 @@ class GraphSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
     "be converted to dot with context" in {
       val expected = contentOf("graph/dot-compacted.dot", "bnode" -> bnode.rdfFormat, "rootNode" -> "john-doé")
-      val context  = jsonContentOf("context.json")
+      val context  = jsonContentOf("context.json").topContextValueOrEmpty
       graph.toDot(context).accepted.toString should equalLinesUnordered(expected)
     }
 
     "be converted to dot with context with a root blank node" in {
       val expected =
         contentOf("graph/dot-compacted.dot", "bnode" -> bnodeNoId.rdfFormat, "rootNode" -> rootBNode.rdfFormat)
-      val context  = jsonContentOf("context.json")
+      val context  = jsonContentOf("context.json").topContextValueOrEmpty
       graphNoId.toDot(context).accepted.toString should equalLinesUnordered(expected)
     }
 
@@ -120,7 +120,7 @@ class GraphSpec extends AnyWordSpecLike with Matchers with Fixtures {
     // The returned json is not exactly the same as the original compacted json from where the Graph was created.
     // This is expected due to the useNativeTypes field on JsonLdOptions and to the @context we have set in place
     "be converted to compacted JSON-LD" in {
-      val context   = jsonContentOf("context.json")
+      val context   = jsonContentOf("context.json").topContextValueOrEmpty
       val compacted = jsonContentOf("graph/compacted.json")
       graph.toCompactedJsonLd(context).accepted.json shouldEqual compacted
     }
@@ -128,7 +128,7 @@ class GraphSpec extends AnyWordSpecLike with Matchers with Fixtures {
     // The returned json is not exactly the same as the original compacted json from where the Graph was created.
     // This is expected due to the useNativeTypes field on JsonLdOptions and to the @context we have set in place
     "be converted to compacted JSON-LD with a root blank node" in {
-      val context   = jsonContentOf("context.json")
+      val context   = jsonContentOf("context.json").topContextValueOrEmpty
       val compacted = jsonContentOf("graph/compacted.json").removeAll("id" -> "john-doé")
       graphNoId.toCompactedJsonLd(context).accepted.json shouldEqual compacted
     }

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
@@ -151,6 +151,14 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
       expanded.toExpanded.accepted should be theSameInstanceAs expanded
     }
 
+    "be empty" in {
+      JsonLd.expand(json"""[{"@id": "http://example.com/id", "a": "b"}]""").accepted.isEmpty shouldEqual true
+    }
+
+    "not be empty" in {
+      JsonLd.expand(compacted).accepted.isEmpty shouldEqual false
+    }
+
     "be converted to graph" in {
       val expanded = JsonLd.expand(compacted).accepted
       val graph    = expanded.toGraph.accepted

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
@@ -14,7 +14,7 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
   "An expanded Json-LD" should {
     val compacted        = jsonContentOf("compacted.json")
-    val context          = compacted.topContextValueOrEmpty.contextObj
+    val context          = compacted.topContextValueOrEmpty
     val expectedExpanded = jsonContentOf("expanded.json")
 
     "be constructed successfully" in {
@@ -24,7 +24,7 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
     "be constructed successfully without @id" in {
       val name             = vocab + "name"
       val expectedExpanded = json"""[{"@type": ["${schema.Person}"], "$name": [{"@value": "Me"} ] } ]"""
-      val compacted        = json"""{"@type": "Person", "name": "Me"}""".addContext(context)
+      val compacted        = json"""{"@type": "Person", "name": "Me"}""".addContext(context.contextObj)
       val expanded         = JsonLd.expand(compacted).accepted
       expanded shouldEqual JsonLd.expandedUnsafe(expectedExpanded, expanded.rootId)
       expanded.rootId shouldBe a[BNode]
@@ -60,31 +60,32 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
     }
 
     "fetch root @type" in {
-      val compacted = json"""{"@id": "$iri", "@type": "Person"}""".addContext(context)
+      val compacted = json"""{"@id": "$iri", "@type": "Person"}""".addContext(context.contextObj)
       val expanded  = JsonLd.expand(compacted).accepted
       expanded.types shouldEqual List(schema.Person)
 
-      val compactedMultipleTypes = json"""{"@id": "$iri", "@type": ["Person", "Hero"]}""".addContext(context)
+      val compactedMultipleTypes = json"""{"@id": "$iri", "@type": ["Person", "Hero"]}""".addContext(context.contextObj)
       val resultMultiple         = JsonLd.expand(compactedMultipleTypes).accepted
       resultMultiple.types shouldEqual List(schema.Person, vocab + "Hero")
     }
 
     "fetch @id values" in {
-      val compacted = json"""{"@id": "$iri", "customid": "Person"}""".addContext(context)
+      val compacted = json"""{"@id": "$iri", "customid": "Person"}""".addContext(context.contextObj)
       val expanded  = JsonLd.expand(compacted).accepted
       expanded.ids(vocab + "customid") shouldEqual List(base + "Person")
 
-      val compactedMultipleCustomId = json"""{"@id": "$iri", "customid": ["Person", "Hero"]}""".addContext(context)
+      val compactedMultipleCustomId =
+        json"""{"@id": "$iri", "customid": ["Person", "Hero"]}""".addContext(context.contextObj)
       val resultMultiple            = JsonLd.expand(compactedMultipleCustomId).accepted
       resultMultiple.ids(vocab + "customid") shouldEqual List(base + "Person", base + "Hero")
     }
 
     "fetch @value values" in {
-      val compacted = json"""{"@id": "$iri", "tags": "a"}""".addContext(context)
+      val compacted = json"""{"@id": "$iri", "tags": "a"}""".addContext(context.contextObj)
       val expanded  = JsonLd.expand(compacted).accepted
       expanded.literals[String](vocab + "tags") shouldEqual List("a")
 
-      val compactedMultipleTags = json"""{"@id": "$iri", "tags": ["a", "b", "c"]}""".addContext(context)
+      val compactedMultipleTags = json"""{"@id": "$iri", "tags": ["a", "b", "c"]}""".addContext(context.contextObj)
       val resultMultiple        = JsonLd.expand(compactedMultipleTags).accepted
       resultMultiple.literals[String](vocab + "tags") shouldEqual List("a", "b", "c")
     }
@@ -137,7 +138,7 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
     }
 
     "be converted to compacted form without @id" in {
-      val compacted = json"""{"@type": "Person", "name": "Me"}""".addContext(context)
+      val compacted = json"""{"@type": "Person", "name": "Me"}""".addContext(context.contextObj)
 
       val expanded = JsonLd.expand(compacted).accepted
       val result   = expanded.toCompacted(context).accepted

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/context/JsonLdContextSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/context/JsonLdContextSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with Inspectors {
 
   "A Json-LD context" should {
-    val context = jsonContentOf("context.json")
+    val context = jsonContentOf("context.json").topContextValueOrEmpty
     val api     = implicitly[JsonLdApi]
 
     "be constructed successfully" in {
@@ -20,7 +20,7 @@ class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with
 
     "get fields" in {
       val result = api.context(context).accepted
-      result.value shouldEqual context.topContextValueOrEmpty
+      result.value shouldEqual context
       result.base.value shouldEqual base.value
       result.vocab.value shouldEqual vocab.value
       result.aliases shouldEqual
@@ -93,7 +93,7 @@ class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with
     }
 
     "add simple alias" in {
-      val context = json"""{"@context": {"@base": "${base.value}"} }"""
+      val context = json"""{"@context": {"@base": "${base.value}"} }""".topContextValueOrEmpty
       val result  = api.context(context).accepted
       result.addAlias("age", schema.age) shouldEqual JsonLdContext(
         value = ContextValue(json"""{"@base": "${base.value}", "age": "${schema.age}"}"""),
@@ -103,7 +103,7 @@ class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with
     }
 
     "add alias with dataType" in {
-      val context = json"""{"@context": {"@base": "${base.value}"} }"""
+      val context = json"""{"@context": {"@base": "${base.value}"} }""".topContextValueOrEmpty
       val result  = api.context(context).accepted
       result.addAlias("age", schema.age, xsd.integer) shouldEqual JsonLdContext(
         value = ContextValue(
@@ -115,7 +115,7 @@ class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with
     }
 
     "add alias with @type @id" in {
-      val context = json"""{"@context": {"@base": "${base.value}"} }"""
+      val context = json"""{"@context": {"@base": "${base.value}"} }""".topContextValueOrEmpty
       val result  = api.context(context).accepted
       result.addAliasIdType("unit", schema.unitText) shouldEqual JsonLdContext(
         value =
@@ -126,7 +126,7 @@ class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with
     }
 
     "add prefixMapping" in {
-      val context = json"""{"@context": [{"@base": "${base.value}"}] }"""
+      val context = json"""{"@context": [{"@base": "${base.value}"}] }""".topContextValueOrEmpty
       val result  = api.context(context).accepted
       result.addPrefix("xsd", xsd.base) shouldEqual JsonLdContext(
         value = ContextValue(json"""[{"@base": "${base.value}"}, {"xsd": "${xsd.base}"}]"""),

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesDummy.scala
@@ -61,7 +61,7 @@ final class ResourcesDummy private (
       project               <- fetchActiveProject(projectRef)
       iri                   <- expandIri(id, project)
       schemeRef             <- expandResourceRef(schema, project)
-      (compacted, expanded) <- ResourceSourceParser.asJsonLd(iri, source)
+      (compacted, expanded) <- ResourceSourceParser.asJsonLd(project, iri, source)
       res                   <- eval(CreateResource(iri, projectRef, schemeRef, source, compacted, expanded, caller), project)
     } yield res
 
@@ -76,7 +76,7 @@ final class ResourcesDummy private (
       project               <- fetchActiveProject(projectRef)
       iri                   <- expandIri(id, project)
       schemeRefOpt          <- expandResourceRef(schemaOpt, project)
-      (compacted, expanded) <- ResourceSourceParser.asJsonLd(iri, source)
+      (compacted, expanded) <- ResourceSourceParser.asJsonLd(project, iri, source)
       res                   <- eval(UpdateResource(iri, projectRef, schemeRefOpt, source, compacted, expanded, rev, caller), project)
     } yield res
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/ResourceSourceParser.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/ResourceSourceParser.scala
@@ -2,13 +2,16 @@ package ch.epfl.bluebrain.nexus.delta.sdk
 
 import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd, JsonLd}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.Project
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.ResourceRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.ResourceRejection.{InvalidJsonLdFormat, UnexpectedResourceId}
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.UUIDF
 import io.circe.Json
+import io.circe.syntax._
 import monix.bio.IO
 
 trait ResourceSourceParser {
@@ -18,7 +21,7 @@ trait ResourceSourceParser {
     * The @id value is extracted from the payload.
     * When no @id is present, one is generated using the base on the project suffixed with a randomly generated UUID.
     *
-    * @param project the project with the base used to generate @id when needed
+    * @param project the project with the base used to generate @id when needed and the @context when not provided on the source
     * @param source  the Json payload
     * @return a tuple with the resulting @id iri, the compacted Json-LD and the expanded Json-LD
     */
@@ -28,39 +31,58 @@ trait ResourceSourceParser {
   )(implicit
       uuidF: UUIDF,
       rcr: RemoteContextResolution
-  ): IO[InvalidJsonLdFormat, (Iri, CompactedJsonLd, ExpandedJsonLd)] =
+  ): IO[InvalidJsonLdFormat, (Iri, CompactedJsonLd, ExpandedJsonLd)] = {
+    val (ctx, sourceWithCtx) = ctxOrProjectDefaults(source, project)
     for {
-      originalExpanded <- JsonLd.expand(source).leftMap(err => InvalidJsonLdFormat(None, err))
+      originalExpanded <- JsonLd.expand(sourceWithCtx).leftMap(err => InvalidJsonLdFormat(None, err))
       base              = project.base.iri
       iri              <- originalExpanded.rootId.asIri.fold(uuidF().map(uuid => base / uuid.toString))(IO.pure)
       expanded          = originalExpanded.replaceId(iri)
-      compacted        <- expanded.toCompacted(source).leftMap(err => InvalidJsonLdFormat(Some(iri), err))
+      compacted        <- expanded.toCompacted(ctx).leftMap(err => InvalidJsonLdFormat(Some(iri), err))
     } yield (iri, compacted, expanded)
+  }
 
   /**
     * Converts the passed ''source'' to JsonLD compacted and expanded.
     * The @id value is extracted from the payload if exists and compared to the passed ''iri''.
     * If they aren't equal an [[UnexpectedResourceId]] rejection is issued.
     *
+    * @param project the project used to generate the @context when no @context is provided on the source
     * @param source the Json payload
     * @return a tuple with the compacted Json-LD and the expanded Json-LD
     */
   def asJsonLd(
+      project: Project,
       iri: Iri,
       source: Json
-  )(implicit rcr: RemoteContextResolution): IO[ResourceRejection, (CompactedJsonLd, ExpandedJsonLd)] =
+  )(implicit rcr: RemoteContextResolution): IO[ResourceRejection, (CompactedJsonLd, ExpandedJsonLd)] = {
+    val (ctx, sourceWithCtx) = ctxOrProjectDefaults(source, project)
     for {
-      originalExpanded <- JsonLd.expand(source).leftMap(err => InvalidJsonLdFormat(Some(iri), err))
+      originalExpanded <- JsonLd.expand(sourceWithCtx).leftMap(err => InvalidJsonLdFormat(Some(iri), err))
       _                <- checkSameId(iri, originalExpanded)
       expanded          = originalExpanded.replaceId(iri)
-      compacted        <- expanded.toCompacted(source).leftMap(err => InvalidJsonLdFormat(Some(iri), err))
+      compacted        <- expanded.toCompacted(ctx).leftMap(err => InvalidJsonLdFormat(Some(iri), err))
     } yield (compacted, expanded)
+  }
 
   private def checkSameId(iri: Iri, expanded: ExpandedJsonLd): IO[UnexpectedResourceId, Unit] =
     expanded.rootId.asIri match {
       case Some(sourceId) if sourceId != iri => IO.raiseError(UnexpectedResourceId(iri, sourceId))
       case _                                 => IO.unit
     }
+
+  private def ctxOrProjectDefaults(source: Json, project: Project): (ContextValue, Json) =
+    source.topContextValueOrEmpty match {
+      case v if v == ContextValue.empty =>
+        val newCtxValue = defaultCtx(project)
+        (newCtxValue, source.addContext(newCtxValue.contextObj))
+      case v                            =>
+        (v, source)
+    }
+
+  private def defaultCtx(project: Project): ContextValue =
+    ContextValue.unsafe(Json.obj(keywords.vocab -> project.vocab.asJson, keywords.base -> project.base.asJson))
+
 }
 
 object ResourceSourceParser extends ResourceSourceParser

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
@@ -13,6 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, ProjectBas
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.Resource
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.ResourceState.Current
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, ResourceRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 import io.circe.Json
 import org.scalatest.OptionValues
@@ -31,7 +32,7 @@ object ResourceGen extends OptionValues with IOValues {
       subject: Subject = Anonymous
   )(implicit resolution: RemoteContextResolution): Current = {
     val expanded  = JsonLd.expand(source).accepted.replaceId(id)
-    val compacted = expanded.toCompacted(source).accepted
+    val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
     Current(
       id,
       project,
@@ -58,7 +59,8 @@ object ResourceGen extends OptionValues with IOValues {
       tags: Map[Label, Long] = Map.empty
   )(implicit resolution: RemoteContextResolution): Resource = {
     val expanded  = JsonLd.expand(source).accepted.replaceId(id)
-    val compacted = expanded.toCompacted(source).accepted
+    val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
+    println(compacted)
     Resource(id, project, tags, schema, source, compacted, expanded)
   }
 
@@ -71,16 +73,21 @@ object ResourceGen extends OptionValues with IOValues {
       deprecated: Boolean = false,
       am: ApiMappings = ApiMappings.empty,
       base: Iri = nxv.base
-  )(implicit resolution: RemoteContextResolution): DataResource =
-    currentState(
+  ): DataResource =
+    Current(
       resource.id,
       resource.project,
       resource.source,
+      resource.compacted,
+      resource.expanded,
+      rev,
+      deprecated,
       resource.schema,
       types,
       tags,
-      rev,
-      deprecated,
+      Instant.EPOCH,
+      subject,
+      Instant.EPOCH,
       subject
     ).toResource(am, ProjectBase.unsafe(base)).value
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
@@ -60,7 +60,6 @@ object ResourceGen extends OptionValues with IOValues {
   )(implicit resolution: RemoteContextResolution): Resource = {
     val expanded  = JsonLd.expand(source).accepted.replaceId(id)
     val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
-    println(compacted)
     Resource(id, project, tags, schema, source, compacted, expanded)
   }
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/SchemaGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/SchemaGen.scala
@@ -12,6 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.{Anonymous, S
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, ProjectBase, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.Schema
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{AccessUrl, ResourceF}
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 import io.circe.Json
 import org.scalatest.OptionValues
@@ -25,7 +26,7 @@ object SchemaGen extends OptionValues with IOValues {
   )(implicit resolution: RemoteContextResolution): Schema = {
     val expanded  = JsonLd.expand(source).accepted.replaceId(id)
     val graph     = expanded.toGraph.accepted
-    val compacted = expanded.toCompacted(source).accepted
+    val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
     Schema(id, project, source, compacted, graph)
   }
 

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourcesImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourcesImpl.scala
@@ -56,7 +56,7 @@ final class ResourcesImpl private (
       project               <- fetchActiveProject(projectRef)
       iri                   <- expandIri(id, project)
       schemeRef             <- expandResourceRef(schema, project)
-      (compacted, expanded) <- ResourceSourceParser.asJsonLd(iri, source)
+      (compacted, expanded) <- ResourceSourceParser.asJsonLd(project, iri, source)
       res                   <- eval(CreateResource(iri, projectRef, schemeRef, source, compacted, expanded, caller), project)
     } yield res).named("createResource", moduleType)
 
@@ -71,7 +71,7 @@ final class ResourcesImpl private (
       project               <- fetchActiveProject(projectRef)
       iri                   <- expandIri(id, project)
       schemeRefOpt          <- expandResourceRef(schemaOpt, project)
-      (compacted, expanded) <- ResourceSourceParser.asJsonLd(iri, source)
+      (compacted, expanded) <- ResourceSourceParser.asJsonLd(project, iri, source)
       res                   <- eval(UpdateResource(iri, projectRef, schemeRefOpt, source, compacted, expanded, rev, caller), project)
     } yield res).named("updateResource", moduleType)
 


### PR DESCRIPTION
Fixes to https://github.com/BlueBrain/nexus/issues/1771

- Added custom Kryo serialization for `Path` and `IRI`. Probably a Jena Model can be added in the future too.
- Simplified the passing of contexts in RDF using `ContextValue`.
- Added `/source` missing endpoint to resource routes.
- Added default context to compute compacted and expanded when source does not have a context.
- Added wiring for resource routes.