### PR TITLE
Added rejection on not found resources fetch

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/PermissionsRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/PermissionsRoutes.scala
@@ -48,7 +48,8 @@ final class PermissionsRoutes(identities: Identities, permissions: Permissions, 
           (pathPrefix("permissions") & pathEndOrSingleSlash) {
             operationName(s"$prefixSegment/permissions") {
               concat(
-                get { // Fetch permissions
+                // Fetch permissions
+                get {
                   authorizeFor(AclAddress.Root, permissionsPerms.read).apply {
                     parameter("rev".as[Long].?) {
                       case Some(rev) => emit(permissions.fetchAt(rev).leftWiden[PermissionsRejection])
@@ -56,7 +57,8 @@ final class PermissionsRoutes(identities: Identities, permissions: Permissions, 
                     }
                   }
                 },
-                (put & parameter("rev" ? 0L)) { rev => // Replace permissions
+                // Replace permissions
+                (put & parameter("rev" ? 0L)) { rev =>
                   authorizeFor(AclAddress.Root, permissionsPerms.write).apply {
                     entity(as[PatchPermissions]) {
                       case Replace(set) => emit(permissions.replace(set, rev).map(_.void))
@@ -67,7 +69,8 @@ final class PermissionsRoutes(identities: Identities, permissions: Permissions, 
                     }
                   }
                 },
-                (patch & parameter("rev" ? 0L)) { rev => // Append or Subtract permissions
+                // Append or Subtract permissions
+                (patch & parameter("rev" ? 0L)) { rev =>
                   authorizeFor(AclAddress.Root, permissionsPerms.write).apply {
                     entity(as[PatchPermissions]) {
                       case Append(set)   => emit(permissions.append(set, rev).map(_.void))
@@ -81,7 +84,8 @@ final class PermissionsRoutes(identities: Identities, permissions: Permissions, 
                     }
                   }
                 },
-                delete { // Delete permissions
+                // Delete permissions
+                delete {
                   authorizeFor(AclAddress.Root, permissionsPerms.write).apply {
                     parameter("rev".as[Long]) { rev =>
                       emit(permissions.delete(rev).map(_.void))
@@ -91,6 +95,7 @@ final class PermissionsRoutes(identities: Identities, permissions: Permissions, 
               )
             }
           },
+          // SSE permissions
           (pathPrefix("permissions" / "events") & pathEndOrSingleSlash) {
             operationName(s"$prefixSegment/permissions/events") {
               authorizeFor(AclAddress.Root, events.read).apply {

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ProjectsRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ProjectsRoutes.scala
@@ -84,7 +84,7 @@ final class ProjectsRoutes(identities: Identities, acls: Acls, projects: Project
           case _                                              => Directive(_ => discardEntityAndEmit(ProjectNotFound(orgUuid, projectUuid): ProjectRejection))
         }
       case Left(ProjectNotFound(_)) => failWith(AuthorizationFailed)
-      case Left(r)                  => Directive(_ => discardEntityAndEmit(r))
+      case Left(r)                  => Directive(_ => discardEntityAndEmit(r: ProjectRejection))
     }
 
   def routes: Route =
@@ -135,7 +135,7 @@ final class ProjectsRoutes(identities: Identities, acls: Acls, projects: Project
                     authorizeFor(AclAddress.Project(ref), projectsPermissions.read).apply {
                       parameter("rev".as[Long].?) {
                         case Some(rev) => // Fetch project at specific revision
-                          emit(projects.fetchAt(ref, rev))
+                          emit(projects.fetchAt(ref, rev).leftWiden[ProjectRejection])
                         case None      => // Fetch project
                           emit(projects.fetch(ref).leftWiden[ProjectRejection])
                       }

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/RealmsRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/RealmsRoutes.scala
@@ -74,29 +74,31 @@ class RealmsRoutes(identities: Identities, realms: Realms, acls: Acls)(implicit
             (label & pathEndOrSingleSlash) { id =>
               operationName(s"$prefixSegment/realms/{label}") {
                 concat(
+                  // Create or update a realm
                   put {
                     authorizeFor(AclAddress.Root, realmsPermissions.write).apply {
                       parameter("rev".as[Long].?) {
                         case Some(rev) =>
-                          // Update realm
+                          // Update a realm
                           entity(as[RealmInput]) { case RealmInput(name, openIdConfig, logo) =>
                             emit(realms.update(id, rev, name, openIdConfig, logo).map(_.void))
                           }
                         case None      =>
-                          // Create realm
+                          // Create a realm
                           entity(as[RealmInput]) { case RealmInput(name, openIdConfig, logo) =>
                             emit(StatusCodes.Created, realms.create(id, name, openIdConfig, logo).map(_.void))
                           }
                       }
                     }
                   },
+                  // Fetch a realm
                   get {
                     authorizeFor(AclAddress.Root, realmsPermissions.read).apply {
                       parameter("rev".as[Long].?) {
                         case Some(rev) => // Fetch realm at specific revision
-                          emit(realms.fetchAt(id, rev).leftWiden[RealmRejection])
+                          emit(realms.fetchAt(id, rev))
                         case None      => // Fetch realm
-                          emit(realms.fetch(id))
+                          emit(realms.fetch(id).leftWiden[RealmRejection])
                       }
                     }
                   },

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/RealmsRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/RealmsRoutes.scala
@@ -96,7 +96,7 @@ class RealmsRoutes(identities: Identities, realms: Realms, acls: Acls)(implicit
                     authorizeFor(AclAddress.Root, realmsPermissions.read).apply {
                       parameter("rev".as[Long].?) {
                         case Some(rev) => // Fetch realm at specific revision
-                          emit(realms.fetchAt(id, rev))
+                          emit(realms.fetchAt(id, rev).leftWiden[RealmRejection])
                         case None      => // Fetch realm
                           emit(realms.fetch(id).leftWiden[RealmRejection])
                       }

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutes.scala
@@ -78,7 +78,7 @@ final class SchemasRoutes(
                     operationName(s"$prefixSegment/schemas/{org}/{project}/events") {
                       authorizeFor(AclAddress.Project(ref), events.read).apply {
                         lastEventId { offset =>
-                          emit(schemas.events(ref, offset).leftWiden[SchemaRejection])
+                          emit(schemas.events(ref, offset))
                         }
                       }
                     }
@@ -162,8 +162,8 @@ final class SchemasRoutes(
       }
     }
 
-  private def asSource(resourceOpt: Option[SchemaResource]): Option[JsonSource] =
-    resourceOpt.map(resource => JsonSource(resource.value.source, resource.value.id))
+  private def asSource(resource: SchemaResource): JsonSource =
+    JsonSource(resource.value.source, resource.value.id)
 
 }
 

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/marshalling/HttpResponseFields.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/marshalling/HttpResponseFields.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.routes.marshalling
 
 import akka.http.scaladsl.model.{HttpHeader, StatusCode, StatusCodes}
 import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.{AuthorizationFailed, NotFound}
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.TokenRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection
@@ -116,7 +116,7 @@ object HttpResponseFields {
     HttpResponseFields {
       case SchemaRejection.RevisionNotFound(_, _)            => StatusCodes.NotFound
       case SchemaRejection.TagNotFound(_)                    => StatusCodes.NotFound
-      case SchemaRejection.SchemaNotFound(_)                 => StatusCodes.NotFound
+      case SchemaRejection.SchemaNotFound(_, _)              => StatusCodes.NotFound
       case SchemaRejection.SchemaAlreadyExists(_)            => StatusCodes.Conflict
       case SchemaRejection.IncorrectRev(_, _)                => StatusCodes.Conflict
       case SchemaRejection.WrappedProjectRejection(rej)      => responseFieldsProjects.statusFrom(rej)
@@ -128,7 +128,7 @@ object HttpResponseFields {
   implicit val responseFieldsResources: HttpResponseFields[ResourceRejection] =
     HttpResponseFields {
       case ResourceRejection.RevisionNotFound(_, _)            => StatusCodes.NotFound
-      case ResourceRejection.ResourceNotFound(_, _)            => StatusCodes.NotFound
+      case ResourceRejection.ResourceNotFound(_, _, _)         => StatusCodes.NotFound
       case ResourceRejection.TagNotFound(_)                    => StatusCodes.NotFound
       case ResourceRejection.WrappedOrganizationRejection(rej) => responseFieldsOrganizations.statusFrom(rej)
       case ResourceRejection.WrappedProjectRejection(rej)      => responseFieldsProjects.statusFrom(rej)
@@ -140,9 +140,8 @@ object HttpResponseFields {
     }
 
   implicit val ServiceError: HttpResponseFields[ServiceError] =
-    HttpResponseFields {
-      case AuthorizationFailed => StatusCodes.Forbidden
-      case NotFound            => StatusCodes.NotFound
+    HttpResponseFields { case AuthorizationFailed =>
+      StatusCodes.Forbidden
     }
 }
 // $COVERAGE-ON$

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/marshalling/HttpResponseFields.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/marshalling/HttpResponseFields.scala
@@ -139,9 +139,10 @@ object HttpResponseFields {
       case _                                                   => StatusCodes.BadRequest
     }
 
-  implicit val ServiceError: HttpResponseFields[ServiceError] =
-    HttpResponseFields { case AuthorizationFailed =>
-      StatusCodes.Forbidden
-    }
+  implicit val responseFieldsServiceError: HttpResponseFields[ServiceError] =
+    HttpResponseFields { case AuthorizationFailed => StatusCodes.Forbidden }
+
+  implicit val responseFieldsUnit: HttpResponseFields[Unit]                 =
+    HttpResponseFields { _ => StatusCodes.OK }
 }
 // $COVERAGE-ON$

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/marshalling/RdfRejectionHandler.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/marshalling/RdfRejectionHandler.scala
@@ -58,6 +58,7 @@ object RdfRejectionHandler {
       .handle { case ExpectedWebSocketRequestRejection => discardEntityAndEmit(ExpectedWebSocketRequestRejection) }
       .handleAll[UnsupportedWebSocketSubprotocolRejection] { discardEntityAndEmit(_) }
       .handle { case r: ValidationRejection => discardEntityAndEmit(r) }
+      .handle { case ResourceNotFound => discardEntityAndEmit(StatusCodes.NotFound, ResourceNotFound) }
       .handleNotFound { discardEntityAndEmit(StatusCodes.NotFound, ResourceNotFound) }
       .result() withFallback RejectionHandler.default
 
@@ -342,7 +343,7 @@ object RdfRejectionHandler {
   /**
     * A resource endpoint cannot be found on the platform
     */
-  private case object ResourceNotFound {
+  final case object ResourceNotFound extends Rejection {
 
     type ResourceNotFound = ResourceNotFound.type
 

--- a/delta/app/src/test/resources/errors/default-not-found.json
+++ b/delta/app/src/test/resources/errors/default-not-found.json
@@ -1,5 +1,0 @@
-{
-  "@context" : "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type" : "ResourceNotFound",
-  "reason" : "The requested resource does not exist."
-}

--- a/delta/app/src/test/resources/errors/resource-not-found.json
+++ b/delta/app/src/test/resources/errors/resource-not-found.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "NotFound",
-  "reason": "The requested resource could not be found."
-}

--- a/delta/app/src/test/resources/projects/errors/project-not-found.json
+++ b/delta/app/src/test/resources/projects/errors/project-not-found.json
@@ -1,0 +1,5 @@
+{
+  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
+  "@type": "ProjectNotFound",
+  "reason": "Project '{{proj}}' not found."
+}

--- a/delta/app/src/test/resources/resources/errors/not-found.json
+++ b/delta/app/src/test/resources/resources/errors/not-found.json
@@ -1,5 +1,5 @@
 {
   "@context" : "https://bluebrain.github.io/nexus/contexts/error.json",
   "@type" : "ResourceNotFound",
-  "reason" : "Resource '{{id}}' not found."
+  "reason" : "Resource '{{id}}' not found in project '{{proj}}'."
 }

--- a/delta/app/src/test/resources/schemas/errors/not-found.json
+++ b/delta/app/src/test/resources/schemas/errors/not-found.json
@@ -1,5 +1,5 @@
 {
   "@context" : "https://bluebrain.github.io/nexus/contexts/error.json",
   "@type" : "SchemaNotFound",
-  "reason" : "Schema '{{id}}' not found."
+  "reason" : "Schema '{{id}}' not found in project '{{proj}}'."
 }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ProjectsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ProjectsRoutesSpec.scala
@@ -345,7 +345,7 @@ class ProjectsRoutesSpec
     "fetch an unknown project" in {
       Get(s"/v1/projects/org1/unknown") ~> routes ~> check {
         status shouldEqual StatusCodes.NotFound
-        response.asJson shouldEqual jsonContentOf("/errors/resource-not-found.json")
+        response.asJson shouldEqual jsonContentOf("/projects/errors/project-not-found.json", "proj" -> "org1/unknown")
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
@@ -160,7 +160,8 @@ class ResourcesRoutesSpec
       val payload = payloadUpdated.removeKeys(keywords.id)
       Put("/v1/resources/myorg/myproject/_/myid10?rev=1", payload.toEntity) ~> routes ~> check {
         status shouldEqual StatusCodes.NotFound
-        response.asJson shouldEqual jsonContentOf("/resources/errors/not-found.json", "id" -> (nxv + "myid10"))
+        response.asJson shouldEqual
+          jsonContentOf("/resources/errors/not-found.json", "id" -> (nxv + "myid10"), "proj" -> "myorg/myproject")
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutesSpec.scala
@@ -103,12 +103,6 @@ class SchemasRoutesSpec
       }
     }
 
-    "reject the creation of a schema using the underscore route" in {
-      Put("/v1/resources/myorg/myproject/_/myother", payload.toEntity) ~> routes ~> check {
-        response.asJson shouldEqual jsonContentOf("/errors/default-not-found.json")
-      }
-    }
-
     "reject the creation of a schema which already exists" in {
       Put("/v1/schemas/myorg/myproject/myid", payload.toEntity) ~> routes ~> check {
         status shouldEqual StatusCodes.Conflict
@@ -142,7 +136,8 @@ class SchemasRoutesSpec
       val payload = payloadUpdated.removeKeys(keywords.id)
       Put("/v1/schemas/myorg/myproject/myid10?rev=1", payload.toEntity) ~> routes ~> check {
         status shouldEqual StatusCodes.NotFound
-        response.asJson shouldEqual jsonContentOf("/schemas/errors/not-found.json", "id" -> (nxv + "myid10"))
+        response.asJson shouldEqual
+          jsonContentOf("/schemas/errors/not-found.json", "id" -> (nxv + "myid10"), "proj" -> "myorg/myproject")
       }
     }
 

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLd.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
@@ -76,5 +76,12 @@ final case class CompactedJsonLd private[jsonld] (
     }
     copy(obj = newObj)
   }
+}
 
+object CompactedJsonLd {
+
+  /**
+    * An empty [[CompactedJsonLd]] with a random blank node
+    */
+  val empty: CompactedJsonLd = CompactedJsonLd(JsonObject.empty, ContextValue.empty, BNode.random)
 }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.xsd
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd._
@@ -122,6 +122,12 @@ final case class ExpandedJsonLd private[jsonld] (obj: JsonObject, rootId: IriOrB
 }
 
 object ExpandedJsonLd {
+
+  /**
+    * An empty [[ExpandedJsonLd]] with a random blank node
+    */
+  val empty: ExpandedJsonLd = ExpandedJsonLd(JsonObject.empty, BNode.random)
+
   final private[jsonld] case class Value[A](`@value`: A)
   final private[jsonld] case class Id(`@id`: Iri)
   implicit private[jsonld] def decodeJsonLdExpandedValue[A: Decoder]: Decoder[Value[A]] = deriveDecoder[Value[A]]

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLdEncoder.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLdEncoder.scala
@@ -167,4 +167,9 @@ object JsonLdEncoder {
         A.context(a).merge(B.context(b))
       }
     }
+
+  implicit val jsonLdEncoderUnit: JsonLdEncoder[Unit] = new JsonLdEncoder[Unit] {
+    override def compact(value: Unit): IO[RdfError, CompactedJsonLd] = IO.pure(CompactedJsonLd.empty)
+    override def context(value: Unit): ContextValue                  = ContextValue.empty
+  }
 }

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/AclsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/AclsDummy.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.Acls.moduleType
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Envelope
 import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclCommand._
-import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclRejection.{RevisionNotFound, UnexpectedInitialState}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclRejection.{AclNotFound, RevisionNotFound, UnexpectedInitialState}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclState.Initial
 import ch.epfl.bluebrain.nexus.delta.sdk.model.acls._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
@@ -35,22 +35,16 @@ final class AclsDummy private (
 
   private val minimum: Set[Permission] = permissions.minimum
 
-  override def fetch(address: AclAddress): UIO[Option[AclResource]] =
-    cache.get.map(_.value.get(address).orElse(Initial.toResource(address, minimum)))
+  override def fetch(address: AclAddress): IO[AclNotFound, AclResource] =
+    cache.get
+      .map(_.value.get(address).orElse(Initial.toResource(address, minimum)))
+      .flatMap(IO.fromOption(_, AclNotFound(address)))
 
-  override def fetchWithAncestors(address: AclAddress): UIO[AclCollection] =
-    fetch(address).flatMap { resourceOpt =>
-      val collection = toCollection(resourceOpt)
-      address.parent match {
-        case Some(parent) => fetchWithAncestors(parent).map(collection ++ _)
-        case None         => UIO.pure(collection)
-      }
-    }
-
-  override def fetchAt(address: AclAddress, rev: Long): IO[RevisionNotFound, Option[AclResource]] =
+  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection, AclResource] =
     journal
       .stateAt(address, rev, Initial, Acls.next, RevisionNotFound.apply)
       .map(stateOpt => stateOpt.getOrElse(Initial).toResource(address, minimum))
+      .flatMap(IO.fromOption(_, AclNotFound(address)))
 
   override def list(filter: AclAddressFilter): UIO[AclCollection] =
     cache.get.map(_.fetch(filter)).map { col =>
@@ -96,9 +90,6 @@ final class AclsDummy private (
         res        <- IO.fromOption(resourceOpt, UnexpectedInitialState(cmd.address))
       } yield res
     }
-
-  private def toCollection(resourceOpt: Option[AclResource]): AclCollection =
-    resourceOpt.fold(AclCollection.empty)(AclCollection(_))
 }
 
 object AclsDummy {

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/AclsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/AclsDummy.scala
@@ -40,7 +40,7 @@ final class AclsDummy private (
       .map(_.value.get(address).orElse(Initial.toResource(address, minimum)))
       .flatMap(IO.fromOption(_, AclNotFound(address)))
 
-  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection, AclResource] =
+  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection.NotFound, AclResource] =
     journal
       .stateAt(address, rev, Initial, Acls.next, RevisionNotFound.apply)
       .map(stateOpt => stateOpt.getOrElse(Initial).toResource(address, minimum))

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsDummy.scala
@@ -60,7 +60,7 @@ final class OrganizationsDummy private (
   override def fetch(label: Label): IO[OrganizationNotFound, OrganizationResource] =
     cache.fetchOr(label, OrganizationNotFound(label))
 
-  override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection, OrganizationResource] =
+  override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection.NotFound, OrganizationResource] =
     journal
       .stateAt(label, rev, Initial, Organizations.next, OrganizationRejection.RevisionNotFound.apply)
       .map(_.flatMap(_.toResource))

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsDummy.scala
@@ -9,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.Organizations.moduleType
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationCommand.{CreateOrganization, DeprecateOrganization, UpdateOrganization}
-import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection.{OwnerPermissionsFailed, UnexpectedInitialState}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection.{OrganizationNotFound, OwnerPermissionsFailed, UnexpectedInitialState}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationState.Initial
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.{OrganizationCommand, OrganizationRejection, _}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchParams.OrganizationSearchParams
@@ -37,10 +37,9 @@ final class OrganizationsDummy private (
 )(implicit clock: Clock[UIO], uuidF: UUIDF)
     extends Organizations {
 
-  override def create(
-      label: Label,
-      description: Option[String]
-  )(implicit caller: Subject): IO[OrganizationRejection, OrganizationResource] =
+  override def create(label: Label, description: Option[String])(implicit
+      caller: Subject
+  ): IO[OrganizationRejection, OrganizationResource] =
     eval(CreateOrganization(label, description, caller)) <* applyOwnerPermissions
       .onOrganization(label, caller)
       .leftMap(OwnerPermissionsFailed(label, _))
@@ -58,28 +57,17 @@ final class OrganizationsDummy private (
   )(implicit caller: Subject): IO[OrganizationRejection, OrganizationResource] =
     eval(DeprecateOrganization(label, rev, caller))
 
-  override def fetch(label: Label): UIO[Option[OrganizationResource]] =
-    cache.fetch(label)
+  override def fetch(label: Label): IO[OrganizationNotFound, OrganizationResource] =
+    cache.fetch(label).flatMap(IO.fromOption(_, OrganizationNotFound(label)))
 
-  override def fetchAt(
-      label: Label,
-      rev: Long
-  ): IO[OrganizationRejection.RevisionNotFound, Option[OrganizationResource]] =
+  override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection, OrganizationResource] =
     journal
       .stateAt(label, rev, Initial, Organizations.next, OrganizationRejection.RevisionNotFound.apply)
       .map(_.flatMap(_.toResource))
+      .flatMap(IO.fromOption(_, OrganizationNotFound(label)))
 
-  override def fetch(uuid: UUID): UIO[Option[OrganizationResource]] =
-    cache.fetchBy(o => o.uuid == uuid)
-
-  override def fetchAt(
-      uuid: UUID,
-      rev: Long
-  ): IO[OrganizationRejection.RevisionNotFound, Option[OrganizationResource]] =
-    fetch(uuid).flatMap {
-      case Some(orgResource) => fetchAt(orgResource.value.label, rev)
-      case None              => IO.pure(None)
-    }
+  override def fetch(uuid: UUID): IO[OrganizationNotFound, OrganizationResource] =
+    cache.fetchBy(o => o.uuid == uuid).flatMap(IO.fromOption(_, OrganizationNotFound(uuid)))
 
   override def list(
       pagination: Pagination.FromPagination,

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsDummy.scala
@@ -58,7 +58,7 @@ final class OrganizationsDummy private (
     eval(DeprecateOrganization(label, rev, caller))
 
   override def fetch(label: Label): IO[OrganizationNotFound, OrganizationResource] =
-    cache.fetch(label).flatMap(IO.fromOption(_, OrganizationNotFound(label)))
+    cache.fetchOr(label, OrganizationNotFound(label))
 
   override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection, OrganizationResource] =
     journal
@@ -67,7 +67,7 @@ final class OrganizationsDummy private (
       .flatMap(IO.fromOption(_, OrganizationNotFound(label)))
 
   override def fetch(uuid: UUID): IO[OrganizationNotFound, OrganizationResource] =
-    cache.fetchBy(o => o.uuid == uuid).flatMap(IO.fromOption(_, OrganizationNotFound(uuid)))
+    cache.fetchByOr(o => o.uuid == uuid, OrganizationNotFound(uuid))
 
   override def list(
       pagination: Pagination.FromPagination,

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsDummy.scala
@@ -70,7 +70,7 @@ final class ProjectsDummy private (
     eval(DeprecateProject(ref, rev, caller))
 
   override def fetch(ref: ProjectRef): IO[ProjectNotFound, ProjectResource] =
-    cache.fetch(ref).flatMap(IO.fromOption(_, ProjectNotFound(ref)))
+    cache.fetchOr(ref, ProjectNotFound(ref))
 
   override def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection, ProjectResource] =
     journal
@@ -90,13 +90,10 @@ final class ProjectsDummy private (
   override def fetchProject[R](
       ref: ProjectRef
   )(implicit rejectionMapper: Mapper[ProjectRejection, R]): IO[R, Project] =
-    cache
-      .fetch(ref)
-      .flatMap(IO.fromOption(_, ProjectNotFound(ref)))
-      .bimap(rejectionMapper.to, _.value)
+    cache.fetchOr(ref, ProjectNotFound(ref)).bimap(rejectionMapper.to, _.value)
 
   override def fetch(uuid: UUID): IO[ProjectNotFound, ProjectResource] =
-    cache.fetchBy(p => p.uuid == uuid).flatMap(IO.fromOption(_, ProjectNotFound(uuid)))
+    cache.fetchByOr(p => p.uuid == uuid, ProjectNotFound(uuid))
 
   override def list(
       pagination: Pagination.FromPagination,

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsDummy.scala
@@ -72,7 +72,7 @@ final class ProjectsDummy private (
   override def fetch(ref: ProjectRef): IO[ProjectNotFound, ProjectResource] =
     cache.fetchOr(ref, ProjectNotFound(ref))
 
-  override def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection, ProjectResource] =
+  override def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection.NotFound, ProjectResource] =
     journal
       .stateAt(ref, rev, Initial, Projects.next, ProjectRejection.RevisionNotFound.apply)
       .map(_.flatMap(_.toResource))

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/RealmsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/RealmsDummy.scala
@@ -56,7 +56,7 @@ final class RealmsDummy private (
   override def fetch(label: Label): IO[RealmNotFound, RealmResource] =
     cache.fetchOr(label, RealmNotFound(label))
 
-  override def fetchAt(label: Label, rev: Long): IO[RealmRejection, RealmResource] =
+  override def fetchAt(label: Label, rev: Long): IO[RealmRejection.NotFound, RealmResource] =
     journal
       .stateAt(label, rev, Initial, Realms.next, RealmRejection.RevisionNotFound.apply)
       .map(_.flatMap(_.toResource))

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/RealmsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/RealmsDummy.scala
@@ -54,7 +54,7 @@ final class RealmsDummy private (
     eval(DeprecateRealm(label, rev, caller))
 
   override def fetch(label: Label): IO[RealmNotFound, RealmResource] =
-    cache.fetch(label).flatMap(IO.fromOption(_, RealmNotFound(label)))
+    cache.fetchOr(label, RealmNotFound(label))
 
   override def fetchAt(label: Label, rev: Long): IO[RealmRejection, RealmResource] =
     journal

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasDummy.scala
@@ -14,7 +14,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{Project, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaCommand._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaRejection._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaState.Initial
-import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.{SchemaCommand, SchemaEvent, SchemaRejection}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.{SchemaCommand, SchemaEvent, SchemaRejection, SchemaState}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{Envelope, IdSegment, Label}
 import ch.epfl.bluebrain.nexus.delta.sdk.testkit.SchemasDummy.SchemaJournal
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.UUIDF
@@ -98,19 +98,19 @@ final class SchemasDummy private (
       res     <- eval(DeprecateSchema(iri, projectRef, rev, caller), project)
     } yield res
 
-  override def fetch(id: IdSegment, projectRef: ProjectRef): IO[SchemaRejection, Option[SchemaResource]] =
-    for {
-      project <- projects.fetchProject(projectRef)
-      iri     <- expandIri(id, project)
-      state   <- currentState(projectRef, iri)
-    } yield state.toResource(project.apiMappings, project.base)
+  override def fetch(id: IdSegment, projectRef: ProjectRef): IO[SchemaRejection, SchemaResource] =
+    fetch(id, projectRef, None)
 
-  override def fetchAt(id: IdSegment, projectRef: ProjectRef, rev: Long): IO[SchemaRejection, Option[SchemaResource]] =
+  override def fetchAt(id: IdSegment, projectRef: ProjectRef, rev: Long): IO[SchemaRejection, SchemaResource] =
+    fetch(id, projectRef, Some(rev))
+
+  private def fetch(id: IdSegment, projectRef: ProjectRef, rev: Option[Long]) =
     for {
       project <- projects.fetchProject(projectRef)
       iri     <- expandIri(id, project)
-      state   <- stateAt(projectRef, iri, rev)
-    } yield state.toResource(project.apiMappings, project.base)
+      state   <- rev.fold(currentState(projectRef, iri))(stateAt(projectRef, iri, _))
+      res     <- IO.fromOption(state.toResource(project.apiMappings, project.base), SchemaNotFound(iri, projectRef))
+    } yield res
 
   override def events(
       projectRef: ProjectRef,
@@ -131,10 +131,10 @@ final class SchemasDummy private (
   override def events(offset: Offset): Stream[Task, Envelope[SchemaEvent]] =
     journal.events(offset)
 
-  private def currentState(projectRef: ProjectRef, iri: Iri) =
+  private def currentState(projectRef: ProjectRef, iri: Iri): IO[SchemaRejection, SchemaState] =
     journal.currentState((projectRef, iri), Initial, Schemas.next).map(_.getOrElse(Initial))
 
-  private def stateAt(projectRef: ProjectRef, iri: Iri, rev: Long) =
+  private def stateAt(projectRef: ProjectRef, iri: Iri, rev: Long): IO[RevisionNotFound, SchemaState] =
     journal.stateAt((projectRef, iri), rev, Initial, Schemas.next, RevisionNotFound.apply).map(_.getOrElse(Initial))
 
   private def eval(cmd: SchemaCommand, project: Project): IO[SchemaRejection, SchemaResource] =

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/AclsBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/AclsBehaviors.scala
@@ -117,11 +117,11 @@ trait AclsBehaviors {
 
     "fetch an ACL" in {
       acls.replace(userR_groupX(orgTarget), 0L).accepted
-      acls.fetch(orgTarget).accepted.value shouldEqual resourceFor(userR_groupX(orgTarget), 1L, subject)
+      acls.fetch(orgTarget).accepted shouldEqual resourceFor(userR_groupX(orgTarget), 1L, subject)
     }
 
     "fetch an ACL containing only caller identities" in {
-      acls.fetchSelf(orgTarget).accepted.value shouldEqual resourceFor(userR(orgTarget), 1L, subject)
+      acls.fetchSelf(orgTarget).accepted shouldEqual resourceFor(userR(orgTarget), 1L, subject)
     }
 
     "fetch an ACL data" in {
@@ -132,22 +132,22 @@ trait AclsBehaviors {
 
     "fetch an ACL at specific revision" in {
       acls.append(userW(orgTarget), 1L).accepted
-      acls.fetchAt(orgTarget, 2L).accepted.value shouldEqual resourceFor(userRW_groupX(orgTarget), 2L, subject)
-      acls.fetchAt(orgTarget, 1L).accepted.value shouldEqual resourceFor(userR_groupX(orgTarget), 1L, subject)
+      acls.fetchAt(orgTarget, 2L).accepted shouldEqual resourceFor(userRW_groupX(orgTarget), 2L, subject)
+      acls.fetchAt(orgTarget, 1L).accepted shouldEqual resourceFor(userR_groupX(orgTarget), 1L, subject)
     }
 
     "fetch an ACL at specific revision containing only caller identities" in {
-      acls.fetchSelfAt(orgTarget, 1L).accepted.value shouldEqual resourceFor(userR(orgTarget), 1L, subject)
+      acls.fetchSelfAt(orgTarget, 1L).accepted shouldEqual resourceFor(userR(orgTarget), 1L, subject)
     }
 
-    "fetch a non existing acl" in {
+    "fail fetching a non existing acl" in {
       val targetNotExist = Organization(Label.unsafe("other"))
-      acls.fetch(targetNotExist).accepted shouldEqual None
+      acls.fetch(targetNotExist).rejectedWith[AclNotFound]
     }
 
-    "fetch a non existing acl at specific revision" in {
+    "fail fetching a non existing acl at specific revision" in {
       val targetNotExist = Organization(Label.unsafe("other"))
-      acls.fetchAt(targetNotExist, 1L).accepted shouldEqual None
+      acls.fetchAt(targetNotExist, 1L).rejectedWith[AclNotFound]
     }
 
     "list ACLs" in {
@@ -330,7 +330,7 @@ trait AclsBehaviors {
     "subtract an ACL correctly" in {
       acls.replace(userRW(AclAddress.Root), 5L).accepted
       acls.subtract(userW(AclAddress.Root), 6L).accepted
-      acls.fetch(AclAddress.Root).accepted shouldEqual Some(resourceFor(userR(AclAddress.Root), 7L, subject))
+      acls.fetch(AclAddress.Root).accepted shouldEqual resourceFor(userR(AclAddress.Root), 7L, subject)
     }
   }
 

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/OrganizationsBehaviors.scala
@@ -74,9 +74,7 @@ trait OrganizationsBehaviors {
       orgs.create(label, description).accepted shouldEqual
         resourceFor(organization("myorg", uuid, description), 1L, subject)
 
-      acls.fetch(AclAddress.Organization(label)).accepted.map(_.value.value) shouldEqual Some(
-        Map(subject -> myOrgPermissions)
-      )
+      acls.fetch(AclAddress.Organization(label)).accepted.value.value shouldEqual Map(subject -> myOrgPermissions)
     }
 
     "update an organization" in {
@@ -90,50 +88,49 @@ trait OrganizationsBehaviors {
     }
 
     "fetch an organization" in {
-      orgs.fetch(label).accepted.value shouldEqual
+      orgs.fetch(label).accepted shouldEqual
         resourceFor(organization("myorg", uuid, description2), 3L, subject, deprecated = true)
     }
 
     "fetch an organization by uuid" in {
-      orgs.fetch(uuid).accepted.value shouldEqual orgs.fetch(label).accepted.value
+      orgs.fetch(uuid).accepted shouldEqual orgs.fetch(label).accepted
     }
 
     "fetch an organization at specific revision" in {
-      orgs.fetchAt(label, 1L).accepted.value shouldEqual
+      orgs.fetchAt(label, 1L).accepted shouldEqual
         resourceFor(organization("myorg", uuid, description), 1L, subject)
     }
 
     "fetch an organization at specific revision by uuid" in {
-      orgs.fetchAt(uuid, 1L).accepted.value shouldEqual orgs.fetchAt(label, 1L).accepted.value
+      orgs.fetchAt(uuid, 1L).accepted shouldEqual orgs.fetchAt(label, 1L).accepted
     }
 
-    "fetch a non existing organization" in {
-      orgs.fetch(Label.unsafe("non-existing")).accepted shouldEqual None
+    "fail fetching a non existing organization" in {
+      orgs.fetch(Label.unsafe("non-existing")).rejectedWith[OrganizationNotFound]
     }
 
-    "fetch a non existing organization by uuid" in {
-      orgs.fetch(UUID.randomUUID()).accepted shouldEqual None
+    "fail fetching a non existing organization by uuid" in {
+      orgs.fetch(UUID.randomUUID()).rejectedWith[OrganizationNotFound]
     }
 
-    "fetch a non existing organization at specific revision" in {
-      orgs.fetchAt(Label.unsafe("non-existing"), 1L).accepted shouldEqual None
+    "fail fetching a non existing organization at specific revision" in {
+      orgs.fetchAt(Label.unsafe("non-existing"), 1L).rejectedWith[OrganizationNotFound]
     }
 
-    "fetch a non existing organization at specific revision by uuid" in {
-      orgs.fetchAt(UUID.randomUUID(), 1L).accepted shouldEqual None
+    "fail fetching a non existing organization at specific revision by uuid" in {
+      orgs.fetchAt(UUID.randomUUID(), 1L).rejectedWith[OrganizationNotFound]
     }
 
     "create another organization" in {
       orgs.create(label2, None).accepted
 
-      acls.fetch(AclAddress.Organization(label2)).accepted.map(_.value.value) shouldEqual Some(
+      acls.fetch(AclAddress.Organization(label2)).accepted.value.value shouldEqual
         Map(subject -> (PermissionsGen.ownerPermissions ++ myOrg2Permissions))
-      )
     }
 
     "list organizations" in {
-      val result1 = orgs.fetch(label).accepted.value
-      val result2 = orgs.fetch(label2).accepted.value
+      val result1 = orgs.fetch(label).accepted
+      val result2 = orgs.fetch(label2).accepted
       val filter  = OrganizationSearchParams(deprecated = Some(true), rev = Some(3), filter = _ => true)
 
       orgs.list(FromPagination(0, 1), OrganizationSearchParams(filter = _ => true)).accepted shouldEqual

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/RealmsBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/RealmsBehaviors.scala
@@ -92,7 +92,7 @@ trait RealmsBehaviors {
     }
 
     "fetch a realm" in {
-      realms.fetch(github).accepted.value shouldEqual
+      realms.fetch(github).accepted shouldEqual
         resourceFor(
           realm(
             githubOpenId,
@@ -106,7 +106,7 @@ trait RealmsBehaviors {
     }
 
     "fetch a realm at specific revision" in {
-      realms.fetchAt(github, 1L).accepted.value shouldEqual
+      realms.fetchAt(github, 1L).accepted shouldEqual
         resourceFor(
           realm(
             githubOpenId,
@@ -118,12 +118,12 @@ trait RealmsBehaviors {
         )
     }
 
-    "fetch a non existing realm" in {
-      realms.fetch(Label.unsafe("non-existing")).accepted shouldEqual None
+    "fail fetching a non existing realm" in {
+      realms.fetch(Label.unsafe("non-existing")).rejectedWith[RealmNotFound]
     }
 
-    "fetch a non existing realm at specific revision" in {
-      realms.fetchAt(Label.unsafe("non-existing"), 1L).accepted shouldEqual None
+    "fail fetching a non existing realm at specific revision" in {
+      realms.fetchAt(Label.unsafe("non-existing"), 1L).rejectedWith[RealmNotFound]
     }
 
     "list realms" in {

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResolversBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResolversBehaviors.scala
@@ -618,16 +618,14 @@ trait ResolversBehaviors {
 
       "succeed" in {
         forAll(List(inProjectExpected, crossProjectExpected)) { resource =>
-          resolvers.fetch(StringSegment(resource.value.id.toString), projectRef).accepted.value shouldEqual resource
+          resolvers.fetch(StringSegment(resource.value.id.toString), projectRef).accepted shouldEqual resource
         }
       }
 
       "succeed by rev" in {
         forAll(List(inProjectExpected, crossProjectExpected)) { resource =>
-          resolvers.fetchAt(IriSegment(resource.value.id), projectRef, 3L).accepted.value shouldEqual resource.copy(
-            rev = 3L,
-            deprecated = false
-          )
+          resolvers.fetchAt(IriSegment(resource.value.id), projectRef, 3L).accepted shouldEqual
+            resource.copy(rev = 3L, deprecated = false)
         }
       }
 
@@ -638,31 +636,28 @@ trait ResolversBehaviors {
             nxv + "cross-project" -> crossProjectValue
           )
         ) { case (id, value) =>
-          resolvers.fetchBy(IriSegment(id), projectRef, tag).accepted.value shouldEqual ResolverGen.resourceFor(
-            id,
-            project,
-            value,
-            subject = bob.subject
-          )
+          resolvers.fetchBy(IriSegment(id), projectRef, tag).accepted shouldEqual
+            ResolverGen.resourceFor(id, project, value, subject = bob.subject)
         }
       }
 
-      "return none if resolver does not exist" in {
-        resolvers.fetch(StringSegment("xxx"), projectRef).accepted shouldEqual None
+      "fail fetching if resolver does not exist" in {
+        resolvers.fetch(StringSegment("xxx"), projectRef).rejectedWith[ResolverNotFound]
+      }
+
+      "fail fetching if resolver does not exist at specific rev" in {
+        resolvers.fetchAt(StringSegment("xxx"), projectRef, 1L).rejectedWith[ResolverNotFound]
       }
 
       "fail if revision does not exist" in {
-        resolvers.fetchAt(IriSegment(nxv + "in-project"), projectRef, 30L).rejected shouldEqual RevisionNotFound(
-          30L,
-          4L
-        )
+        resolvers.fetchAt(IriSegment(nxv + "in-project"), projectRef, 30L).rejected shouldEqual
+          RevisionNotFound(30L, 4L)
       }
 
       "fail if tag does not exist" in {
         val unknownTag = Label.unsafe("xxx")
-        resolvers.fetchBy(IriSegment(nxv + "in-project"), projectRef, unknownTag).rejected shouldEqual TagNotFound(
-          unknownTag
-        )
+        resolvers.fetchBy(IriSegment(nxv + "in-project"), projectRef, unknownTag).rejected shouldEqual
+          TagNotFound(unknownTag)
       }
     }
 

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesBehaviors.scala
@@ -202,7 +202,7 @@ trait ResourcesBehaviors {
         val schemaSegment = StringSegment("nxv:notExist")
         val noIdSource    = source.removeKeys(keywords.id)
         resources.create(IriSegment(otherId), projectRef, schemaSegment, noIdSource).rejected shouldEqual
-          WrappedSchemaRejection(SchemaNotFound(nxv + "notExist"))
+          WrappedSchemaRejection(SchemaNotFound(nxv + "notExist", projectRef))
       }
 
       "reject if project does not exist" in {
@@ -406,7 +406,7 @@ trait ResourcesBehaviors {
 
       "succeed" in {
         forAll(List(None, Some(IriSegment(schemas.resources)))) { schema =>
-          resources.fetch(IriSegment(myId), projectRef, schema).accepted.value shouldEqual
+          resources.fetch(IriSegment(myId), projectRef, schema).accepted shouldEqual
             ResourceGen.resourceFor(
               expectedDataLatest,
               types = types,
@@ -420,14 +420,14 @@ trait ResourcesBehaviors {
 
       "succeed by tag" in {
         forAll(List(None, Some(IriSegment(schemas.resources)))) { schema =>
-          resources.fetchBy(StringSegment("nxv:myid"), projectRef, schema, tag).accepted.value shouldEqual
+          resources.fetchBy(StringSegment("nxv:myid"), projectRef, schema, tag).accepted shouldEqual
             ResourceGen.resourceFor(expectedData, types = types, subject = subject, rev = 1L, am = am, base = projBase)
         }
       }
 
       "succeed by rev" in {
         forAll(List(None, Some(IriSegment(schemas.resources)))) { schema =>
-          resources.fetchAt(IriSegment(myId), projectRef, schema, 1L).accepted.value shouldEqual
+          resources.fetchAt(IriSegment(myId), projectRef, schema, 1L).accepted shouldEqual
             ResourceGen.resourceFor(expectedData, types = types, subject = subject, rev = 1L, am = am, base = projBase)
         }
       }
@@ -446,18 +446,18 @@ trait ResourcesBehaviors {
         }
       }
 
-      "return none if resource does not exist" in {
+      "fail fetching if resource does not exist" in {
         val myId = nxv + "notFound"
-        resources.fetch(IriSegment(myId), projectRef, None).accepted shouldEqual None
-        resources.fetchBy(IriSegment(myId), projectRef, None, tag).accepted shouldEqual None
-        resources.fetchAt(IriSegment(myId), projectRef, None, 2L).accepted shouldEqual None
+        resources.fetch(IriSegment(myId), projectRef, None).rejectedWith[ResourceNotFound]
+        resources.fetchBy(IriSegment(myId), projectRef, None, tag).rejectedWith[ResourceNotFound]
+        resources.fetchAt(IriSegment(myId), projectRef, None, 2L).rejectedWith[ResourceNotFound]
       }
 
-      "return none if schema is not resource schema" in {
+      "fail fetching if schema is not resource schema" in {
         val schemaSegment = IriSegment(schema1.id)
-        resources.fetch(IriSegment(myId), projectRef, Some(schemaSegment)).accepted shouldEqual None
-        resources.fetchBy(IriSegment(myId), projectRef, Some(schemaSegment), tag).accepted shouldEqual None
-        resources.fetchAt(IriSegment(myId), projectRef, Some(schemaSegment), 2L).accepted shouldEqual None
+        resources.fetch(IriSegment(myId), projectRef, Some(schemaSegment)).rejectedWith[ResourceNotFound]
+        resources.fetchBy(IriSegment(myId), projectRef, Some(schemaSegment), tag).rejectedWith[ResourceNotFound]
+        resources.fetchAt(IriSegment(myId), projectRef, Some(schemaSegment), 2L).rejectedWith[ResourceNotFound]
       }
 
       "reject if project does not exist" in {
@@ -467,8 +467,8 @@ trait ResourcesBehaviors {
           WrappedProjectRejection(ProjectNotFound(projectRef))
       }
 
-      "return none if resource does not exist on deprecated project" in {
-        resources.fetch(IriSegment(myId), projectDeprecated.ref, None).accepted shouldEqual None
+      "fail fetching if resource does not exist on deprecated project" in {
+        resources.fetch(IriSegment(myId), projectDeprecated.ref, None).rejectedWith[ResourceNotFound]
       }
     }
 

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasBehaviors.scala
@@ -271,17 +271,17 @@ trait SchemasBehaviors {
       val schema2 = SchemaGen.schema(mySchema2, project.ref, source deepMerge json"""{"@id": "$mySchema2"}""")
 
       "succeed" in {
-        schemas.fetch(IriSegment(mySchema), projectRef).accepted.value shouldEqual
+        schemas.fetch(IriSegment(mySchema), projectRef).accepted shouldEqual
           SchemaGen.resourceFor(schemaUpdated, rev = 3L, deprecated = true, subject = subject, am = am, base = projBase)
       }
 
       "succeed by tag" in {
-        schemas.fetchBy(IriSegment(mySchema2), projectRef, tag).accepted.value shouldEqual
+        schemas.fetchBy(IriSegment(mySchema2), projectRef, tag).accepted shouldEqual
           SchemaGen.resourceFor(schema2, subject = subject, am = am, base = projBase)
       }
 
       "succeed by rev" in {
-        schemas.fetchAt(IriSegment(mySchema2), projectRef, 1L).accepted.value shouldEqual
+        schemas.fetchAt(IriSegment(mySchema2), projectRef, 1L).accepted shouldEqual
           SchemaGen.resourceFor(schema2, subject = subject, am = am, base = projBase)
       }
 
@@ -295,11 +295,11 @@ trait SchemasBehaviors {
           RevisionNotFound(provided = 5L, current = 3L)
       }
 
-      "return none if schema does not exist" in {
+      "fail fetching if schema does not exist" in {
         val mySchema = nxv + "notFound"
-        schemas.fetch(IriSegment(mySchema), projectRef).accepted shouldEqual None
-        schemas.fetchBy(IriSegment(mySchema), projectRef, tag).accepted shouldEqual None
-        schemas.fetchAt(IriSegment(mySchema), projectRef, 2L).accepted shouldEqual None
+        schemas.fetch(IriSegment(mySchema), projectRef).rejectedWith[SchemaNotFound]
+        schemas.fetchBy(IriSegment(mySchema), projectRef, tag).rejectedWith[SchemaNotFound]
+        schemas.fetchAt(IriSegment(mySchema), projectRef, 2L).rejectedWith[SchemaNotFound]
       }
 
       "reject if project does not exist" in {

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Acls.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Acls.scala
@@ -53,7 +53,7 @@ trait Acls {
     * @param address the ACL address
     * @param rev    the revision to fetch
     */
-  def fetchAt(address: AclAddress, rev: Long): IO[AclRejection, AclResource]
+  def fetchAt(address: AclAddress, rev: Long): IO[AclRejection.NotFound, AclResource]
 
   /**
     * Fetches the ACL resource with the passed address ''address'' and its ancestors on the passed revision.
@@ -61,7 +61,7 @@ trait Acls {
     * @param address the ACL address
     * @param rev    the revision to fetch
     */
-  def fetchAtWithAncestors(address: AclAddress, rev: Long): IO[AclRejection, AclCollection] = {
+  def fetchAtWithAncestors(address: AclAddress, rev: Long): IO[AclRejection.NotFound, AclCollection] = {
 
     def recurseOnParentAddress(current: AclCollection) =
       address.parent match {
@@ -103,7 +103,7 @@ trait Acls {
     */
   final def fetchSelfAt(address: AclAddress, rev: Long)(implicit
       caller: Caller
-  ): IO[AclRejection, AclResource] =
+  ): IO[AclRejection.NotFound, AclResource] =
     fetchAt(address, rev).map(filterSelf)
 
   /**
@@ -115,7 +115,7 @@ trait Acls {
     */
   def fetchSelfAtWithAncestors(address: AclAddress, rev: Long)(implicit
       caller: Caller
-  ): IO[AclRejection, AclCollection] =
+  ): IO[AclRejection.NotFound, AclCollection] =
     fetchAtWithAncestors(address, rev).map(_.filter(caller.identities))
 
   /**

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Organizations.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Organizations.scala
@@ -78,7 +78,7 @@ trait Organizations {
     * @param rev   the organization revision
     * @return the organization in a Resource representation, None otherwise
     */
-  def fetchAt(label: Label, rev: Long): IO[OrganizationRejection, OrganizationResource]
+  def fetchAt(label: Label, rev: Long): IO[OrganizationRejection.NotFound, OrganizationResource]
 
   /**
     * Fetch an organization at the current revision by uuid.
@@ -95,7 +95,7 @@ trait Organizations {
     * @param rev   the organization revision
     * @return the organization in a Resource representation, None otherwise
     */
-  def fetchAt(uuid: UUID, rev: Long): IO[OrganizationRejection, OrganizationResource] =
+  def fetchAt(uuid: UUID, rev: Long): IO[OrganizationRejection.NotFound, OrganizationResource] =
     fetch(uuid).flatMap(resource => fetchAt(resource.value.label, rev))
 
   /**

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Projects.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Projects.scala
@@ -88,7 +88,7 @@ trait Projects {
     * @param ref the project reference
     * @param rev the revision to be retrieved
     */
-  def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection, ProjectResource]
+  def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection.NotFound, ProjectResource]
 
   /**
     * Fetches a project resource based on its uuid.
@@ -114,7 +114,7 @@ trait Projects {
     * @param uuid the unique project identifier
     * @param rev  the revision to be retrieved
     */
-  def fetchAt(uuid: UUID, rev: Long): IO[ProjectRejection, ProjectResource] =
+  def fetchAt(uuid: UUID, rev: Long): IO[ProjectRejection.NotFound, ProjectResource] =
     fetch(uuid).flatMap(resource => fetchAt(resource.value.ref, rev))
 
   /**
@@ -123,7 +123,7 @@ trait Projects {
     * @param projectUuid the unique project identifier
     * @param rev         the revision to be retrieved
     */
-  def fetchAt(orgUuid: UUID, projectUuid: UUID, rev: Long): IO[ProjectRejection, ProjectResource] =
+  def fetchAt(orgUuid: UUID, projectUuid: UUID, rev: Long): IO[ProjectRejection.NotFound, ProjectResource] =
     fetchAt(projectUuid, rev).flatMap {
       case res if res.value.organizationUuid != orgUuid => IO.raiseError(ProjectNotFound(orgUuid, projectUuid))
       case other                                        => IO.pure(other)

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Realms.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Realms.scala
@@ -67,9 +67,8 @@ trait Realms {
     * Fetches a realm.
     *
     * @param label the realm label
-    * @return the realm in a Resource representation, None otherwise
     */
-  def fetch(label: Label): UIO[Option[RealmResource]]
+  def fetch(label: Label): IO[RealmNotFound, RealmResource]
 
   /**
     * Fetches a realm at a specific revision.
@@ -78,7 +77,7 @@ trait Realms {
     * @param rev   the realm revision
     * @return the realm as a resource at the specified revision
     */
-  def fetchAt(label: Label, rev: Long): IO[RevisionNotFound, Option[RealmResource]]
+  def fetchAt(label: Label, rev: Long): IO[RealmRejection, RealmResource]
 
   /**
     * Lists realms with optional filters.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Realms.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Realms.scala
@@ -77,7 +77,7 @@ trait Realms {
     * @param rev   the realm revision
     * @return the realm as a resource at the specified revision
     */
-  def fetchAt(label: Label, rev: Long): IO[RealmRejection, RealmResource]
+  def fetchAt(label: Label, rev: Long): IO[RealmRejection.NotFound, RealmResource]
 
   /**
     * Lists realms with optional filters.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resolvers.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resolvers.scala
@@ -83,7 +83,7 @@ trait Resolvers {
     * @param id      the resolver identifier to expand as the id of the resolver
     * @param projectRef the project where the resolver belongs
     */
-  def fetch(id: IdSegment, projectRef: ProjectRef): IO[ResolverRejection, Option[ResolverResource]]
+  def fetch(id: IdSegment, projectRef: ProjectRef): IO[ResolverRejection, ResolverResource]
 
   /**
     * Fetches the resolver at a given revision
@@ -91,7 +91,7 @@ trait Resolvers {
     * @param projectRef the project where the resolver belongs
     * @param rev     the current revision of the resolver
     */
-  def fetchAt(id: IdSegment, projectRef: ProjectRef, rev: Long): IO[ResolverRejection, Option[ResolverResource]]
+  def fetchAt(id: IdSegment, projectRef: ProjectRef, rev: Long): IO[ResolverRejection, ResolverResource]
 
   /**
     * Fetches a resolver by tag.
@@ -104,14 +104,12 @@ trait Resolvers {
       id: IdSegment,
       projectRef: ProjectRef,
       tag: Label
-  ): IO[ResolverRejection, Option[ResolverResource]] =
-    fetch(id, projectRef).flatMap {
-      case Some(resource) =>
-        resource.value.tags.get(tag) match {
-          case Some(rev) => fetchAt(id, projectRef, rev).leftMap(_ => TagNotFound(tag))
-          case None      => IO.raiseError(TagNotFound(tag))
-        }
-      case None           => IO.pure(None)
+  ): IO[ResolverRejection, ResolverResource] =
+    fetch(id, projectRef).flatMap { resource =>
+      resource.value.tags.get(tag) match {
+        case Some(rev) => fetchAt(id, projectRef, rev).leftMap(_ => TagNotFound(tag))
+        case None      => IO.raiseError(TagNotFound(tag))
+      }
     }
 
   /**

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/ServiceError.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/ServiceError.scala
@@ -19,11 +19,6 @@ sealed abstract class ServiceError(val reason: String) extends SDKError {
 object ServiceError {
 
   /**
-    * Signals that the requested resource was not found
-    */
-  final case object NotFound extends ServiceError("The requested resource could not be found.")
-
-  /**
     * Signals that the authorization failed
     */
   final case object AuthorizationFailed

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/IdSegment.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/IdSegment.scala
@@ -19,6 +19,7 @@ sealed trait IdSegment extends Product with Serializable { self =>
     */
   def toIri(mappings: ApiMappings, base: ProjectBase): Option[Iri]
 
+  override def toString: String = asString
 }
 
 object IdSegment {

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/acls/AclRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/acls/AclRejection.scala
@@ -19,19 +19,33 @@ sealed abstract class AclRejection(val reason: String) extends Product with Seri
 object AclRejection {
 
   /**
-    * Signals an attempt to append/subtract ACLs that won't change the current state.
-    *
-    * @param address the ACL address
+    * Enumeration of possible reasons why an acl is not found
     */
-  final case class NothingToBeUpdated(address: AclAddress)
-      extends AclRejection(s"The ACL on address '$address' will not change after applying the provided update.")
+  sealed abstract class NotFound(reason: String) extends AclRejection(reason)
+
+  /**
+    * Signals an attempt to retrieve the ACL at a specific revision when the provided revision does not exist.
+    *
+    * @param provided the provided revision
+    * @param current  the last known revision
+    */
+  final case class RevisionNotFound(provided: Long, current: Long)
+      extends NotFound(s"Revision requested '$provided' not found, last known revision is '$current'.")
 
   /**
     * Signals an attempt to modify ACLs that do not exists.
     *
     * @param address the ACL address
     */
-  final case class AclNotFound(address: AclAddress) extends AclRejection(s"The ACL address '$address' does not exists.")
+  final case class AclNotFound(address: AclAddress) extends NotFound(s"The ACL address '$address' does not exists.")
+
+  /**
+    * Signals an attempt to append/subtract ACLs that won't change the current state.
+    *
+    * @param address the ACL address
+    */
+  final case class NothingToBeUpdated(address: AclAddress)
+      extends AclRejection(s"The ACL on address '$address' will not change after applying the provided update.")
 
   /**
     * Signals an attempt to delete ACLs that are already empty.
@@ -51,15 +65,6 @@ object AclRejection {
       extends AclRejection(
         s"Incorrect revision '$provided' provided, expected '$expected', the ACL address '$address' may have been updated since last seen."
       )
-
-  /**
-    * Signals an attempt to retrieve the ACL at a specific revision when the provided revision does not exist.
-    *
-    * @param provided the provided revision
-    * @param current  the last known revision
-    */
-  final case class RevisionNotFound(provided: Long, current: Long)
-      extends AclRejection(s"Revision requested '$provided' not found, last known revision is '$current'.")
 
   /**
     * Signals an attempt to create/replace/append/subtract ACL collection which contains void permissions.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejection.scala
@@ -23,6 +23,11 @@ sealed abstract class ProjectRejection(val reason: String) extends Product with 
 object ProjectRejection {
 
   /**
+    * Enumeration of possible reasons why a project is not found
+    */
+  sealed abstract class NotFound(reason: String) extends ProjectRejection(reason)
+
+  /**
     * Rejection returned when a subject intends to retrieve a project at a specific revision, but the provided revision
     * does not exist.
     *
@@ -30,18 +35,12 @@ object ProjectRejection {
     * @param current  the last known revision
     */
   final case class RevisionNotFound(provided: Long, current: Long)
-      extends ProjectRejection(s"Revision requested '$provided' not found, last known revision is '$current'.")
-
-  /**
-    * Signals that a project cannot be created because one with the same identifier already exists.
-    */
-  final case class ProjectAlreadyExists(projectRef: ProjectRef)
-      extends ProjectRejection(s"Project '$projectRef' already exists.")
+      extends NotFound(s"Revision requested '$provided' not found, last known revision is '$current'.")
 
   /**
     * Signals that an operation on a project cannot be performed due to the fact that the referenced project does not exist.
     */
-  final case class ProjectNotFound private (override val reason: String) extends ProjectRejection(reason)
+  final case class ProjectNotFound private (override val reason: String) extends NotFound(reason)
   object ProjectNotFound {
     def apply(uuid: UUID): ProjectNotFound                       =
       ProjectNotFound(s"Project with uuid '${uuid.toString.toLowerCase()}' not found.")
@@ -52,6 +51,12 @@ object ProjectRejection {
     def apply(projectRef: ProjectRef): ProjectNotFound           =
       ProjectNotFound(s"Project '$projectRef' not found.")
   }
+
+  /**
+    * Signals that a project cannot be created because one with the same identifier already exists.
+    */
+  final case class ProjectAlreadyExists(projectRef: ProjectRef)
+      extends ProjectRejection(s"Project '$projectRef' already exists.")
 
   /**
     * Signals a rejection caused when interacting with the organizations API

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmRejection.scala
@@ -20,6 +20,11 @@ sealed abstract class RealmRejection(val reason: String) extends Product with Se
 object RealmRejection {
 
   /**
+    * Enumeration of possible reasons why a realm is not found
+    */
+  sealed abstract class NotFound(reason: String) extends RealmRejection(reason)
+
+  /**
     * Rejection returned when a subject intends to retrieve a realm at a specific revision, but the provided revision
     * does not exist.
     *
@@ -27,7 +32,14 @@ object RealmRejection {
     * @param current  the last known revision
     */
   final case class RevisionNotFound(provided: Long, current: Long)
-      extends RealmRejection(s"Revision requested '$provided' not found, last known revision is '$current'.")
+      extends NotFound(s"Revision requested '$provided' not found, last known revision is '$current'.")
+
+  /**
+    * Rejection returned when attempting to update a realm with an id that doesn't exist.
+    *
+    * @param label the label of the realm
+    */
+  final case class RealmNotFound(label: Label) extends NotFound(s"Realm '$label' not found.")
 
   /**
     * Rejection returned when attempting to create a realm with an id that already exists.
@@ -44,13 +56,6 @@ object RealmRejection {
     */
   final case class RealmOpenIdConfigAlreadyExists(label: Label, openIdConfig: Uri)
       extends RealmRejection(s"Realm '$label' with openIdConfig '${openIdConfig.toString()}' already exists.")
-
-  /**
-    * Rejection returned when attempting to update a realm with an id that doesn't exist.
-    *
-    * @param label the label of the realm
-    */
-  final case class RealmNotFound(label: Label) extends RealmRejection(s"Realm '$label' not found.")
 
   /**
     * Rejection returned when attempting to deprecate a realm that is already deprecated.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/resolvers/ResolverRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/resolvers/ResolverRejection.scala
@@ -53,7 +53,7 @@ object ResolverRejection {
     * @param project the project it belongs to
     */
   final case class ResolverNotFound(id: Iri, project: ProjectRef)
-      extends ResolverRejection(s"Resolver '$id' not found in project $project.")
+      extends ResolverRejection(s"Resolver '$id' not found in project '$project'.")
 
   /**
     * Rejection returned when attempting to create a resolver where the passed id does not match the id on the payload.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/resources/ResourceRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/resources/ResourceRejection.scala
@@ -11,7 +11,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.Mapper
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection.{InvalidId, UnexpectedId}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ProjectRef, ProjectRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, ResourceRef}
 import io.circe.syntax._
@@ -55,10 +55,13 @@ object ResourceRejection {
     * Rejection returned when attempting to update a resource with an id that doesn't exist.
     *
     * @param id        the resource identifier
-    * @param schemaOpt the optional resource schema
+    * @param project   the project it belongs to
+    * @param schemaOpt the optional schema reference
     */
-  final case class ResourceNotFound(id: Iri, schemaOpt: Option[ResourceRef])
-      extends ResourceRejection(s"Resource '$id' not found${schemaOpt.fold("")(schema => s" with schema '$schema'")}.")
+  final case class ResourceNotFound(id: Iri, project: ProjectRef, schemaOpt: Option[ResourceRef])
+      extends ResourceRejection(
+        s"Resource '$id' not found${schemaOpt.fold("")(schema => s" with schema '$schema'")} in project '$project'."
+      )
 
   /**
     * Rejection returned when attempting to create a resource where the passed id does not match the id on the payload.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/SchemaRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/SchemaRejection.scala
@@ -12,7 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection.{InvalidId, UnexpectedId}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ProjectRef, ProjectRejection}
 import io.circe.syntax._
 import io.circe.{Encoder, JsonObject}
 
@@ -53,9 +53,11 @@ object SchemaRejection {
   /**
     * Rejection returned when attempting to update a schema with an id that doesn't exist.
     *
-    * @param id the schema identifier
+    * @param id      the schema identifier
+    * @param project the project it belongs to
     */
-  final case class SchemaNotFound(id: Iri) extends SchemaRejection(s"Schema '$id' not found.")
+  final case class SchemaNotFound(id: Iri, project: ProjectRef)
+      extends SchemaRejection(s"Schema '$id' not found in project '$project'.")
 
   /**
     * Rejection returned when attempting to create a schema where the passed id does not match the id on the payload.

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/ResourcesSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/ResourcesSpec.scala
@@ -55,7 +55,8 @@ class ResourcesSpec
         IO.raiseError(WrappedSchemaRejection(SchemaIsDeprecated(ref.iri)))
       case (_, ref) if ref.iri == schema1.id      =>
         IO.pure(schema1)
-      case (_, ref)                               => IO.raiseError(WrappedSchemaRejection(SchemaNotFound(ref.iri)))
+      case (_, ref)                               =>
+        IO.raiseError(WrappedSchemaRejection(SchemaNotFound(ref.iri, project.value.ref)))
     }
 
     val eval: (ResourceState, ResourceCommand) => IO[ResourceRejection, ResourceEvent] = evaluate(fetchSchema)
@@ -182,7 +183,7 @@ class ResourcesSpec
         eval(
           Initial,
           CreateResource(myId, project.value.ref, notFoundSchema, source, compacted, expanded, subject)
-        ).rejected shouldEqual WrappedSchemaRejection(SchemaNotFound(notFoundSchema.iri))
+        ).rejected shouldEqual WrappedSchemaRejection(SchemaNotFound(notFoundSchema.iri, project.value.ref))
       }
 
       "reject with ResourceSchemaUnexpected" in {

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/acls/AclsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/acls/AclsImpl.scala
@@ -34,27 +34,21 @@ final class AclsImpl private (
 
   private val minimum: Set[Permission] = permissions.minimum
 
-  override def fetch(address: AclAddress): UIO[Option[AclResource]] =
-    agg.state(address.string).map(_.toResource(address, minimum)).named("fetchAcl", moduleType)
+  override def fetch(address: AclAddress): IO[AclNotFound, AclResource] =
+    agg
+      .state(address.string)
+      .map(_.toResource(address, minimum))
+      .flatMap(IO.fromOption(_, AclNotFound(address)))
+      .named("fetchAcl", moduleType)
 
   override def fetchWithAncestors(address: AclAddress): UIO[AclCollection] =
-    fetch(address).flatMap { resourceOpt =>
-      val collection = toCollection(resourceOpt)
-      address.parent match {
-        case Some(parent) => fetchWithAncestors(parent).map(collection ++ _)
-        case None         => UIO.pure(collection)
-      }
-    }
+    super.fetchWithAncestors(address).named("fetchWithAncestors", moduleType)
 
-  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection.RevisionNotFound, Option[AclResource]] =
+  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection, AclResource] =
     eventLog
-      .fetchStateAt(
-        persistenceId(moduleType, address.string),
-        rev,
-        Initial,
-        Acls.next
-      )
+      .fetchStateAt(persistenceId(moduleType, address.string), rev, Initial, Acls.next)
       .bimap(RevisionNotFound(rev, _), _.toResource(address, minimum))
+      .flatMap(IO.fromOption(_, AclNotFound(address)))
       .named("fetchAclAt", moduleType)
 
   override def list(filter: AclAddressFilter): UIO[AclCollection]                              =
@@ -99,9 +93,6 @@ final class AclsImpl private (
       resource         <- IO.fromOption(resourceOpt, UnexpectedInitialState(cmd.address))
       _                <- index.put(cmd.address, resource)
     } yield resource
-
-  private def toCollection(resourceOpt: Option[AclResource]): AclCollection =
-    resourceOpt.fold(AclCollection.empty)(AclCollection(_))
 
 }
 
@@ -153,10 +144,7 @@ object AclsImpl {
         eventLog
           .eventsByTag(moduleType, Offset.noOffset)
           .mapAsync(config.indexing.concurrency)(envelope =>
-            acls.fetch(envelope.event.address).flatMap {
-              case Some(aclResource) => index.put(aclResource.value.address, aclResource)
-              case None              => UIO.unit
-            }
+            acls.fetch(envelope.event.address).redeemCauseWith(_ => IO.unit, res => index.put(res.value.address, res))
           )
       ),
       retryStrategy = RetryStrategy(

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/acls/AclsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/acls/AclsImpl.scala
@@ -44,7 +44,7 @@ final class AclsImpl private (
   override def fetchWithAncestors(address: AclAddress): UIO[AclCollection] =
     super.fetchWithAncestors(address).named("fetchWithAncestors", moduleType)
 
-  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection, AclResource] =
+  override def fetchAt(address: AclAddress, rev: Long): IO[AclRejection.NotFound, AclResource] =
     eventLog
       .fetchStateAt(persistenceId(moduleType, address.string), rev, Initial, Acls.next)
       .bimap(RevisionNotFound(rev, _), _.toResource(address, minimum))

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/cache/KeyValueStore.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/cache/KeyValueStore.scala
@@ -95,6 +95,13 @@ trait KeyValueStore[K, V] {
     entries.map(_.get(key))
 
   /**
+    * @param key the key
+    * @return an the value for the provided key when found, ''or'' otherwise on the error channel
+    */
+  def getOr[E](key: K, or: => E): IO[E, V] =
+    get(key).flatMap(IO.fromOption(_, or))
+
+  /**
     * Finds the first (key, value) pair that satisfies the predicate.
     *
     * @param f the predicate to the satisfied
@@ -112,6 +119,15 @@ trait KeyValueStore[K, V] {
     */
   def collectFirst[A](pf: PartialFunction[(K, V), A]): UIO[Option[A]] =
     entries.map(_.collectFirst(pf))
+
+  /**
+    * Finds the first (key, value) pair  for which the given partial function is defined,
+    * and applies the partial function to it. If nothing is found, returns on the error channel the passed ''or''.
+    *
+    * @param pf the partial function
+    */
+  def collectFirstOr[A, E](pf: PartialFunction[(K, V), A])(or: => E): IO[E, A] =
+    collectFirst(pf).flatMap(IO.fromOption(_, or))
 
   /**
     * Finds the first value in the store that satisfies the predicate.

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/organizations/OrganizationsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/organizations/OrganizationsImpl.scala
@@ -10,7 +10,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.Organizations.moduleType
 import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationCommand._
-import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection.{OwnerPermissionsFailed, RevisionNotFound, UnexpectedInitialState}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection.{OrganizationNotFound, OwnerPermissionsFailed, RevisionNotFound, UnexpectedInitialState}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationState.Initial
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.ResultEntry.UnscoredResultEntry
@@ -63,10 +63,14 @@ final class OrganizationsImpl private (
   )(implicit caller: Subject): IO[OrganizationRejection, OrganizationResource] =
     eval(DeprecateOrganization(label, rev, caller)).named("deprecateOrganization", moduleType)
 
-  override def fetch(label: Label): UIO[Option[OrganizationResource]] =
-    agg.state(label.value).map(_.toResource).named("fetchOrganization", moduleType)
+  override def fetch(label: Label): IO[OrganizationNotFound, OrganizationResource] =
+    agg
+      .state(label.value)
+      .map(_.toResource)
+      .flatMap(IO.fromOption(_, OrganizationNotFound(label)))
+      .named("fetchOrganization", moduleType)
 
-  override def fetchAt(label: Label, rev: Long): IO[RevisionNotFound, Option[OrganizationResource]] =
+  override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection, OrganizationResource] =
     eventLog
       .fetchStateAt(
         persistenceId(moduleType, label.value),
@@ -75,26 +79,19 @@ final class OrganizationsImpl private (
         Organizations.next
       )
       .bimap(RevisionNotFound(rev, _), _.toResource)
+      .flatMap(IO.fromOption(_, OrganizationNotFound(label)))
       .named("fetchOrganizationAt", moduleType)
 
-  override def fetch(uuid: UUID): UIO[Option[OrganizationResource]] =
-    fetchFromCache(uuid)
-      .flatMap {
-        case Some(label) => fetch(label)
-        case None        => UIO.pure(None)
-      }
-      .named("fetchOrganizationByUuid", moduleType)
+  override def fetch(uuid: UUID): IO[OrganizationNotFound, OrganizationResource] =
+    fetchFromCache(uuid).flatMap(fetch).named("fetchOrganizationByUuid", moduleType)
 
-  override def fetchAt(uuid: UUID, rev: Long): IO[RevisionNotFound, Option[OrganizationResource]] =
-    fetchFromCache(uuid)
-      .flatMap {
-        case Some(label) => fetchAt(label, rev)
-        case None        => UIO.pure(None)
-      }
-      .named("fetchOrganizationAtByUuid", moduleType)
+  override def fetchAt(uuid: UUID, rev: Long): IO[OrganizationRejection, OrganizationResource] =
+    super.fetchAt(uuid, rev).named("fetchOrganizationAtByUuid", moduleType)
 
-  private def fetchFromCache(uuid: UUID): UIO[Option[Label]]                                  =
-    cache.collectFirst { case (label, resource) if resource.value.uuid == uuid => label }
+  private def fetchFromCache(uuid: UUID): IO[OrganizationNotFound, Label] =
+    cache
+      .collectFirst { case (label, resource) if resource.value.uuid == uuid => label }
+      .flatMap(IO.fromOption(_, OrganizationNotFound(uuid)))
 
   private def eval(cmd: OrganizationCommand): IO[OrganizationRejection, OrganizationResource] =
     for {
@@ -147,7 +144,7 @@ object OrganizationsImpl {
       config: OrganizationsConfig,
       eventLog: EventLog[Envelope[OrganizationEvent]],
       index: OrganizationsCache,
-      organizations: Organizations
+      orgs: Organizations
   )(implicit as: ActorSystem[Nothing], sc: Scheduler) =
     StreamSupervisor.runAsSingleton(
       "OrganizationsIndex",
@@ -155,10 +152,7 @@ object OrganizationsImpl {
         eventLog
           .eventsByTag(moduleType, Offset.noOffset)
           .mapAsync(config.indexing.concurrency)(envelope =>
-            organizations.fetch(envelope.event.label).flatMap {
-              case Some(orgResource) => index.put(orgResource.value.label, orgResource)
-              case None              => UIO.unit
-            }
+            orgs.fetch(envelope.event.label).redeemCauseWith(_ => IO.unit, res => index.put(res.value.label, res))
           )
       ),
       retryStrategy = RetryStrategy(

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/organizations/OrganizationsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/organizations/OrganizationsImpl.scala
@@ -70,7 +70,7 @@ final class OrganizationsImpl private (
       .flatMap(IO.fromOption(_, OrganizationNotFound(label)))
       .named("fetchOrganization", moduleType)
 
-  override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection, OrganizationResource] =
+  override def fetchAt(label: Label, rev: Long): IO[OrganizationRejection.NotFound, OrganizationResource] =
     eventLog
       .fetchStateAt(persistenceId(moduleType, label.value), rev, Initial, Organizations.next)
       .bimap(RevisionNotFound(rev, _), _.toResource)
@@ -80,7 +80,7 @@ final class OrganizationsImpl private (
   override def fetch(uuid: UUID): IO[OrganizationNotFound, OrganizationResource] =
     fetchFromCache(uuid).flatMap(fetch).named("fetchOrganizationByUuid", moduleType)
 
-  override def fetchAt(uuid: UUID, rev: Long): IO[OrganizationRejection, OrganizationResource] =
+  override def fetchAt(uuid: UUID, rev: Long): IO[OrganizationRejection.NotFound, OrganizationResource] =
     super.fetchAt(uuid, rev).named("fetchOrganizationAtByUuid", moduleType)
 
   private def fetchFromCache(uuid: UUID): IO[OrganizationNotFound, Label]                     =

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectsImpl.scala
@@ -83,7 +83,7 @@ final class ProjectsImpl private (
       .flatMap(IO.fromOption(_, ProjectNotFound(ref)))
       .named("fetchProject", moduleType)
 
-  override def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection, ProjectResource] =
+  override def fetchAt(ref: ProjectRef, rev: Long): IO[ProjectRejection.NotFound, ProjectResource] =
     eventLog
       .fetchStateAt(persistenceId(moduleType, ref.toString), rev, Initial, Projects.next)
       .bimap(RevisionNotFound(rev, _), _.toResource)
@@ -107,7 +107,7 @@ final class ProjectsImpl private (
   override def fetch(uuid: UUID): IO[ProjectNotFound, ProjectResource] =
     fetchFromCache(uuid).flatMap(fetch)
 
-  override def fetchAt(uuid: UUID, rev: Long): IO[ProjectRejection, ProjectResource] =
+  override def fetchAt(uuid: UUID, rev: Long): IO[ProjectRejection.NotFound, ProjectResource] =
     super.fetchAt(uuid, rev).named("fetchProjectAtByUuid", moduleType)
 
   private def fetchFromCache(uuid: UUID): IO[ProjectNotFound, ProjectRef] =

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
@@ -71,7 +71,7 @@ final class RealmsImpl private (
       .flatMap(IO.fromOption(_, RealmNotFound(label)))
       .named("fetchRealm", moduleType)
 
-  override def fetchAt(label: Label, rev: Long): IO[RealmRejection, RealmResource] =
+  override def fetchAt(label: Label, rev: Long): IO[RealmRejection.NotFound, RealmResource] =
     eventLog
       .fetchStateAt(persistenceId(moduleType, label.value), rev, Initial, Realms.next)
       .bimap(RevisionNotFound(rev, _), _.toResource)

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
@@ -8,7 +8,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.Realms.moduleType
 import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.realms.RealmCommand.{CreateRealm, DeprecateRealm, UpdateRealm}
-import ch.epfl.bluebrain.nexus.delta.sdk.model.realms.RealmRejection.{RevisionNotFound, UnexpectedInitialState}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.realms.RealmRejection.{RealmNotFound, RevisionNotFound, UnexpectedInitialState}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.realms.RealmState.Initial
 import ch.epfl.bluebrain.nexus.delta.sdk.model.realms._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.ResultEntry.UnscoredResultEntry
@@ -67,18 +67,18 @@ final class RealmsImpl private (
       _                <- index.put(cmd.label, resource)
     } yield resource
 
-  override def fetch(label: Label): UIO[Option[RealmResource]] =
-    agg.state(label.value).map(_.toResource).named("fetchRealm", moduleType)
+  override def fetch(label: Label): IO[RealmNotFound, RealmResource] =
+    agg
+      .state(label.value)
+      .map(_.toResource)
+      .flatMap(IO.fromOption(_, RealmNotFound(label)))
+      .named("fetchRealm", moduleType)
 
-  override def fetchAt(label: Label, rev: Long): IO[RealmRejection.RevisionNotFound, Option[RealmResource]] =
+  override def fetchAt(label: Label, rev: Long): IO[RealmRejection, RealmResource] =
     eventLog
-      .fetchStateAt(
-        persistenceId(moduleType, label.value),
-        rev,
-        Initial,
-        Realms.next
-      )
+      .fetchStateAt(persistenceId(moduleType, label.value), rev, Initial, Realms.next)
       .bimap(RevisionNotFound(rev, _), _.toResource)
+      .flatMap(IO.fromOption(_, RealmNotFound(label)))
       .named("fetchRealmAt", moduleType)
 
   override def list(
@@ -129,10 +129,7 @@ object RealmsImpl {
         eventLog
           .eventsByTag(moduleType, Offset.noOffset)
           .mapAsync(config.indexing.concurrency)(envelope =>
-            realms.fetch(envelope.event.label).flatMap {
-              case Some(realmResource) => index.put(realmResource.value.label, realmResource)
-              case None                => UIO.unit
-            }
+            realms.fetch(envelope.event.label).redeemCauseWith(_ => IO.unit, res => index.put(res.value.label, res))
           )
       ),
       retryStrategy = RetryStrategy(

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
@@ -60,10 +60,7 @@ final class RealmsImpl private (
   private def eval(cmd: RealmCommand): IO[RealmRejection, RealmResource] =
     for {
       evaluationResult <- agg.evaluate(cmd.label.value, cmd).mapError(_.value)
-      resource         <- IO.fromOption(
-                            evaluationResult.state.toResource,
-                            UnexpectedInitialState(cmd.label)
-                          )
+      resource         <- IO.fromOption(evaluationResult.state.toResource, UnexpectedInitialState(cmd.label))
       _                <- index.put(cmd.label, resource)
     } yield resource
 

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
@@ -141,10 +141,9 @@ final class ResolversImpl(
     for {
       evaluationResult <- agg.evaluate(identifier(cmd.project, cmd.id), cmd).mapError(_.value)
       (am, base)        = project.apiMappings -> project.base
-      resource         <-
-        IO.fromOption(evaluationResult.state.toResource(am, base), UnexpectedInitialState(cmd.id, project.ref))
-      _                <- index.put(cmd.project -> cmd.id, resource)
-    } yield resource
+      res              <- IO.fromOption(evaluationResult.state.toResource(am, base), UnexpectedInitialState(cmd.id, project.ref))
+      _                <- index.put(cmd.project -> cmd.id, res)
+    } yield res
 
   private def identifier(projectRef: ProjectRef, id: Iri): String =
     s"${projectRef}_$id"

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
@@ -94,33 +94,25 @@ final class ResolversImpl(
     } yield res
   }.named("deprecateResolver", moduleType)
 
-  override def fetch(id: IdSegment, projectRef: ProjectRef): IO[ResolverRejection, Option[ResolverResource]] = {
-    for {
-      p   <- projects.fetchProject(projectRef)
-      iri <- expandIri(id, p)
-      res <- agg.state(identifier(projectRef, iri))
-    } yield res.toResource(p.apiMappings, p.base)
-  }.named("fetchResolver", moduleType)
+  override def fetch(id: IdSegment, projectRef: ProjectRef): IO[ResolverRejection, ResolverResource] =
+    fetch(id, projectRef, None).named("fetchResolver", moduleType)
 
-  override def fetchAt(
-      id: IdSegment,
-      projectRef: ProjectRef,
-      rev: Long
-  ): IO[ResolverRejection, Option[ResolverResource]] = {
+  override def fetchAt(id: IdSegment, projectRef: ProjectRef, rev: Long): IO[ResolverRejection, ResolverResource] =
+    fetch(id, projectRef, Some(rev)).named("fetchResolverAt", moduleType)
+
+  private def fetch(id: IdSegment, projectRef: ProjectRef, rev: Option[Long]) =
     for {
-      p   <- projects.fetchProject(projectRef)
-      iri <- expandIri(id, p)
-      res <- eventLog
-               .fetchStateAt(persistenceId(moduleType, identifier(projectRef, iri)), rev, Initial, Resolvers.next)
-               .leftMap(RevisionNotFound(rev, _))
-    } yield res.toResource(p.apiMappings, p.base)
-  }.named("fetchResolverAt", moduleType)
+      p     <- projects.fetchProject(projectRef)
+      iri   <- expandIri(id, p)
+      state <- rev.fold(currentState(projectRef, iri))(stateAt(projectRef, iri, _))
+      res   <- IO.fromOption(state.toResource(p.apiMappings, p.base), ResolverNotFound(iri, projectRef))
+    } yield res
 
   override def fetchBy(
       id: IdSegment,
       projectRef: ProjectRef,
       tag: Label
-  ): IO[ResolverRejection, Option[ResolverResource]] =
+  ): IO[ResolverRejection, ResolverResource] =
     super.fetchBy(id, projectRef, tag).named("fetchResolverBy", moduleType)
 
   def list(pagination: FromPagination, params: ResolverSearchParams): UIO[UnscoredSearchResults[ResolverResource]] =
@@ -136,6 +128,14 @@ final class ResolversImpl(
 
   override def events(offset: Offset): fs2.Stream[Task, Envelope[ResolverEvent]] =
     eventLog.eventsByTag(moduleType, offset)
+
+  private def currentState(projectRef: ProjectRef, iri: Iri): IO[ResolverRejection, ResolverState] =
+    agg.state(identifier(projectRef, iri))
+
+  private def stateAt(projectRef: ProjectRef, iri: Iri, rev: Long) =
+    eventLog
+      .fetchStateAt(persistenceId(moduleType, identifier(projectRef, iri)), rev, Initial, Resolvers.next)
+      .leftMap(RevisionNotFound(rev, _))
 
   private def eval(cmd: ResolverCommand, project: Project): IO[ResolverRejection, ResolverResource] =
     for {
@@ -180,11 +180,7 @@ object ResolversImpl {
           .mapAsync(config.indexing.concurrency)(envelope =>
             resolvers
               .fetch(IriSegment(envelope.event.id), envelope.event.project)
-              .flatMap {
-                case Some(res) => index.put(res.value.project -> res.value.id, res)
-                case None      => UIO.unit
-              }
-              .onErrorHandle(_ => ())
+              .redeemCauseWith(_ => IO.unit, res => index.put(res.value.project -> res.value.id, res))
           )
       ),
       retryStrategy = RetryStrategy(


### PR DESCRIPTION
This works fixes the generic rejection we were outputting when something in the routes was a `None`.

- Each resource type has its own `*NotFound` with its specific message, which helps clients to know what's going on.
- Simplify `DeltaDirectives` substantially since there is no need to support this `Option[A]`
- Other minor refactorings