### PR TITLE
Defined Schemas events, states, rejections and contract

### DIFF
--- a/delta/app/src/main/resources/akka.conf
+++ b/delta/app/src/main/resources/akka.conf
@@ -27,6 +27,7 @@ akka {
       "java.nio.file.Path"                                                         = "kryo"
       "org.apache.jena.iri.IRI"                                                    = "kryo"
       "org.apache.jena.rdf.model.Model"                                            = "kryo"
+      "ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph"                              = "kryo"
       "ch.epfl.bluebrain.nexus.delta.service.cache.SubscriberCommand$Unsubscribe$" = "kryo"
     }
   }

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializerInit.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializerInit.scala
@@ -38,7 +38,7 @@ object KryoSerializerInit {
   private val iriFactory = IRIFactory.iriImplementation()
 
   class GraphSerializer extends Serializer[Graph] {
-    private val fakeIRI = iriFactory.create("http://fake.com/6ff2c90a-2bc3-4fd5-bf0b-bf2d563f28a7")
+    private val fakeIRI = iriFactory.create("http://localhost/6ff2c90a-2bc3-4fd5-bf0b-bf2d563f28a7")
     private val fakeIri = Iri.unsafe(fakeIRI.toString)
 
     override def write(kryo: Kryo, output: Output, graph: Graph): Unit =

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializerInit.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializerInit.scala
@@ -3,10 +3,13 @@ package ch.epfl.bluebrain.nexus.delta
 import java.nio.file.Path
 
 import ch.epfl.bluebrain.nexus.delta.KryoSerializerInit._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
+import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import io.altoo.akka.serialization.kryo.DefaultKryoInitializer
 import io.altoo.akka.serialization.kryo.serializer.scala.ScalaKryo
+import org.apache.jena.graph.Factory.createDefaultGraph
 import org.apache.jena.iri.{IRI, IRIFactory}
 import org.apache.jena.rdf.model.{Model, ModelFactory}
 import org.apache.jena.riot.{Lang, RDFParser, RDFWriter}
@@ -24,11 +27,42 @@ class KryoSerializerInit extends DefaultKryoInitializer {
     kryo.addDefaultSerializer(classOf[Path], classOf[PathSerializer])
     kryo.register(classOf[Path], new PathSerializer)
 
+    kryo.addDefaultSerializer(classOf[Graph], classOf[GraphSerializer])
+    kryo.register(classOf[Graph], new GraphSerializer)
     ()
   }
 }
 
 object KryoSerializerInit {
+
+  private val iriFactory = IRIFactory.iriImplementation()
+
+  class GraphSerializer extends Serializer[Graph] {
+    private val fakeIRI = iriFactory.create("http://fake.com/6ff2c90a-2bc3-4fd5-bf0b-bf2d563f28a7")
+    private val fakeIri = Iri.unsafe(fakeIRI.toString)
+
+    override def write(kryo: Kryo, output: Output, graph: Graph): Unit =
+      graph.rootNode match {
+        case Iri(value) =>
+          kryo.writeObject(output, graph.model)
+          kryo.writeObject(output, value)
+
+        case bNode: BNode =>
+          kryo.writeObject(output, graph.replace(bNode, fakeIri).model)
+          kryo.writeObject(output, fakeIRI)
+      }
+
+    override def read(kryo: Kryo, input: Input, `type`: Class[Graph]): Graph = {
+      val model = kryo.readObject(input, classOf[Model])
+      kryo.readObject(input, classOf[IRI]) match {
+        case `fakeIRI` =>
+          val bNode = BNode.random
+          Graph.unsafe(bNode, model).replace(fakeIri, bNode)
+        case other     =>
+          Graph.unsafe(Iri.unsafe(other.toString), model)
+      }
+    }
+  }
 
   class ModelSerializer extends Serializer[Model] {
 
@@ -36,14 +70,13 @@ object KryoSerializerInit {
       output.writeString(RDFWriter.create.lang(Lang.NTRIPLES).source(model).asString())
 
     override def read(kryo: Kryo, input: Input, `type`: Class[Model]): Model = {
-      val model = ModelFactory.createDefaultModel()
+      val model = ModelFactory.createModelForGraph(createDefaultGraph())
       RDFParser.create().fromString(input.readString()).lang(Lang.NTRIPLES).parse(model)
       model
     }
   }
 
   class IRISerializer extends Serializer[IRI] {
-    private val iriFactory = IRIFactory.iriImplementation()
 
     override def write(kryo: Kryo, output: Output, iri: IRI): Unit =
       output.writeString(iri.toString)

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializationInitSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/KryoSerializationInitSpec.scala
@@ -5,10 +5,13 @@ import java.nio.file.Paths
 import akka.actor.ActorSystem
 import akka.serialization.SerializationExtension
 import akka.testkit.TestKit
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.syntax._
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
-import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
+import ch.epfl.bluebrain.nexus.testkit.{EitherValuable, IOValues, TestHelpers}
 import io.altoo.akka.serialization.kryo.KryoSerializer
 import org.apache.jena.iri.{IRI, IRIFactory}
 import org.scalatest.TryValues
@@ -21,9 +24,15 @@ class KryoSerializerInitSpec
     with Matchers
     with TryValues
     with TestHelpers
-    with IOValues {
+    with IOValues
+    with EitherValuable {
 
-  private val serialization = SerializationExtension(system)
+  private val serialization                         = SerializationExtension(system)
+  implicit private val rcr: RemoteContextResolution = RemoteContextResolution.fixed()
+
+  private val expanded = JsonLd.expand(jsonContentOf("/kryo/expanded.json")).accepted
+  private val graph    = Graph(expanded).rightValue
+  private val iri      = iri"http://nexus.example.com/john-doé"
 
   "A Path Kryo serialization" should {
     "succeed" in {
@@ -43,10 +52,45 @@ class KryoSerializerInitSpec
     }
   }
 
+  "An Anonymous Graph Kryo serialization" should {
+    val expandedJson = jsonContentOf("/kryo/expanded.json").removeAll(keywords.id -> iri)
+    val graphNoId    = Graph(JsonLd.expand(expandedJson).accepted).rightValue
+
+    "succeed" in {
+      // Find the Serializer for it
+      val serializer = serialization.findSerializerFor(graphNoId)
+      serializer.getClass.equals(classOf[KryoSerializer]) shouldEqual true
+
+      // Check serialization/deserialization
+      val serialized = serialization.serialize(graphNoId)
+      serialized.isSuccess shouldEqual true
+
+      val deserialized            = serialization.deserialize(serialized.get, graphNoId.getClass)
+      deserialized.isSuccess shouldEqual true
+      val deserializedGraph       = deserialized.success.value
+      deserializedGraph.rootNode shouldBe a[BNode]
+      val deserializedGraphWithId = deserializedGraph.replace(deserializedGraph.rootNode, iri)
+      deserializedGraphWithId.triples shouldEqual graph.triples
+    }
+  }
+
+  "An Iri Graph Kryo serialization" should {
+    "succeed" in {
+      // Find the Serializer for it
+      val serializer = serialization.findSerializerFor(graph)
+      serializer.getClass.equals(classOf[KryoSerializer]) shouldEqual true
+
+      // Check serialization/deserialization
+      val serialized = serialization.serialize(graph)
+      serialized.isSuccess shouldEqual true
+
+      val deserialized = serialization.deserialize(serialized.get, graph.getClass)
+      deserialized.isSuccess shouldEqual true
+      deserialized.success.value shouldEqual graph
+    }
+  }
+
   "An Jena Model Kryo serialization" should {
-    implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed()
-    val expanded                              = JsonLd.expand(jsonContentOf("/kryo/expanded.json")).accepted
-    val graph                                 = Graph(expanded).accepted
 
     "succeed" in {
 

--- a/delta/rdf/src/main/resources/shacl-shacl.ttl
+++ b/delta/rdf/src/main/resources/shacl-shacl.ttl
@@ -1,0 +1,410 @@
+# baseURI: http://www.w3.org/ns/shacl-shacl#
+
+# A SHACL shapes graph to validate SHACL shapes graphs
+# Draft last edited 2017-04-04
+
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix shsh: <http://www.w3.org/ns/shacl-shacl#> .
+
+shsh:
+	rdfs:label "SHACL for SHACL"@en ;
+	rdfs:comment "This shapes graph can be used to validate SHACL shapes graphs against a subset of the syntax rules."@en ;
+	sh:declare [
+		sh:prefix "shsh" ;
+		sh:namespace "http://www.w3.org/ns/shacl-shacl#" ;
+	] .
+
+
+shsh:ListShape
+	a sh:NodeShape ;
+	rdfs:label "List shape"@en ;
+	rdfs:comment "A shape describing well-formed RDF lists. Currently does not check for non-recursion. This could be expressed using SHACL-SPARQL."@en ;
+	rdfs:seeAlso <https://www.w3.org/TR/shacl/#syntax-rule-SHACL-list> ;
+	sh:property [
+		sh:path [ sh:zeroOrMorePath rdf:rest ] ;
+		rdfs:comment "Each list member (including this node) must be have the shape shsh:ListNodeShape."@en ;
+		sh:hasValue rdf:nil ;
+		sh:node shsh:ListNodeShape ;
+	] .
+
+shsh:ListNodeShape
+	a sh:NodeShape ;
+	rdfs:label "List node shape"@en ;
+	rdfs:comment "Defines constraints on what it means for a node to be a node within a well-formed RDF list. Note that this does not check whether the rdf:rest items are also well-formed lists as this would lead to unsupported recursion."@en ;
+	sh:or ( [
+				sh:hasValue rdf:nil ;
+        		sh:property [
+					sh:path rdf:first ;
+					sh:maxCount 0 ;
+				] ;
+				sh:property [
+					sh:path rdf:rest ;
+					sh:maxCount 0 ;
+				] ;
+			]
+			[
+				sh:not [ sh:hasValue rdf:nil ] ;
+				sh:property [
+					sh:path rdf:first ;
+					sh:maxCount 1 ;
+					sh:minCount 1 ;
+				] ;
+				sh:property [
+					sh:path rdf:rest ;
+					sh:maxCount 1 ;
+					sh:minCount 1 ;
+				] ;
+			] ) .
+
+shsh:ShapeShape
+	a sh:NodeShape ;
+	rdfs:label "Shape shape"@en ;
+	rdfs:comment "A shape that can be used to validate syntax rules for other shapes."@en ;
+
+	# See https://www.w3.org/TR/shacl/#shapes for what counts as a shape
+	sh:targetClass sh:NodeShape ;
+	sh:targetClass sh:PropertyShape ;
+	sh:targetSubjectsOf sh:targetClass, sh:targetNode, sh:targetObjectsOf, sh:targetSubjectsOf ;
+	sh:targetSubjectsOf sh:and, sh:class, sh:closed, sh:datatype, sh:disjoint, sh:equals, sh:flags, sh:hasValue,
+		sh:ignoredProperties, sh:in, sh:languageIn, sh:lessThan, sh:lessThanOrEquals, sh:maxCount, sh:maxExclusive,
+		sh:maxInclusive, sh:maxLength, sh:minCount, sh:minExclusive, sh:minInclusive, sh:minLength, sh:node, sh:nodeKind,
+		sh:not, sh:or, sh:pattern, sh:property, sh:qualifiedMaxCount, sh:qualifiedMinCount, sh:qualifiedValueShape,
+		sh:qualifiedValueShape, sh:qualifiedValueShapesDisjoint, sh:qualifiedValueShapesDisjoint, sh:sparql, sh:uniqueLang, sh:xone ;
+
+	sh:targetObjectsOf sh:node ;        # node-node
+	sh:targetObjectsOf sh:not ;         # not-node
+	sh:targetObjectsOf sh:property ;    # property-node
+	sh:targetObjectsOf sh:qualifiedValueShape ; # qualifiedValueShape-node
+
+	# Shapes are either node shapes or property shapes
+	sh:xone ( shsh:NodeShapeShape shsh:PropertyShapeShape ) ;
+
+	sh:property [
+		sh:path sh:targetNode ;
+		sh:nodeKind	sh:IRIOrLiteral ;   # targetNode-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:targetClass ;
+		sh:nodeKind sh:IRI ;            # targetClass-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:targetSubjectsOf ;
+		sh:nodeKind sh:IRI ;            # targetSubjectsOf-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:targetObjectsOf ;
+		sh:nodeKind sh:IRI ;            # targetObjectsOf-nodeKind
+	] ;
+	sh:or ( [ sh:not [
+				sh:class rdfs:Class ;
+				sh:or ( [ sh:class sh:NodeShape ] [ sh:class sh:PropertyShape ] )
+			] ]
+			[ sh:nodeKind sh:IRI ]
+		  ) ;                           # implicit-targetClass-nodeKind
+
+	sh:property [
+		sh:path sh:severity ;
+		sh:maxCount 1 ;                 # severity-maxCount
+		sh:nodeKind sh:IRI ;            # severity-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:message ;
+		sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ;   # message-datatype
+	] ;
+	sh:property [
+		sh:path sh:deactivated ;
+		sh:maxCount 1 ;                 # deactivated-maxCount
+		sh:in ( true false ) ;          # deactivated-datatype
+	] ;
+
+	sh:property [
+		sh:path sh:and ;
+		sh:node shsh:ListShape ;        # and-node
+	] ;
+	sh:property [
+		sh:path sh:class ;
+		sh:nodeKind sh:IRI ;            # class-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:closed ;
+		sh:datatype xsd:boolean ;       # closed-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:ignoredProperties ;
+		sh:node shsh:ListShape ;        # ignoredProperties-node
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path ( sh:ignoredProperties [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+		sh:nodeKind sh:IRI ;            # ignoredProperties-members-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:datatype ;
+		sh:nodeKind sh:IRI ;            # datatype-nodeKind
+		sh:maxCount 1 ;                 # datatype-maxCount
+	] ;
+	sh:property [
+		sh:path sh:disjoint ;
+		sh:nodeKind sh:IRI ;            # disjoint-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:equals ;
+		sh:nodeKind sh:IRI ;            # equals-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:in ;
+		sh:maxCount 1 ;                 # in-maxCount
+		sh:node shsh:ListShape ;        # in-node
+	] ;
+	sh:property [
+		sh:path sh:languageIn ;
+		sh:maxCount 1 ;                 # languageIn-maxCount
+		sh:node shsh:ListShape ;        # languageIn-node
+	] ;
+	sh:property [
+		sh:path ( sh:languageIn [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+		sh:datatype xsd:string ;        # languageIn-members-datatype
+	] ;
+	sh:property [
+		sh:path sh:lessThan ;
+		sh:nodeKind sh:IRI ;            # lessThan-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:lessThanOrEquals ;
+		sh:nodeKind sh:IRI ;            # lessThanOrEquals-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:maxCount ;
+		sh:datatype xsd:integer ;       # maxCount-datatype
+		sh:maxCount 1 ;                 # maxCount-maxCount
+	] ;
+	sh:property [
+		sh:path sh:maxExclusive ;
+		sh:maxCount 1 ;                 # maxExclusive-maxCount
+		sh:nodeKind sh:Literal ;        # maxExclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:maxInclusive ;
+		sh:maxCount 1 ;                 # maxInclusive-maxCount
+		sh:nodeKind sh:Literal ;        # maxInclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:maxLength ;
+		sh:datatype xsd:integer ;       # maxLength-datatype
+		sh:maxCount 1 ;                 # maxLength-maxCount
+	] ;
+	sh:property [
+		sh:path sh:minCount ;
+		sh:datatype xsd:integer ;       # minCount-datatype
+		sh:maxCount 1 ;                 # minCount-maxCount
+	] ;
+	sh:property [
+		sh:path sh:minExclusive ;
+		sh:maxCount 1 ;                 # minExclusive-maxCount
+		sh:nodeKind sh:Literal ;        # minExclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:minInclusive ;
+		sh:maxCount 1 ;                 # minInclusive-maxCount
+		sh:nodeKind sh:Literal ;        # minInclusive-nodeKind
+	] ;
+	sh:property [
+		sh:path sh:minLength ;
+		sh:datatype xsd:integer ;       # minLength-datatype
+		sh:maxCount 1 ;                 # minLength-maxCount
+	] ;
+	sh:property [
+		sh:path sh:nodeKind ;
+		sh:in ( sh:BlankNode sh:IRI sh:Literal sh:BlankNodeOrIRI sh:BlankNodeOrLiteral sh:IRIOrLiteral ) ;	# nodeKind-in
+		sh:maxCount 1 ;                 # nodeKind-maxCount
+	] ;
+	sh:property [
+		sh:path sh:or ;
+		sh:node shsh:ListShape ;        # or-node
+	] ;
+	sh:property [
+		sh:path sh:pattern ;
+		sh:datatype xsd:string ;        # pattern-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+		# Not implemented: syntax rule pattern-regex
+	] ;
+	sh:property [
+		sh:path sh:flags ;
+		sh:datatype xsd:string ;        # flags-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedMaxCount ;
+		sh:datatype xsd:integer ;       # qualifiedMaxCount-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedMinCount ;
+		sh:datatype xsd:integer ;       # qualifiedMinCount-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedValueShape ;
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:qualifiedValueShapesDisjoint ;
+		sh:datatype xsd:boolean ;       # qualifiedValueShapesDisjoint-datatype
+		sh:maxCount 1 ;                 # multiple-parameters
+	] ;
+	sh:property [
+		sh:path sh:uniqueLang ;
+		sh:datatype xsd:boolean ;       # uniqueLang-datatype
+		sh:maxCount 1 ;                 # uniqueLang-maxCount
+	] ;
+	sh:property [
+		sh:path sh:xone ;
+		sh:node shsh:ListShape ;        # xone-node
+	] .
+
+shsh:NodeShapeShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:node ;        # node-node
+	sh:property [
+		sh:path sh:path ;
+		sh:maxCount 0 ;                 # NodeShape-path-maxCount
+	] ;
+	sh:property [
+		sh:path sh:lessThan ;
+		sh:maxCount 0 ;                 # lessThan-scope
+	] ;
+	sh:property [
+		sh:path sh:lessThanOrEquals ;
+		sh:maxCount 0 ;                 # lessThanOrEquals-scope
+	] ;
+	sh:property [
+		sh:path sh:maxCount ;
+		sh:maxCount 0 ;                 # maxCount-scope
+	] ;
+	sh:property [
+		sh:path sh:minCount ;
+		sh:maxCount 0 ;                 # minCount-scope
+	] ;
+	sh:property [
+		sh:path sh:qualifiedValueShape ;
+		sh:maxCount 0 ;                 # qualifiedValueShape-scope
+	] ;
+	sh:property [
+		sh:path sh:uniqueLang ;
+		sh:maxCount 0 ;                 # uniqueLang-scope
+	] .
+
+shsh:PropertyShapeShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:property ;    # property-node
+	sh:property [
+		sh:path sh:path ;
+		sh:maxCount 1 ;                 # path-maxCount
+		sh:minCount 1 ;                 # PropertyShape-path-minCount
+		sh:node shsh:PathShape ;        # path-node
+	] .
+
+# Values of sh:and, sh:or and sh:xone must be lists of shapes
+shsh:ShapesListShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:and ;         # and-members-node
+	sh:targetObjectsOf sh:or ;          # or-members-node
+	sh:targetObjectsOf sh:xone ;        # xone-members-node
+	sh:property [
+		sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+		sh:node shsh:ShapeShape ;
+	] .
+
+
+# A path of blank node path syntax, used to simulate recursion
+_:PathPath
+	sh:alternativePath (
+		( [ sh:zeroOrMorePath rdf:rest ] rdf:first )
+		( sh:alternativePath [ sh:zeroOrMorePath rdf:rest ] rdf:first )
+		sh:inversePath
+		sh:zeroOrMorePath
+		sh:oneOrMorePath
+		sh:zeroOrOnePath
+	) .
+
+shsh:PathShape
+	a sh:NodeShape ;
+	rdfs:label "Path shape"@en ;
+	rdfs:comment "A shape that can be used to validate the syntax rules of well-formed SHACL paths."@en ;
+	rdfs:seeAlso <https://www.w3.org/TR/shacl/#property-paths> ;
+	sh:property [
+		sh:path [ sh:zeroOrMorePath _:PathPath ] ;
+		sh:node shsh:PathNodeShape ;
+	] .
+
+shsh:PathNodeShape
+	sh:xone (                           # path-metarule
+			[ sh:nodeKind sh:IRI ]          # 2.3.1.1: Predicate path
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.2: Sequence path
+			  sh:node shsh:PathListWithAtLeast2Members ;
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.3: Alternative path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:alternativePath ;
+			    sh:node shsh:PathListWithAtLeast2Members ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ]
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.4: Inverse path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:inversePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ]
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.5: Zero-or-more path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:zeroOrMorePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ]
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.6: One-or-more path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:oneOrMorePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ]
+			]
+			[ sh:nodeKind sh:BlankNode ;    # 2.3.1.7: Zero-or-one path
+			  sh:closed true ;
+			  sh:property [
+			    sh:path sh:zeroOrOnePath ;
+			    sh:minCount 1 ;
+			    sh:maxCount 1 ;
+			  ]
+			]
+		) .
+
+shsh:PathListWithAtLeast2Members
+	a sh:NodeShape ;
+	sh:node shsh:ListShape ;
+	sh:property [
+		sh:path [ sh:oneOrMorePath rdf:rest ] ;
+		sh:minCount 2 ;    # 1 other list node plus rdf:nil
+	] .
+
+shsh:ShapesGraphShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:shapesGraph ;
+	sh:nodeKind sh:IRI .                # shapesGraph-nodeKind
+
+shsh:EntailmentShape
+	a sh:NodeShape ;
+	sh:targetObjectsOf sh:entailment ;
+	sh:nodeKind sh:IRI .                # entailment-nodeKind

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/Graph.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/Graph.scala
@@ -162,7 +162,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
       // A new model is created where the rootNode is a fake Iri.
       // This is done in order to be able to perform the framing, since framing won't work on blank nodes.
       // After the framing is done, the @id value is removed from the json and the blank node reverted as rootId
-      val fakeId   = iri"http://fake.com/${UUID.randomUUID()}"
+      val fakeId   = iri"http://localhost/${UUID.randomUUID()}"
       val newModel = replace(rootNode, fakeId).model
       for {
         expanded  <- IO.fromEither(api.fromRdf(newModel))
@@ -238,7 +238,7 @@ object Graph {
     } else {
       // A fake @id is injected in the Json and then replaced in the model.
       // This is required in order preserve the original blank node since jena will create its own otherwise
-      val fakeId = iri"http://fake.com/${UUID.randomUUID()}"
+      val fakeId = iri"http://localhost/${UUID.randomUUID()}"
       val json   = Json.arr(expanded.obj.add(keywords.id, fakeId.asJson).asJson)
       api.toRdf(json).map(model => Graph(expanded.rootId, model).replace(fakeId, expanded.rootId))
     }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/Graph.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/Graph.scala
@@ -5,16 +5,18 @@ import java.util.UUID
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.{predicate, subject, Triple}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.rdf
+import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph.emptyModel
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.jena.writer.DotWriter._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd, JsonLd}
-import ch.epfl.bluebrain.nexus.delta.rdf.{tryOrConversionErr, IriOrBNode, RdfError, Triple}
+import ch.epfl.bluebrain.nexus.delta.rdf.{ioTryOrConversionErr, tryOrConversionErr, IriOrBNode, RdfError, Triple}
 import io.circe.Json
 import io.circe.syntax._
 import monix.bio.IO
+import org.apache.jena.graph.Factory.createDefaultGraph
 import org.apache.jena.rdf.model.ResourceFactory.createStatement
 import org.apache.jena.rdf.model._
 import org.apache.jena.riot.{Lang, RDFWriter}
@@ -37,7 +39,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
     */
   def filter(evalTriple: Triple => Boolean): Graph = {
     val iter     = model.listStatements()
-    val newModel = ModelFactory.createDefaultModel()
+    val newModel = emptyModel()
     while (iter.hasNext) {
       val stmt = iter.nextStatement
       if (evalTriple(Triple(stmt))) newModel.add(stmt)
@@ -72,7 +74,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
     val currentResource = subject(current)
     val replaceResource = subject(replace)
     val iter            = model.listStatements()
-    val newModel        = ModelFactory.createDefaultModel()
+    val newModel        = emptyModel()
     while (iter.hasNext) {
       val stmt      = iter.nextStatement
       val (s, p, o) = Triple(stmt)
@@ -86,7 +88,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
   /**
     * Returns all the triples of the current graph
     */
-  def triples: Set[Triple] =
+  lazy val triples: Set[Triple] =
     model.listStatements().asScala.map(Triple(_)).toSet
 
   /**
@@ -124,7 +126,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
   /**
     * Attempts to convert the current Graph to the N-Triples format: https://www.w3.org/TR/n-triples/
     */
-  def toNTriples: IO[RdfError, NTriples] =
+  def toNTriples: Either[RdfError, NTriples] =
     tryOrConversionErr(RDFWriter.create().lang(Lang.NTRIPLES).source(model).asString(), Lang.NTRIPLES.getName)
       .map(NTriples(_, rootNode))
 
@@ -140,7 +142,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
     for {
       resolvedCtx <- JsonLdContext(contextValue)
       ctx          = dotContext(rootResource, resolvedCtx)
-      string      <- tryOrConversionErr(RDFWriter.create().lang(DOT).source(model).context(ctx).asString(), DOT.getName)
+      string      <- ioTryOrConversionErr(RDFWriter.create().lang(DOT).source(model).context(ctx).asString(), DOT.getName)
     } yield Dot(string, rootNode)
 
   /**
@@ -155,7 +157,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
       opts: JsonLdOptions
   ): IO[RdfError, CompactedJsonLd] =
     if (rootNode.isIri) {
-      api.fromRdf(model).flatMap(expanded => JsonLd.frame(expanded.asJson, contextValue, rootNode))
+      IO.fromEither(api.fromRdf(model)).flatMap(expanded => JsonLd.frame(expanded.asJson, contextValue, rootNode))
     } else {
       // A new model is created where the rootNode is a fake Iri.
       // This is done in order to be able to perform the framing, since framing won't work on blank nodes.
@@ -163,7 +165,7 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
       val fakeId   = iri"http://fake.com/${UUID.randomUUID()}"
       val newModel = replace(rootNode, fakeId).model
       for {
-        expanded  <- api.fromRdf(newModel)
+        expanded  <- IO.fromEither(api.fromRdf(newModel))
         framed    <- JsonLd.frame(expanded.asJson, contextValue, fakeId)
         fakeIdJson = fakeId.asJson
       } yield framed.copy(obj = framed.obj.filter { case (_, v) => v != fakeIdJson }, rootId = self.rootNode)
@@ -181,6 +183,17 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
   ): IO[RdfError, ExpandedJsonLd] =
     toCompactedJsonLd(ContextValue.empty).flatMap(_.toExpanded)
 
+  override def hashCode(): Int = (rootNode, triples).##
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case that: Graph => rootNode == that.rootNode && triples == that.triples
+      case _           => false
+    }
+
+  override def toString: String =
+    s"rootNode = '$rootNode', triples = '$triples'"
+
   /**
     * Replaces the root node
     *
@@ -192,24 +205,34 @@ final case class Graph private (rootNode: IriOrBNode, model: Model) { self =>
     else self
 
   private def copy(model: Model): Model =
-    ModelFactory.createDefaultModel().add(model)
+    emptyModel().add(model)
 }
 
 object Graph {
 
+  /**
+    * An empty graph with a auto generated [[BNode]] as a root node
+    */
+  final val empty: Graph = Graph(BNode.random, emptyModel())
+
+  /**
+    * Unsafely builds a graph from an already passed [[Model]] and an auto generated [[BNode]] as a root node
+    */
   final def unsafe(model: Model): Graph =
     Graph(BNode.random, model)
+
+  /**
+    * Unsafely builds a graph from an already passed [[Model]] and the passed [[IriOrBNode]]
+    */
+  final def unsafe(rootNode: IriOrBNode, model: Model): Graph =
+    Graph(rootNode, model)
 
   /**
     * Creates a [[Graph]] from an expanded JSON-LD.
     *
     * @param expanded the expanded JSON-LD input to transform into a Graph
     */
-  final def apply(expanded: ExpandedJsonLd)(implicit
-      api: JsonLdApi,
-      resolution: RemoteContextResolution,
-      options: JsonLdOptions
-  ): IO[RdfError, Graph] =
+  final def apply(expanded: ExpandedJsonLd)(implicit api: JsonLdApi, options: JsonLdOptions): Either[RdfError, Graph] =
     if (expanded.rootId.isIri) {
       api.toRdf(expanded.json).map(model => Graph(expanded.rootId, model))
     } else {
@@ -219,4 +242,7 @@ object Graph {
       val json   = Json.arr(expanded.obj.add(keywords.id, fakeId.asJson).asJson)
       api.toRdf(json).map(model => Graph(expanded.rootId, model).replace(fakeId, expanded.rootId))
     }
+
+  private[rdf] def emptyModel(): Model = ModelFactory.createModelForGraph(createDefaultGraph())
+
 }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
@@ -51,27 +51,19 @@ final case class CompactedJsonLd private[jsonld] (
   def add(key: String, literal: Double): This =
     add(key, literal.asJson)
 
-  def toCompacted(contextValue: ContextValue)(implicit
-      opts: JsonLdOptions,
-      api: JsonLdApi,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, CompactedJsonLd] =
-    if (contextValue == ctx) IO.pure(self)
-    else JsonLd.compact(json, contextValue, rootId)
-
-  override def toExpanded(implicit
+  def toExpanded(implicit
       opts: JsonLdOptions,
       api: JsonLdApi,
       resolution: RemoteContextResolution
   ): IO[RdfError, ExpandedJsonLd] =
     JsonLd.expand(json).map(_.replaceId(rootId))
 
-  override def toGraph(implicit
+  def toGraph(implicit
       opts: JsonLdOptions,
       api: JsonLdApi,
       resolution: RemoteContextResolution
   ): IO[RdfError, Graph] =
-    toExpanded.flatMap(_.toGraph)
+    toExpanded.flatMap(expanded => IO.fromEither(expanded.toGraph))
 
   override def isEmpty: Boolean = obj.isEmpty
 

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
@@ -98,18 +98,10 @@ final case class ExpandedJsonLd private[jsonld] (obj: JsonObject, rootId: IriOrB
   ): IO[RdfError, CompactedJsonLd] =
     JsonLd.compact(json, contextValue, rootId)
 
-  override def toExpanded(implicit
+  def toGraph(implicit
       opts: JsonLdOptions,
-      api: JsonLdApi,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, ExpandedJsonLd] =
-    IO.pure(self)
-
-  override def toGraph(implicit
-      opts: JsonLdOptions,
-      api: JsonLdApi,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, Graph] = Graph(this)
+      api: JsonLdApi
+  ): Either[RdfError, Graph] = Graph(this)
 
   override def isEmpty: Boolean = obj.isEmpty
 

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.{InvalidIri, UnexpectedJsonLd}
-import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
@@ -69,29 +68,6 @@ trait JsonLd extends Product with Serializable {
     * Adds a ''key'' with its ''literal'' boolean.
     */
   def add(key: Predicate, literal: Boolean): This
-
-  /**
-    * Converts the current JsonLd into a [[CompactedJsonLd]]
-    *
-    * @param contextValue the context value to use in order to compact the current JsonLd.
-    */
-  def toCompacted(contextValue: ContextValue)(implicit
-      opts: JsonLdOptions,
-      api: JsonLdApi,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, CompactedJsonLd]
-
-  def toExpanded(implicit
-      opts: JsonLdOptions,
-      api: JsonLdApi,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, ExpandedJsonLd]
-
-  def toGraph(implicit
-      opts: JsonLdOptions,
-      api: JsonLdApi,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, Graph]
 
   /**
     * Checks if the current [[JsonLd]] is empty

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLdEncoder.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLdEncoder.scala
@@ -50,7 +50,7 @@ trait JsonLdEncoder[A] {
   ): IO[RdfError, Dot] =
     for {
       expanded <- expand(value)
-      graph    <- expanded.toGraph
+      graph    <- IO.fromEither(expanded.toGraph)
       dot      <- graph.toDot(context(value))
     } yield dot
 
@@ -66,8 +66,8 @@ trait JsonLdEncoder[A] {
   ): IO[RdfError, NTriples] =
     for {
       expanded <- expand(value)
-      graph    <- expanded.toGraph
-      ntriples <- graph.toNTriples
+      graph    <- IO.fromEither(expanded.toGraph)
+      ntriples <- IO.fromEither(graph.toNTriples)
     } yield ntriples
 
 }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApi.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApi.scala
@@ -27,14 +27,9 @@ trait JsonLdApi {
       resolution: RemoteContextResolution
   ): IO[RdfError, JsonObject]
 
-  private[rdf] def toRdf(input: Json)(implicit
-      opts: JsonLdOptions,
-      resolution: RemoteContextResolution
-  ): IO[RdfError, Model]
+  private[rdf] def toRdf(input: Json)(implicit opts: JsonLdOptions): Either[RdfError, Model]
 
-  private[rdf] def fromRdf(input: Model)(implicit
-      opts: JsonLdOptions
-  ): IO[RdfError, Seq[JsonObject]]
+  private[rdf] def fromRdf(input: Model)(implicit opts: JsonLdOptions): Either[RdfError, Seq[JsonObject]]
 
   private[rdf] def context(value: ContextValue)(implicit
       opts: JsonLdOptions,

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/package.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/package.scala
@@ -8,10 +8,9 @@ import scala.util.Try
 
 package object rdf {
 
-  /**
-    * Wrap the passed ''value'' on a Try.
-    * Convert the Try result into an Either, where a Failure(throwable) is transformed into a Left(ConversionError())
-    */
-  def tryOrConversionErr[A](value: => A, stage: String): IO[RdfError, A] =
-    IO.fromTry(Try(value)).leftMap(err => ConversionError(err.getMessage, stage))
+  private[rdf] def ioTryOrConversionErr[A](value: => A, stage: String): IO[RdfError, A] =
+    IO.fromEither(tryOrConversionErr(value, stage))
+
+  private[rdf] def tryOrConversionErr[A](value: => A, stage: String): Either[RdfError, A] =
+    Try(value).toEither.leftMap(err => ConversionError(err.getMessage, stage))
 }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/syntax/JsonSyntax.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/syntax/JsonSyntax.scala
@@ -69,7 +69,7 @@ final class JsonOps(private val json: Json) extends AnyVal {
   /**
     * Removes the provided keys from everywhere on the current json.
     */
-  def removeAllKeys(keys: String*): Json = JsonUtils.remoteAllKeys(json, keys: _*)
+  def removeAllKeys(keys: String*): Json = JsonUtils.removeAllKeys(json, keys: _*)
 
   /**
     * Removes the provided key value pairs from everywhere on the json.
@@ -84,7 +84,7 @@ final class JsonOps(private val json: Json) extends AnyVal {
   /**
     * Replace in the current json the found key value pairs in ''from'' with the value in ''toValue''
     */
-  def replace(from: (String, Json), toValue: Json): Json = JsonUtils.replace(json, from, toValue)
+  def replace[A: Encoder, B: Encoder](from: (String, A), toValue: B): Json = JsonUtils.replace(json, from, toValue)
 
   /**
     * Extract all the values found from the passed ''keys'' in the current json.

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/utils/JsonUtils.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/utils/JsonUtils.scala
@@ -61,19 +61,19 @@ trait JsonUtils {
   /**
     * Removes the provided keys from everywhere on the json.
     */
-  def remoteAllKeys(json: Json, keys: String*): Json =
+  def removeAllKeys(json: Json, keys: String*): Json =
     removeNested(json, keys.map(k => (kk => kk == k, _ => true)))
 
   /**
     * Replace in the passed ''json'' the found key value pairs in ''from'' with the value in ''toValue''
     */
-  def replace(json: Json, from: (String, Json), toValue: Json): Json = {
-    val (fromKey, fromValue)               = from
+  def replace[A: Encoder, B: Encoder](json: Json, from: (String, A), toValue: B): Json = {
+    val (fromKey, fromValue)               = (from._1, from._2.asJson)
     def inner(obj: JsonObject): JsonObject =
       JsonObject.fromIterable(
         obj.toVector.map {
-          case (`fromKey`, `fromValue`) => fromKey -> toValue
-          case (k, v)                   => k       -> v
+          case (`fromKey`, `fromValue`) => fromKey -> toValue.asJson
+          case (k, v)                   => k       -> replace(v, from, toValue)
         }
       )
     json.arrayOrObject(

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/GraphSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/GraphSpec.scala
@@ -15,21 +15,21 @@ class GraphSpec extends AnyWordSpecLike with Matchers with Fixtures {
   "A Graph" should {
     val expandedJson     = jsonContentOf("expanded.json")
     val expanded         = JsonLd.expand(expandedJson).accepted
-    val graph            = Graph(expanded).accepted
+    val graph            = Graph(expanded).rightValue
     val bnode            = bNode(graph)
     val iriSubject       = subject(iri)
     val rootBNode        = BNode.random
     val expandedNoIdJson = expandedJson.removeAll(keywords.id -> iri)
     val expandedNoId     = JsonLd.expand(expandedNoIdJson).accepted.replaceId(rootBNode)
-    val graphNoId        = Graph(expandedNoId).accepted
+    val graphNoId        = Graph(expandedNoId).rightValue
     val bnodeNoId        = bNode(graphNoId)
 
     "be created from expanded jsonld" in {
-      Graph(expanded).accepted.triples.size shouldEqual 16
+      Graph(expanded).rightValue.triples.size shouldEqual 16
     }
 
     "be created from expanded jsonld with a root blank node" in {
-      Graph(expandedNoId).accepted.triples.size shouldEqual 16
+      Graph(expandedNoId).rightValue.triples.size shouldEqual 16
     }
 
     "return a filtered graph" in {
@@ -71,12 +71,12 @@ class GraphSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
     "be converted to NTriples" in {
       val expected = contentOf("ntriples.nt", "bnode" -> bnode.rdfFormat, "rootNode" -> iri.rdfFormat)
-      graph.toNTriples.accepted.toString should equalLinesUnordered(expected)
+      graph.toNTriples.rightValue.toString should equalLinesUnordered(expected)
     }
 
     "be converted to NTriples with a root blank node" in {
       val expected = contentOf("ntriples.nt", "bnode" -> bnodeNoId.rdfFormat, "rootNode" -> rootBNode.rdfFormat)
-      graphNoId.toNTriples.accepted.toString should equalLinesUnordered(expected)
+      graphNoId.toNTriples.rightValue.toString should equalLinesUnordered(expected)
     }
 
     "be converted to dot without context" in {

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLdSpec.scala
@@ -68,18 +68,6 @@ class CompactedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures wi
       result.json.removeKeys(keywords.context) shouldEqual json"""{"@id": "$iri", "@type": "${schema.Person}"}"""
     }
 
-    "return self when attempted to convert again to compacted form with same values" in {
-      val compacted = JsonLd.compact(expanded, context, iri).accepted
-      compacted.toCompacted(context).accepted should be theSameInstanceAs compacted
-    }
-
-    "recompute compacted form when attempted to convert again to compacted form with different @context" in {
-      val compacted = JsonLd.compact(expanded, context, iri).accepted
-      val context2  = context.contextObj deepMerge json"""{"@context": {"other-something": {"@type": "@id"}}}"""
-      val result    = compacted.toCompacted(context2.topContextValueOrEmpty).accepted
-      result.json.removeKeys(keywords.context) shouldEqual compacted.json.removeKeys(keywords.context)
-    }
-
     "be converted to expanded form" in {
       val compacted = JsonLd.compact(expanded, context, iri).accepted
       compacted.toExpanded.accepted shouldEqual JsonLd.expandedUnsafe(expanded, iri)
@@ -95,7 +83,7 @@ class CompactedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures wi
       val graph     = compacted.toGraph.accepted
       val expected  = contentOf("ntriples.nt", "bnode" -> bNode(graph).rdfFormat, "rootNode" -> iri.rdfFormat)
       graph.rootNode shouldEqual iri
-      graph.toNTriples.accepted.toString should equalLinesUnordered(expected)
+      graph.toNTriples.rightValue.toString should equalLinesUnordered(expected)
     }
 
     "be converted to graph with a root blank node" in {
@@ -103,7 +91,7 @@ class CompactedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures wi
       val graph     = compacted.toGraph.accepted
       val expected  = contentOf("ntriples.nt", "bnode" -> bNode(graph).rdfFormat, "rootNode" -> rootBNode.rdfFormat)
       graph.rootNode shouldEqual rootBNode
-      graph.toNTriples.accepted.toString should equalLinesUnordered(expected)
+      graph.toNTriples.rightValue.toString should equalLinesUnordered(expected)
     }
   }
 }

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
@@ -6,7 +6,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.UnexpectedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{schema, xsd}
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -56,7 +55,7 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
       val newIri   = iri"http://example.com/myid"
       val expanded = JsonLd.expand(compacted).accepted.replaceId(newIri)
       expanded.rootId shouldEqual newIri
-      expanded.json shouldEqual expectedExpanded.replace(keywords.id -> iri.asJson, newIri.asJson)
+      expanded.json shouldEqual expectedExpanded.replace(keywords.id -> iri, newIri)
     }
 
     "fetch root @type" in {
@@ -146,11 +145,6 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
       result.json.removeKeys(keywords.context) shouldEqual compacted.removeKeys(keywords.context)
     }
 
-    "return self when attempted to convert again to expanded form" in {
-      val expanded = JsonLd.expand(compacted).accepted
-      expanded.toExpanded.accepted should be theSameInstanceAs expanded
-    }
-
     "be empty" in {
       JsonLd.expand(json"""[{"@id": "http://example.com/id", "a": "b"}]""").accepted.isEmpty shouldEqual true
     }
@@ -161,10 +155,10 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
     "be converted to graph" in {
       val expanded = JsonLd.expand(compacted).accepted
-      val graph    = expanded.toGraph.accepted
+      val graph    = expanded.toGraph.rightValue
       val expected = contentOf("ntriples.nt", "bnode" -> bNode(graph).rdfFormat, "rootNode" -> iri.rdfFormat)
       graph.rootNode shouldEqual iri
-      graph.toNTriples.accepted.toString should equalLinesUnordered(expected)
+      graph.toNTriples.rightValue.toString should equalLinesUnordered(expected)
     }
   }
 }

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngineSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngineSpec.scala
@@ -5,13 +5,12 @@ import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
-import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
+import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
+import ch.epfl.bluebrain.nexus.testkit.{EitherValuable, IOValues, TestHelpers}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
-import io.circe.syntax._
 
-class ShaclEngineSpec extends AnyWordSpecLike with Matchers with TestHelpers with IOValues {
+class ShaclEngineSpec extends AnyWordSpecLike with Matchers with TestHelpers with IOValues with EitherValuable {
 
   "A ShaclEngine" should {
 
@@ -21,33 +20,36 @@ class ShaclEngineSpec extends AnyWordSpecLike with Matchers with TestHelpers wit
 
     implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(contexts.shacl -> shaclResolvedCtx)
 
-    val schemaGraph   = Graph(JsonLd.expand(schema).accepted).accepted
-    val resourceGraph = Graph(JsonLd.expand(resource).accepted).accepted
+    val schemaGraph   = Graph(JsonLd.expand(schema).accepted).rightValue
+    val resourceGraph = Graph(JsonLd.expand(resource).accepted).rightValue
 
-    "validate" in {
-      val report =
-        ShaclEngine(resourceGraph.model, schemaGraph.model, validateShapes = true, reportDetails = true).accepted
+    "validate data" in {
+      val report = ShaclEngine(resourceGraph.model, schemaGraph.model, reportDetails = true).accepted
       report.isValid() shouldEqual true
     }
 
-    "fail validation when not matching nodes" in {
-      val resourceChangedType = resource.replace(keywords.tpe -> "Custom".asJson, "Other".asJson)
-      val resourceGraph       = Graph(JsonLd.expand(resourceChangedType).accepted).accepted
-      val report              =
-        ShaclEngine(resourceGraph.model, schemaGraph.model, validateShapes = true, reportDetails = true).accepted
+    "validate shapes" in {
+      ShaclEngine(schemaGraph.model, reportDetails = true).accepted.isValid() shouldEqual true
+    }
+
+    "fail validating shapes if unexpected field value" in {
+      val wrongSchema = schema.replace("minCount" -> 1, "wrong")
+      val graph       = Graph(JsonLd.expand(wrongSchema).accepted).rightValue
+      ShaclEngine(graph.model, reportDetails = true).accepted.isValid() shouldEqual false
+    }
+
+    "fail validating data if not matching nodes" in {
+      val resourceChangedType = resource.replace(keywords.tpe -> "Custom", "Other")
+      val resourceGraph       = Graph(JsonLd.expand(resourceChangedType).accepted).rightValue
+      val report              = ShaclEngine(resourceGraph.model, schemaGraph.model, reportDetails = true).accepted
       report.isValid() shouldEqual false
       report.targetedNodes shouldEqual 0
     }
 
-    "fail validation when wrong field type" in {
-      val resourceChangedNumber = resource.replace("number" -> 24.asJson, "Other".asJson)
-      val resourceGraph         = Graph(JsonLd.expand(resourceChangedNumber).accepted).accepted
-      ShaclEngine(
-        resourceGraph.model,
-        schemaGraph.model,
-        validateShapes = true,
-        reportDetails = true
-      ).accepted shouldEqual
+    "fail validating data if wrong field type" in {
+      val resourceChangedNumber = resource.replace("number" -> 24, "Other")
+      val resourceGraph         = Graph(JsonLd.expand(resourceChangedNumber).accepted).rightValue
+      ShaclEngine(resourceGraph.model, schemaGraph.model, reportDetails = true).accepted shouldEqual
         ValidationReport(false, 10, jsonContentOf("shacl/failed_number.json"))
     }
   }

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReportSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReportSpec.scala
@@ -26,7 +26,7 @@ class ValidationReportSpec
     RemoteContextResolution.fixed(contexts.shacl -> shaclResolvedCtx)
 
   private def resource(json: Json): Resource        =
-    Graph(JsonLd.expand(json).accepted).accepted.model.createResource()
+    Graph(JsonLd.expand(json).accepted).rightValue.model.createResource()
 
   "A ValidationReport" should {
     val conforms = jsonContentOf("/shacl/conforms.json")

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/utils/JsonUtilsSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/utils/JsonUtilsSpec.scala
@@ -52,7 +52,7 @@ class JsonUtilsSpec extends AnyWordSpecLike with Matchers with Fixtures with Ins
       val json =
         json"""[{"key": 1, "key2": {"key": "value"}}, { "key": 1, "@context": {"@vocab": "${vocab.value}"} }]"""
 
-      json.replace("key" -> 1.asJson, "other".asJson) shouldEqual
+      json.replace("key" -> 1, "other") shouldEqual
         json"""[{"key": "other", "key2": {"key": "value"}}, { "key": "other", "@context": {"@vocab": "${vocab.value}"} }]"""
     }
 

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesBehaviors.scala
@@ -290,13 +290,12 @@ trait ResourcesBehaviors {
     "tagging a resource" should {
 
       "succeed" in {
-        val expectedData = ResourceGen.resource(myId, projectRef, source, resourceSchema)
+        val expectedData = ResourceGen.resource(myId, projectRef, source, resourceSchema, tags = Map(tag -> 1L))
         val resource     =
           resources.tag(IriSegment(myId), projectRef, Some(IriSegment(schemas.resources)), tag, 1L, 1L).accepted
         resource shouldEqual
           ResourceGen.resourceFor(
             expectedData,
-            tags = Map(tag -> 1L),
             types = types,
             subject = subject,
             rev = 2L,
@@ -399,14 +398,14 @@ trait ResourcesBehaviors {
     }
 
     "fetching a resource" should {
-      val expectedData = ResourceGen.resource(myId, projectRef, source, resourceSchema)
+      val expectedData       = ResourceGen.resource(myId, projectRef, source, resourceSchema)
+      val expectedDataLatest = expectedData.copy(tags = Map(tag -> 1L))
 
       "succeed" in {
         forAll(List(None, Some(IriSegment(schemas.resources)))) { schema =>
           resources.fetch(IriSegment(myId), projectRef, schema).accepted.value shouldEqual
             ResourceGen.resourceFor(
-              expectedData,
-              tags = Map(tag -> 1L),
+              expectedDataLatest,
               types = types,
               subject = subject,
               rev = 2L,

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resolvers.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resolvers.scala
@@ -251,18 +251,18 @@ object Resolvers {
 
     def addTag(c: TagResolver): IO[ResolverRejection, ResolverTagAdded] = state match {
       // Resolver can't be found
-      case Initial                                              =>
+      case Initial                                               =>
         IO.raiseError(ResolverNotFound(c.id, c.project))
       // Invalid revision
-      case s: Current if c.rev != s.rev                         =>
+      case s: Current if c.rev != s.rev                          =>
         IO.raiseError(IncorrectRev(c.rev, s.rev))
       // Revision to tag is invalid
-      case s: Current if c.targetRev < 0 || c.targetRev > s.rev =>
+      case s: Current if c.targetRev <= 0 || c.targetRev > s.rev =>
         IO.raiseError(RevisionNotFound(c.targetRev, s.rev))
       // State is deprecated
-      case s: Current if s.deprecated                           =>
+      case s: Current if s.deprecated                            =>
         IO.raiseError(ResolverIsDeprecated(s.id))
-      case s: Current                                           =>
+      case s: Current                                            =>
         instant.map { now =>
           ResolverTagAdded(
             id = c.id,

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Schemas.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Schemas.scala
@@ -1,0 +1,267 @@
+package ch.epfl.bluebrain.nexus.delta.sdk
+
+import akka.persistence.query.Offset
+import cats.effect.Clock
+import cats.syntax.all._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.shacl.ShaclEngine
+import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaCommand._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaEvent._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaState.{Current, Initial}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.{SchemaCommand, SchemaEvent, SchemaRejection, SchemaState}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{Envelope, IdSegment, Label}
+import ch.epfl.bluebrain.nexus.delta.sdk.utils.IOUtils
+import fs2.Stream
+import io.circe.Json
+import monix.bio.{IO, Task, UIO}
+
+/**
+  * Operations pertaining to managing schemas.
+  */
+trait Schemas {
+
+  /**
+    * Creates a new schema where the id is either present on the payload or self generated.
+    *
+    * @param projectRef the project reference where the schema belongs
+    * @param source     the schema payload
+    */
+  def create(projectRef: ProjectRef, source: Json)(implicit caller: Subject): IO[SchemaRejection, SchemaResource]
+
+  /**
+    * Creates a new schema with the expanded form of the passed id.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @param source     the schema payload
+    */
+  def create(
+      id: IdSegment,
+      projectRef: ProjectRef,
+      source: Json
+  )(implicit caller: Subject): IO[SchemaRejection, SchemaResource]
+
+  /**
+    * Updates an existing schema.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @param rev        the current revision of the schema
+    * @param source     the schema payload
+    */
+  def update(
+      id: IdSegment,
+      projectRef: ProjectRef,
+      rev: Long,
+      source: Json
+  )(implicit caller: Subject): IO[SchemaRejection, SchemaResource]
+
+  /**
+    * Adds a tag to an existing schema.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @param tag        the tag name
+    * @param tagRev     the tag revision
+    * @param rev        the current revision of the schema
+    */
+  def tag(
+      id: IdSegment,
+      projectRef: ProjectRef,
+      tag: Label,
+      tagRev: Long,
+      rev: Long
+  )(implicit caller: Subject): IO[SchemaRejection, SchemaResource]
+
+  /**
+    * Deprecates an existing schema.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @param rev       the revision of the schema
+    */
+  def deprecate(
+      id: IdSegment,
+      projectRef: ProjectRef,
+      rev: Long
+  )(implicit caller: Subject): IO[SchemaRejection, SchemaResource]
+
+  /**
+    * Fetches a schema.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @return the schema in a Resource representation, None otherwise
+    */
+  def fetch(id: IdSegment, projectRef: ProjectRef): IO[SchemaRejection, Option[SchemaResource]]
+
+  /**
+    * Fetches a schema at a specific revision.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @param rev       the schemas revision
+    * @return the schema as a schema at the specified revision
+    */
+  def fetchAt(id: IdSegment, projectRef: ProjectRef, rev: Long): IO[SchemaRejection, Option[SchemaResource]]
+
+  /**
+    * Fetches a schema by tag.
+    *
+    * @param id         the identifier that will be expanded to the Iri of the schema
+    * @param projectRef the project reference where the schema belongs
+    * @param tag        the tag revision
+    * @return the schema as a schema at the specified revision
+    */
+  def fetchBy(
+      id: IdSegment,
+      projectRef: ProjectRef,
+      tag: Label
+  ): IO[SchemaRejection, Option[SchemaResource]] =
+    fetch(id, projectRef).flatMap {
+      case Some(schema) =>
+        schema.value.tags.get(tag) match {
+          case Some(rev) => fetchAt(id, projectRef, rev).leftMap(_ => TagNotFound(tag))
+          case None      => IO.raiseError(TagNotFound(tag))
+        }
+      case None         => IO.pure(None)
+    }
+
+  /**
+    * A non terminating stream of events for schemas. After emitting all known events it sleeps until new events
+    * are recorded.
+    *
+    * @param offset the last seen event offset; it will not be emitted by the stream
+    */
+  def events(offset: Offset): Stream[Task, Envelope[SchemaEvent]]
+
+}
+
+object Schemas {
+
+  /**
+    * The schemas module type.
+    */
+  final val moduleType: String = "schema"
+
+  private[delta] def next(state: SchemaState, event: SchemaEvent): SchemaState = {
+
+    @SuppressWarnings(Array("OptionGet"))
+    // It is fine to do it unsafely since we have already computed the graph on evaluation previously in order to validate the schema.
+    def toGraphUnsafe(expanded: ExpandedJsonLd) =
+      expanded.toGraph.toOption.get
+
+    // format: off
+    def created(e: SchemaCreated): SchemaState = state match {
+      case Initial     => Current(e.id, e.project, e.source, e.compacted, e.expanded, toGraphUnsafe(e.expanded), e.rev, deprecated = false, Map.empty, e.instant, e.subject, e.instant, e.subject)
+      case s: Current  => s
+    }
+
+    def updated(e: SchemaUpdated): SchemaState = state match {
+      case Initial    => Initial
+      case s: Current => s.copy(rev = e.rev, source = e.source, compacted = e.compacted, expanded = e.expanded, graph = toGraphUnsafe(e.expanded), updatedAt = e.instant, updatedBy = e.subject)
+    }
+
+    def tagAdded(e: SchemaTagAdded): SchemaState = state match {
+      case Initial    => Initial
+      case s: Current => s.copy(rev = e.rev, tags = s.tags + (e.tag -> e.targetRev), updatedAt = e.instant, updatedBy = e.subject)
+    }
+    // format: on
+
+    def deprecated(e: SchemaDeprecated): SchemaState = state match {
+      case Initial    => Initial
+      case s: Current => s.copy(rev = e.rev, deprecated = true, updatedAt = e.instant, updatedBy = e.subject)
+    }
+    event match {
+      case e: SchemaCreated    => created(e)
+      case e: SchemaUpdated    => updated(e)
+      case e: SchemaTagAdded   => tagAdded(e)
+      case e: SchemaDeprecated => deprecated(e)
+    }
+  }
+
+  @SuppressWarnings(Array("OptionGet"))
+  private[delta] def evaluate(state: SchemaState, cmd: SchemaCommand)(implicit
+      clock: Clock[UIO] = IO.clock,
+      rcr: RemoteContextResolution
+  ): IO[SchemaRejection, SchemaEvent] = {
+
+    def toGraph(id: Iri, expanded: ExpandedJsonLd) =
+      IO.fromEither(expanded.toGraph.leftMap(err => InvalidJsonLdFormat(Some(id), err)))
+
+    def validate(id: Iri, graph: Graph): IO[SchemaRejection, Unit] =
+      for {
+        report <- ShaclEngine(graph.model, reportDetails = true).leftMap(SchemaShaclEngineRejection(id, _))
+        result <- if (report.isValid()) IO.unit else IO.raiseError(InvalidSchema(id, report))
+      } yield result
+
+    def create(c: CreateSchema) =
+      state match {
+        case Initial =>
+          for {
+            graph <- toGraph(c.id, c.expanded)
+            _     <- validate(c.id, graph)
+            t     <- IOUtils.instant
+          } yield SchemaCreated(c.id, c.project, c.source, c.compacted, c.expanded, 1L, t, c.subject)
+
+        case _ => IO.raiseError(SchemaAlreadyExists(c.id))
+      }
+
+    def update(c: UpdateSchema) =
+      state match {
+        case Initial                      =>
+          IO.raiseError(SchemaNotFound(c.id))
+        case s: Current if s.rev != c.rev =>
+          IO.raiseError(IncorrectRev(c.rev, s.rev))
+        case s: Current if s.deprecated   =>
+          IO.raiseError(SchemaIsDeprecated(c.id))
+        case s: Current                   =>
+          for {
+            graph <- toGraph(c.id, c.expanded)
+            _     <- validate(c.id, graph)
+            time  <- IOUtils.instant
+          } yield SchemaUpdated(c.id, c.project, c.source, c.compacted, c.expanded, s.rev + 1, time, c.subject)
+
+      }
+
+    def tag(c: TagSchema) =
+      state match {
+        case Initial                                               =>
+          IO.raiseError(SchemaNotFound(c.id))
+        case s: Current if s.rev != c.rev                          =>
+          IO.raiseError(IncorrectRev(c.rev, s.rev))
+        case s: Current if s.deprecated                            =>
+          IO.raiseError(SchemaIsDeprecated(c.id))
+        case s: Current if c.targetRev <= 0 || c.targetRev > s.rev =>
+          IO.raiseError(RevisionNotFound(c.targetRev, s.rev))
+        case s: Current                                            =>
+          IOUtils.instant.map(SchemaTagAdded(c.id, c.project, c.targetRev, c.tag, s.rev + 1, _, c.subject))
+
+      }
+
+    def deprecate(c: DeprecateSchema) =
+      state match {
+        case Initial                      =>
+          IO.raiseError(SchemaNotFound(c.id))
+        case s: Current if s.rev != c.rev =>
+          IO.raiseError(IncorrectRev(c.rev, s.rev))
+        case s: Current if s.deprecated   =>
+          IO.raiseError(SchemaIsDeprecated(c.id))
+        case s: Current                   =>
+          IOUtils.instant.map(SchemaDeprecated(c.id, c.project, s.rev + 1, _, c.subject))
+      }
+
+    cmd match {
+      case c: CreateSchema    => create(c)
+      case c: UpdateSchema    => update(c)
+      case c: TagSchema       => tag(c)
+      case c: DeprecateSchema => deprecate(c)
+    }
+  }
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/Schema.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/Schema.scala
@@ -2,18 +2,28 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.schemas
 
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.CompactedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import io.circe.Json
 
 /**
   * A schema representation
   *
-  * @param id        the resource identifier
-  * @param project   the project where the resource belongs
-  * @param source    the representation of the resource as posted by the subject
+  * @param id        the schema identifier
+  * @param project   the project where the schema belongs
+  * @param tags      the schema tags
+  * @param source    the representation of the schema as posted by the subject
   * @param compacted the compacted JSON-LD representation of the schema
+  * @param expanded  the expanded JSON-LD representation of the schema
   * @param graph     the Graph  representation of the schema
   */
-//TODO: Review this when dealing with schemas
-final case class Schema(id: Iri, project: ProjectRef, source: Json, compacted: CompactedJsonLd, graph: Graph)
+final case class Schema(
+    id: Iri,
+    project: ProjectRef,
+    tags: Map[Label, Long],
+    source: Json,
+    compacted: CompactedJsonLd,
+    expanded: ExpandedJsonLd,
+    graph: Graph
+)

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/SchemaCommand.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/SchemaCommand.scala
@@ -1,0 +1,107 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.schemas
+
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
+import io.circe.Json
+
+/**
+  * Enumeration of schema commands
+  */
+sealed trait SchemaCommand extends Product with Serializable {
+
+  /**
+    * @return the project where the schema belongs to
+    */
+  def project: ProjectRef
+
+  /**
+    * @return the schema identifier
+    */
+  def id: Iri
+
+  /**
+    * @return the identity associated to this command
+    */
+  def subject: Subject
+
+}
+
+object SchemaCommand {
+
+  /**
+    * Command that signals the intent to create a new schema.
+    *
+    * @param id          the schema identifier
+    * @param project     the project where the schema belongs
+    * @param source      the representation of the schema as posted by the subject
+    * @param compacted   the compacted JSON-LD representation of the schema
+    * @param expanded    the expanded JSON-LD representation of the schema
+    * @param subject     the subject which created this event
+    */
+  final case class CreateSchema(
+      id: Iri,
+      project: ProjectRef,
+      source: Json,
+      compacted: CompactedJsonLd,
+      expanded: ExpandedJsonLd,
+      subject: Subject
+  ) extends SchemaCommand
+
+  /**
+    * Command that signals the intent to update an existing schema.
+    *
+    * @param id        the schema identifier
+    * @param project   the project where the schema belongs
+    * @param source    the representation of the schema as posted by the subject
+    * @param compacted the compacted JSON-LD representation of the schema
+    * @param expanded  the expanded JSON-LD representation of the schema
+    * @param rev       the last known revision of the schema
+    * @param subject   the subject which created this event
+    */
+  final case class UpdateSchema(
+      id: Iri,
+      project: ProjectRef,
+      source: Json,
+      compacted: CompactedJsonLd,
+      expanded: ExpandedJsonLd,
+      rev: Long,
+      subject: Subject
+  ) extends SchemaCommand
+
+  /**
+    * Command that signals the intent to add a tag to an existing schema.
+    *
+    * @param id        the schema identifier
+    * @param project   the project where the schema belongs
+    * @param targetRev the revision that is being aliased with the provided ''tag''
+    * @param tag       the tag of the alias for the provided ''tagRev''
+    * @param rev       the last known revision of the schema
+    * @param subject   the subject which created this event
+    */
+  final case class TagSchema(
+      id: Iri,
+      project: ProjectRef,
+      targetRev: Long,
+      tag: Label,
+      rev: Long,
+      subject: Subject
+  ) extends SchemaCommand
+
+  /**
+    * Command that signals the intent to deprecate a schema.
+    *
+    * @param id        the schema identifier
+    * @param project   the project where the schema belongs
+    * @param rev       the last known revision of the schema
+    * @param subject   the subject which created this event
+    */
+  final case class DeprecateSchema(
+      id: Iri,
+      project: ProjectRef,
+      rev: Long,
+      subject: Subject
+  ) extends SchemaCommand
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/SchemaRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/SchemaRejection.scala
@@ -1,0 +1,166 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.schemas
+
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClassUtils
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLdEncoder
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.rdf.shacl.ValidationReport
+import ch.epfl.bluebrain.nexus.delta.sdk.Mapper
+import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection.{InvalidId, UnexpectedId}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection
+import io.circe.syntax._
+import io.circe.{Encoder, JsonObject}
+
+/**
+  * Enumeration of schema rejection types.
+  *
+  * @param reason a descriptive message as to why the rejection occurred
+  */
+sealed abstract class SchemaRejection(val reason: String) extends Product with Serializable
+
+object SchemaRejection {
+
+  /**
+    * Rejection returned when a subject intends to retrieve a schema at a specific revision, but the provided revision
+    * does not exist.
+    *
+    * @param provided the provided revision
+    * @param current  the last known revision
+    */
+  final case class RevisionNotFound(provided: Long, current: Long)
+      extends SchemaRejection(s"Revision requested '$provided' not found, last known revision is '$current'.")
+
+  /**
+    * Rejection returned when a subject intends to retrieve a schema at a specific tag, but the provided tag
+    * does not exist.
+    *
+    * @param tag the provided tag
+    */
+  final case class TagNotFound(tag: Label) extends SchemaRejection(s"Tag requested '$tag' not found.")
+
+  /**
+    * Rejection returned when attempting to create a schema with an id that already exists.
+    *
+    * @param id the schema identifier
+    */
+  final case class SchemaAlreadyExists(id: Iri) extends SchemaRejection(s"Schema '$id' already exists.")
+
+  /**
+    * Rejection returned when attempting to update a schema with an id that doesn't exist.
+    *
+    * @param id the schema identifier
+    */
+  final case class SchemaNotFound(id: Iri) extends SchemaRejection(s"Schema '$id' not found.")
+
+  /**
+    * Rejection returned when attempting to create a schema where the passed id does not match the id on the payload.
+    *
+    * @param id        the schema identifier
+    * @param payloadId the schema identifier on the payload
+    */
+  final case class UnexpectedSchemaId(id: Iri, payloadId: Iri)
+      extends SchemaRejection(s"Schema '$id' does not match schema id on payload '$payloadId'.")
+
+  /**
+    * Rejection returned when attempting to interact with a schema providing an id that cannot be resolved to an Iri.
+    *
+    * @param id the schema identifier
+    */
+  final case class InvalidSchemaId(id: String)
+      extends SchemaRejection(s"Schema identifier '$id' cannot be expanded to an Iri.")
+
+  /**
+    * Rejection returned when attempting to create/update a schema where the payload does not satisfy the SHACL schema constrains.
+    *
+    * @param id      the schema identifier
+    * @param report  the SHACL validation failure report
+    */
+  final case class InvalidSchema(id: Iri, report: ValidationReport)
+      extends SchemaRejection(s"Schema '$id' failed to validate against the constrains defined in the SHACL schema.")
+
+  /**
+    * Rejection returned when attempting to create a SHACL engine.
+    *
+    * @param id      the schema identifier
+    * @param details the SHACL engine errors
+    */
+  final case class SchemaShaclEngineRejection(id: Iri, details: String)
+      extends SchemaRejection(s"Schema '$id' failed to produce a SHACL engine for the SHACL schema.")
+
+  /**
+    * Rejection returned when attempting to update/deprecate a schema that is already deprecated.
+    *
+    * @param id the schema identifier
+    */
+  final case class SchemaIsDeprecated(id: Iri) extends SchemaRejection(s"Schema '$id' is deprecated.")
+
+  /**
+    * Rejection returned when a subject intends to perform an operation on the current schema, but either provided an
+    * incorrect revision or a concurrent update won over this attempt.
+    *
+    * @param provided the provided revision
+    * @param expected the expected revision
+    */
+  final case class IncorrectRev(provided: Long, expected: Long)
+      extends SchemaRejection(
+        s"Incorrect revision '$provided' provided, expected '$expected', the schema may have been updated since last seen."
+      )
+
+  /**
+    * Signals a rejection caused when interacting with the projects API
+    */
+  final case class WrappedProjectRejection(rejection: ProjectRejection) extends SchemaRejection(rejection.reason)
+
+  /**
+    * Signals a rejection caused when interacting with the organizations API
+    */
+  final case class WrappedOrganizationRejection(rejection: OrganizationRejection)
+      extends SchemaRejection(rejection.reason)
+
+  /**
+    * Signals an error converting the source Json to JsonLD
+    */
+  final case class InvalidJsonLdFormat(idOpt: Option[Iri], rdfError: RdfError)
+      extends SchemaRejection(s"Schema ${idOpt.fold("")(id => s"'$id'")} has invalid JSON-LD payload.")
+
+  /**
+    * Rejection returned when the returned state is the initial state after a Schemas.evaluation plus a Schemas.next
+    * Note: This should never happen since the evaluation method already guarantees that the next function returns a current
+    */
+  final case class UnexpectedInitialState(id: Iri)
+      extends SchemaRejection(s"Unexpected initial state for schema '$id'.")
+
+  implicit private val schemasRejectionEncoder: Encoder.AsObject[SchemaRejection] =
+    Encoder.AsObject.instance { r =>
+      val tpe = ClassUtils.simpleName(r)
+      val obj = JsonObject.empty.add(keywords.tpe, tpe.asJson).add("reason", r.reason.asJson)
+      r match {
+        case WrappedOrganizationRejection(rejection) => rejection.asJsonObject
+        case WrappedProjectRejection(rejection)      => rejection.asJsonObject
+        case SchemaShaclEngineRejection(_, details)  => obj.add("details", details.asJson)
+        case InvalidJsonLdFormat(_, details)         => obj.add("details", details.reason.asJson)
+        case InvalidSchema(_, report)                => obj.add("details", report.json)
+        case _                                       => obj
+      }
+    }
+
+  implicit final val schemasRejectionJsonLdEncoder: JsonLdEncoder[SchemaRejection] =
+    JsonLdEncoder.fromCirce(id = BNode.random, iriContext = contexts.error)
+
+  implicit val schemaJsonLdRejectionMapper: Mapper[JsonLdRejection, SchemaRejection] = {
+    case InvalidId(id)                                     => InvalidSchemaId(id)
+    case UnexpectedId(id, payloadIri)                      => UnexpectedSchemaId(id, payloadIri)
+    case JsonLdRejection.InvalidJsonLdFormat(id, rdfError) => InvalidJsonLdFormat(id, rdfError)
+  }
+
+  implicit val schemaProjectRejectionMapper: Mapper[ProjectRejection, SchemaRejection] = {
+    case ProjectRejection.WrappedOrganizationRejection(r) => WrappedOrganizationRejection(r)
+    case value                                            => WrappedProjectRejection(value)
+  }
+
+}

--- a/delta/sdk/src/test/resources/resources/schema.json
+++ b/delta/sdk/src/test/resources/resources/schema.json
@@ -15,16 +15,19 @@
       "targetClass": "nxv:Custom",
       "property": [
         {
+          "@id": "nxv:NameProperty",
           "path": "nxv:name",
           "datatype": "xsd:string",
           "minCount": 1
         },
         {
+          "@id": "nxv:NumberProperty",
           "path": "nxv:number",
           "datatype": "xsd:integer",
           "minCount": 1
         },
         {
+          "@id": "nxv:PathProperty",
           "path": "nxv:bool",
           "datatype": "xsd:boolean",
           "minCount": 1

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/ResourcesSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/ResourcesSpec.scala
@@ -258,7 +258,7 @@ class ResourcesSpec
         ) shouldEqual current
       }
 
-      "create a new ProjectUpdated state" in {
+      "create a new ResourceUpdated state" in {
         val newTypes  = types + (nxv + "Other")
         val newSource = source deepMerge json"""{"key": "value"}"""
         next(

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/SchemasSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/SchemasSpec.scala
@@ -1,0 +1,204 @@
+package ch.epfl.bluebrain.nexus.delta.sdk
+
+import java.time.Instant
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.sdk.Schemas.{evaluate, next}
+import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, SchemaGen}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
+import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.User
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaCommand._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaEvent._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaRejection._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaState.Initial
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit._
+import monix.execution.Scheduler
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{CancelAfterFailure, Inspectors, OptionValues}
+
+class SchemasSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with EitherValuable
+    with Inspectors
+    with IOFixedClock
+    with CancelAfterFailure
+    with IOValues
+    with TestHelpers
+    with CirceLiteral
+    with OptionValues {
+
+  "The Schemas state machine" when {
+    implicit val sc: Scheduler = Scheduler.global
+    val epoch                  = Instant.EPOCH
+    val time2                  = Instant.ofEpochMilli(10L)
+    val subject                = User("myuser", Label.unsafe("myrealm"))
+
+    val shaclResolvedCtx                      = jsonContentOf("contexts/shacl.json")
+    implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(contexts.shacl -> shaclResolvedCtx)
+
+    val project = ProjectGen.resourceFor(ProjectGen.project("myorg", "myproject", base = nxv.base))
+
+    val myId      = nxv + "myschema"
+    val source    = jsonContentOf("resources/schema.json")
+    val schema    = SchemaGen.schema(myId, project.value.ref, source)
+    val compacted = schema.compacted
+    val expanded  = schema.expanded
+
+    val sourceUpdated = source.replace("targetClass" -> "nxv:Custom", "nxv:Other")
+    val schemaUpdated = SchemaGen.schema(myId, project.value.ref, sourceUpdated)
+
+    "evaluating an incoming command" should {
+      "create a new event from a CreateSchema command" in {
+        evaluate(
+          Initial,
+          CreateSchema(myId, project.value.ref, source, compacted, expanded, subject)
+        ).accepted shouldEqual
+          SchemaCreated(myId, project.value.ref, source, compacted, expanded, 1L, epoch, subject)
+      }
+
+      "create a new event from a UpdateSchema command" in {
+        val compacted = schemaUpdated.compacted
+        val expanded  = schemaUpdated.expanded
+
+        evaluate(
+          SchemaGen.currentState(schema),
+          UpdateSchema(myId, project.value.ref, sourceUpdated, compacted, expanded, 1L, subject)
+        ).accepted shouldEqual
+          SchemaUpdated(myId, project.value.ref, sourceUpdated, compacted, expanded, 2L, epoch, subject)
+      }
+
+      "create a new event from a TagSchema command" in {
+        evaluate(
+          SchemaGen.currentState(schema, rev = 2L),
+          TagSchema(myId, project.value.ref, 1L, Label.unsafe("myTag"), 2L, subject)
+        ).accepted shouldEqual
+          SchemaTagAdded(myId, project.value.ref, 1L, Label.unsafe("myTag"), 3L, epoch, subject)
+      }
+
+      "create a new event from a DeprecateSchema command" in {
+
+        val current = SchemaGen.currentState(schema, rev = 2L)
+
+        evaluate(current, DeprecateSchema(myId, project.value.ref, 2L, subject)).accepted shouldEqual
+          SchemaDeprecated(myId, project.value.ref, 3L, epoch, subject)
+      }
+
+      "reject with IncorrectRev" in {
+        val current = SchemaGen.currentState(schema)
+        val list    = List(
+          current -> UpdateSchema(myId, project.value.ref, source, compacted, expanded, 2L, subject),
+          current -> TagSchema(myId, project.value.ref, 1L, Label.unsafe("tag"), 2L, subject),
+          current -> DeprecateSchema(myId, project.value.ref, 2L, subject)
+        )
+        forAll(list) { case (state, cmd) =>
+          evaluate(state, cmd).rejected shouldEqual IncorrectRev(provided = 2L, expected = 1L)
+        }
+      }
+
+      "reject with InvalidSchema" in {
+        val current     = SchemaGen.currentState(schema)
+        val wrongSource = source.replace("minCount" -> 1, "wrong")
+        val wrongSchema = SchemaGen.schema(myId, project.value.ref, wrongSource)
+        val compacted   = wrongSchema.compacted
+        val expanded    = wrongSchema.expanded
+        val list        = List(
+          Initial -> CreateSchema(myId, project.value.ref, wrongSource, compacted, expanded, subject),
+          current -> UpdateSchema(myId, project.value.ref, wrongSource, compacted, expanded, 1L, subject)
+        )
+        forAll(list) { case (state, cmd) =>
+          evaluate(state, cmd).rejectedWith[InvalidSchema]
+        }
+      }
+
+      "reject with SchemaAlreadyExists" in {
+        val current = SchemaGen.currentState(schema)
+        evaluate(current, CreateSchema(myId, project.value.ref, source, compacted, expanded, subject))
+          .rejectedWith[SchemaAlreadyExists]
+      }
+
+      "reject with SchemaNotFound" in {
+        val list = List(
+          Initial -> UpdateSchema(myId, project.value.ref, source, compacted, expanded, 1L, subject),
+          Initial -> TagSchema(myId, project.value.ref, 1L, Label.unsafe("myTag"), 1L, subject),
+          Initial -> DeprecateSchema(myId, project.value.ref, 1L, subject)
+        )
+        forAll(list) { case (state, cmd) =>
+          evaluate(state, cmd).rejectedWith[SchemaNotFound]
+        }
+      }
+
+      "reject with SchemaIsDeprecated" in {
+        val current = SchemaGen.currentState(schema, deprecated = true)
+        val list    = List(
+          current -> UpdateSchema(myId, project.value.ref, source, compacted, expanded, 1L, subject),
+          current -> TagSchema(myId, project.value.ref, 1L, Label.unsafe("a"), 1L, subject),
+          current -> DeprecateSchema(myId, project.value.ref, 1L, subject)
+        )
+        forAll(list) { case (state, cmd) =>
+          evaluate(state, cmd).rejectedWith[SchemaIsDeprecated]
+        }
+      }
+
+      "reject with RevisionNotFound" in {
+        evaluate(
+          SchemaGen.currentState(schema),
+          TagSchema(myId, project.value.ref, 3L, Label.unsafe("myTag"), 1L, subject)
+        ).rejected shouldEqual RevisionNotFound(provided = 3L, current = 1L)
+      }
+
+    }
+
+    "producing next state" should {
+      val tags    = Map(Label.unsafe("a") -> 1L)
+      val current = SchemaGen.currentState(schema.copy(tags = tags))
+
+      "create a new SchemaCreated state" in {
+        next(
+          Initial,
+          SchemaCreated(myId, project.value.ref, source, compacted, expanded, 1L, epoch, subject)
+        ) shouldEqual
+          current.copy(createdAt = epoch, createdBy = subject, updatedAt = epoch, updatedBy = subject, tags = Map.empty)
+
+        next(
+          current,
+          SchemaCreated(myId, project.value.ref, source, compacted, expanded, 1L, time2, subject)
+        ) shouldEqual current
+      }
+
+      "create a new SchemaUpdated state" in {
+        next(
+          Initial,
+          SchemaUpdated(myId, project.value.ref, source, compacted, expanded, 1L, time2, subject)
+        ) shouldEqual Initial
+
+        next(
+          current,
+          SchemaUpdated(myId, project.value.ref, sourceUpdated, compacted, expanded, 2L, time2, subject)
+        ) shouldEqual
+          current.copy(rev = 2L, source = sourceUpdated, updatedAt = time2, updatedBy = subject)
+      }
+
+      "create new SchemaTagAdded state" in {
+        val tag = Label.unsafe("tag")
+        next(
+          Initial,
+          SchemaTagAdded(myId, project.value.ref, 1L, tag, 2L, time2, subject)
+        ) shouldEqual Initial
+
+        next(current, SchemaTagAdded(myId, project.value.ref, 1L, tag, 2L, time2, subject)) shouldEqual
+          current.copy(rev = 2L, updatedAt = time2, updatedBy = subject, tags = tags + (tag -> 1L))
+      }
+
+      "create new SchemaDeprecated state" in {
+        next(Initial, SchemaDeprecated(myId, project.value.ref, 1L, time2, subject)) shouldEqual Initial
+
+        next(current, SchemaDeprecated(myId, project.value.ref, 2L, time2, subject)) shouldEqual
+          current.copy(rev = 2L, deprecated = true, updatedAt = time2, updatedBy = subject)
+      }
+    }
+  }
+}

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
@@ -66,7 +66,6 @@ object ResourceGen extends OptionValues with IOValues {
   def resourceFor(
       resource: Resource,
       types: Set[Iri] = Set.empty,
-      tags: Map[Label, Long] = Map.empty,
       rev: Long = 1L,
       subject: Subject = Anonymous,
       deprecated: Boolean = false,
@@ -83,7 +82,7 @@ object ResourceGen extends OptionValues with IOValues {
       deprecated,
       resource.schema,
       types,
-      tags,
+      resource.tags,
       Instant.EPOCH,
       subject,
       Instant.EPOCH,

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/TestHelpers.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/TestHelpers.scala
@@ -1,5 +1,7 @@
 package ch.epfl.bluebrain.nexus.testkit
 
+import java.io.InputStream
+
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.{ClasspathResourceError, ClasspathResourceUtils}
 import io.circe.Json
 import monix.bio.{IO, UIO}
@@ -42,6 +44,15 @@ trait TestHelpers extends ClasspathResourceUtils {
     */
   final def ioFromMap[A, B, C](map: Map[A, B], ifAbsent: A => C): A => IO[C, B] =
     (a: A) => IO.fromOption(map.get(a), ifAbsent(a))
+
+  /**
+    * Loads the content of the argument classpath resource as an [[InputStream]].
+    *
+    * @param resourcePath the path of a resource available on the classpath
+    * @return the content of the referenced resource as an [[InputStream]]
+    */
+  final def streamOf(resourcePath: String)(implicit s: Scheduler = Scheduler.global): InputStream =
+    runAcceptOrThrow(ioStreamOf(resourcePath))
 
   /**
     * Loads the content of the argument classpath resource as a string and replaces all the key matches of


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/1492

Besides addressing the linked issue, it fixes the following:

- Fixed Schema validation, now uses SHACL of SHACL and validates properly.
- Remove unnecessary `IO[E,A]` in favour of `Either[E, A]` when not necessary in JsonLd API.
- Added Kryo serialization for `Graph` for message with the Actors (`SchemaState.Current` and `Schema` both contain a `Graph`).