### PR TITLE
Added support for multiple root entries

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/directives/DeltaDirectives.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/directives/DeltaDirectives.scala
@@ -74,13 +74,13 @@ object DeltaDirectives extends UriDirectives with RdfMarshalling {
     jsonLdFormat.map {
       case JsonLdFormat.Compacted =>
         uio.flatMap {
-          case Left(err)    => err.toCompactedJsonLd.map[Result](v => (err.status, err.headers, v))
-          case Right(value) => value.toCompactedJsonLd.map[Result](v => (successStatus, successHeaders, v))
+          case Left(err)    => err.toCompactedJsonLd.map(v => (err.status, err.headers, v))
+          case Right(value) => value.toCompactedJsonLd.map(v => (successStatus, successHeaders, v))
         }
       case JsonLdFormat.Expanded  =>
         uio.flatMap {
-          case Left(err)    => err.toExpandedJsonLd.map[Result](v => (err.status, err.headers, v))
-          case Right(value) => value.toExpandedJsonLd.map[Result](v => (successStatus, successHeaders, v))
+          case Left(err)    => err.toExpandedJsonLd.map(v => (err.status, err.headers, v))
+          case Right(value) => value.toExpandedJsonLd.map(v => (successStatus, successHeaders, v))
         }
     }
 

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/models/JsonSource.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/models/JsonSource.scala
@@ -5,7 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.UnexpectedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, JsonLd}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.CompactedJsonLd
 import ch.epfl.bluebrain.nexus.delta.syntax._
 import io.circe.{Json, JsonObject}
 import monix.bio.IO
@@ -35,7 +35,7 @@ object JsonSource {
         )
 
       override def compact(value: JsonSource): IO[RdfError, CompactedJsonLd] =
-        IO.fromEither(toObj(value.value)).map(obj => JsonLd.compactedUnsafe(obj, value.context, value.id))
+        IO.fromEither(toObj(value.value)).map(obj => CompactedJsonLd.unsafe(value.id, value.context, obj))
 
       override def context(value: JsonSource): ContextValue = value.context
     }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/RdfError.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/RdfError.scala
@@ -1,5 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.rdf
 
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolutionError
 
 sealed abstract class RdfError(val reason: String, details: Option[String] = None) extends Exception {
@@ -34,7 +35,8 @@ object RdfError {
   /**
     * Invalid Iri
     */
-  final case class InvalidIri(err: String) extends RdfError(err)
+  final case object InvalidIri extends RdfError(s"keyword '${keywords.id}' could not be converted to an Iri")
+  type InvalidIri = InvalidIri.type
 
   /**
     * Unexpected Iri value

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLd.scala
@@ -1,141 +1,189 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
+import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
-import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.xsd
+import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.{InvalidIri, UnexpectedJsonLd}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.{JsonLdDecoder, JsonLdDecoderError}
 import ch.epfl.bluebrain.nexus.delta.rdf.{IriOrBNode, RdfError}
-import io.circe.generic.semiauto.deriveDecoder
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, Json, JsonObject}
+import io.circe.{Json, JsonObject}
 import monix.bio.IO
 
+import scala.collection.immutable.VectorMap
+
 /**
-  * Json-LD Expanded Document. This specific implementation is entity centric, having always only one root @id.
+  * Json-LD Expanded Document. This specific implementation is entity centric, having always one root id.
   */
-final case class ExpandedJsonLd private[jsonld] (obj: JsonObject, rootId: IriOrBNode) extends JsonLd { self =>
+final case class ExpandedJsonLd private (rootId: IriOrBNode, entries: VectorMap[IriOrBNode, JsonObject])
+    extends JsonLd { self =>
 
-  override type This = ExpandedJsonLd
-
-  protected type Predicate = Iri
-
-  private lazy val hc = obj.asJson.hcursor
-
-  lazy val json: Json = Json.arr(obj.asJson)
-
-  private val rootIdJson = rootId.asJson
-
-  def add(key: Predicate, iri: Iri): This =
-    add(key.toString, expand(iri))
-
-  def addType(iri: Iri): This =
-    add(keywords.tpe, iri.asJson)
-
-  def add(key: Predicate, literal: String): This =
-    add(key.toString, expand(literal))
-
-  def add(key: Predicate, literal: Boolean): This =
-    add(key, literal, includeDataType = false)
-
-  def add(key: Predicate, literal: Int): This =
-    add(key, literal, includeDataType = false)
-
-  def add(key: Predicate, literal: Long): This =
-    add(key, literal, includeDataType = false)
-
-  def add(key: Predicate, literal: Double): This =
-    add(key, literal, includeDataType = false)
-
-  def add(key: Iri, literal: Int, includeDataType: Boolean): This =
-    add(key.toString, expand(literal, Option.when(includeDataType)(xsd.integer)))
-
-  def add(key: Iri, literal: Boolean, includeDataType: Boolean): This =
-    add(key.toString, expand(literal, Option.when(includeDataType)(xsd.boolean)))
-
-  def add(key: Iri, literal: Long, includeDataType: Boolean): This =
-    add(key.toString, expand(literal, Option.when(includeDataType)(xsd.long)))
-
-  def add(key: Iri, literal: Double, includeDataType: Boolean): This =
-    add(key.toString, expand(literal, Option.when(includeDataType)(xsd.double)))
+  override lazy val json: Json = Json.arr(entries.map { case (_, obj) => obj.asJson }.toSeq: _*)
 
   /**
-    * Fetches the @id values for the passed ''key''.
+    * The cursor for this document
     */
-  def ids(key: Iri): List[Iri] =
-    hc.get[List[Id]](key.toString).map(_.map(_.`@id`)).getOrElse(List.empty)
+  lazy val cursor: ExpandedJsonLdCursor = ExpandedJsonLdCursor(self)
+
+  override def isEmpty: Boolean = entries.forall { case (_, obj) => obj.isEmpty }
 
   /**
-    * Fetches the literal values for the passed ''key''.
+    * @return true if there is a single entry on the top level of this document, false otherwise
     */
-  def literals[A: Decoder](key: Iri): List[A] =
-    hc.get[List[Value[A]]](key.toString).map(_.map(_.`@value`)).getOrElse(List.empty)
+  def singleRoot: Boolean = entries.size == 1
 
   /**
-    * Fetches the top @type values.
+    * Converts the current document to a [[CompactedJsonLd]]
     */
-  def types: List[Iri] =
-    hc.get[List[Iri]](keywords.tpe).getOrElse(List.empty)
-
-  /**
-    * Replaces the root @id value and returns a new [[ExpandedJsonLd]]
-    *
-    * @param iriOrBNode the new root @id value
-    */
-  def replaceId(iriOrBNode: IriOrBNode): ExpandedJsonLd =
-    iriOrBNode match {
-      case _ if iriOrBNode == rootId && obj(keywords.id) == Some(rootIdJson) => self
-      case iri: Iri                                                          => new ExpandedJsonLd(obj.add(keywords.id, iri.asJson), iri)
-      case bNode: IriOrBNode.BNode                                           => new ExpandedJsonLd(obj.remove(keywords.id), bNode)
-    }
-
   def toCompacted(contextValue: ContextValue)(implicit
       opts: JsonLdOptions,
       api: JsonLdApi,
       resolution: RemoteContextResolution
   ): IO[RdfError, CompactedJsonLd] =
-    JsonLd.compact(json, contextValue, rootId)
+    CompactedJsonLd(rootId, contextValue, json)
 
+  /**
+    * Converts the current document to a [[Graph]]
+    */
   def toGraph(implicit
       opts: JsonLdOptions,
       api: JsonLdApi
-  ): Either[RdfError, Graph] = Graph(this)
+  ): Either[RdfError, Graph] = Graph(self)
 
   /**
     * Converts the current document to an ''A''
     */
-  def to[A](implicit dec: JsonLdDecoder[A]): Either[JsonLdDecoderError, A] = dec(self)
+  def to[A](implicit dec: JsonLdDecoder[A]): Either[JsonLdDecoderError, A] =
+    dec(self)
 
-  override def isEmpty: Boolean = obj.isEmpty
+  /**
+    * Merges the current document with the passed ''that'' on the matching ids.
+    *
+    * If some keys are present in both documents, the passed one will override the current ones.
+    *
+    * The resulting order of the entries is the build keeping the entries on the current document and adding the new
+    * entries of the passed document afterwards.
+    *
+    * @param rootId the new root id of the resulting document
+    * @param that   the document to merge with the current one
+    */
+  def merge(rootId: IriOrBNode, that: ExpandedJsonLd): ExpandedJsonLd =
+    if (entries.contains(rootId) || that.entries.contains(rootId)) {
+      val newEntries = (entries.keys ++ that.entries.keys).foldLeft(entries) { case (acc, id) =>
+        val thatObj = that.entries.getOrElse(id, JsonObject.empty)
+        acc.updatedWith(id)(objOpt => Some(objOpt.getOrElse(JsonObject.empty).deepMerge(thatObj)))
+      }
+      ExpandedJsonLd(rootId, newEntries)
+    } else self
 
-  private def add(key: String, value: Json): This =
-    obj(key).flatMap(v => v.asArray) match {
-      case None      => copy(obj = obj.add(key, Json.arr(value)))
-      case Some(arr) => copy(obj = obj.add(key, (arr :+ value).asJson))
+  /**
+    * If the passed ''id'' exists on the current entries of the document, a new [[ExpandedJsonLd]] with the root id
+    * pointing to the ''id'' is returned, otherwise None
+    */
+  def changeRootIfExists(id: IriOrBNode): Option[ExpandedJsonLd] =
+    entries.get(id).map(obj => setToFirstEntry(id, id, obj))
+
+  /**
+    * Replaces the root id value and returns a new [[ExpandedJsonLd]]
+    *
+    * @param id the new root id value
+    */
+  def replaceId(id: IriOrBNode): ExpandedJsonLd =
+    id match {
+      case _ if id == rootId && mainObj(keywords.id).contains(rootId.asJson) => self
+      case iri: Iri                                                          => setToFirstEntry(iri, mainObj.add(keywords.id, iri.asJson))
+      case bNode: IriOrBNode.BNode                                           => setToFirstEntry(bNode, mainObj.remove(keywords.id))
     }
 
-  private def expand[A: Encoder](value: A, dataType: Option[Iri] = None): Json =
-    dataType match {
-      case Some(dt) => Json.obj(keywords.value -> value.asJson, keywords.tpe -> dt.asJson)
-      case None     => Json.obj(keywords.value -> value.asJson)
-    }
+  private def setToFirstEntry(id: IriOrBNode, newObj: JsonObject): ExpandedJsonLd =
+    setToFirstEntry(id, rootId, newObj)
 
-  private def expand(value: Iri): Json =
-    Json.obj(keywords.id -> value.asJson)
+  private def setToFirstEntry(newId: IriOrBNode, oldId: IriOrBNode, newObj: JsonObject): ExpandedJsonLd =
+    if (oldId == newId && newId == rootId)
+      ExpandedJsonLd(rootId, entries.updated(rootId, newObj))
+    else
+      ExpandedJsonLd(newId, VectorMap(newId -> newObj) ++ entries.filterNot { case (id, _) => id == oldId })
+
+  private def mainObj: JsonObject                                                                       = entries(rootId)
+
 }
 
 object ExpandedJsonLd {
 
+  private val bNode = BNode.random
+
   /**
     * An empty [[ExpandedJsonLd]] with a random blank node
     */
-  val empty: ExpandedJsonLd = ExpandedJsonLd(JsonObject.empty, BNode.random)
+  val empty: ExpandedJsonLd       =
+    ExpandedJsonLd(bNode, VectorMap(bNode -> JsonObject.empty))
 
-  final private[jsonld] case class Value[A](`@value`: A)
-  final private[jsonld] case class Id(`@id`: Iri)
-  implicit private[jsonld] def decodeJsonLdExpandedValue[A: Decoder]: Decoder[Value[A]] = deriveDecoder[Value[A]]
-  implicit private[jsonld] val decodeJsonLdExpandedId: Decoder[Id]                      = deriveDecoder[Id]
+  /**
+    * Creates a [[ExpandedJsonLd]] document.
+    *
+    * In case of multiple top level Json Object entries present after expansion has been applied, the first one with an
+    * [[Iri]] is selected as the root id.
+    *
+    * @param input the input Json document
+    */
+  final def apply(input: Json)(implicit
+      api: JsonLdApi,
+      resolution: RemoteContextResolution,
+      opts: JsonLdOptions
+  ): IO[RdfError, ExpandedJsonLd] =
+    for {
+      expandedSeq <- api.expand(input)
+      result      <- IO.fromEither(expanded(expandedSeq))
+    } yield result
+
+  /**
+    * Constructs a [[ExpandedJsonLd]].
+    *
+    * @param value the already expanded document
+    */
+  final def expanded(value: Json): Either[RdfError, ExpandedJsonLd] =
+    for {
+      expandedSeq <- value.as[Seq[JsonObject]].leftMap(_ => UnexpectedJsonLd("Expected a Json Array with Json Objects"))
+      result      <- expanded(expandedSeq)
+    } yield result
+
+  /**
+    * Constructs a [[ExpandedJsonLd]].
+    *
+    * @param value the already expanded seuqnce of Json Objects
+    */
+  final def expanded(value: Seq[JsonObject]): Either[RdfError, ExpandedJsonLd] =
+    for {
+      expandedEntries      <- extractIds(value)
+      expandedSortedEntries = selectMainId(expandedEntries)
+    } yield expandedSortedEntries.headOption.fold(ExpandedJsonLd.empty) { case (rootId, _) =>
+      ExpandedJsonLd(rootId, expandedSortedEntries)
+    }
+
+  /**
+    * Unsafely constructs a [[ExpandedJsonLd]].
+    *
+    * @param rootId   the root id
+    * @param expanded the already expanded document
+    */
+  final def unsafe(rootId: IriOrBNode, expanded: JsonObject): ExpandedJsonLd                                   =
+    ExpandedJsonLd(rootId, VectorMap(rootId -> expanded))
+
+  private def extractIds(seq: Seq[JsonObject]): Either[RdfError.InvalidIri, VectorMap[IriOrBNode, JsonObject]] =
+    seq.toVector.foldM(VectorMap.empty[IriOrBNode, JsonObject]) { (acc, obj) =>
+      val extractedId = obj(keywords.id).map(_.as[Iri]).getOrElse(Right(BNode.random))
+      extractedId.bimap(_ => InvalidIri, id => acc + (id -> obj))
+    }
+
+  /**
+    * The main id will be the first one to have an [[Iri]]
+    */
+  private def selectMainId(entries: VectorMap[IriOrBNode, JsonObject]) =
+    entries.find { case (id, _) => id.isIri }.fold(entries) { case (iri, entry) =>
+      VectorMap(iri -> entry) ++ entries.filterNot { case (id, _) => id == iri }
+    }
+
 }

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/JsonLd.scala
@@ -1,28 +1,12 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
-import cats.implicits._
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
-import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.{InvalidIri, UnexpectedJsonLd}
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
-import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
-import ch.epfl.bluebrain.nexus.delta.rdf.{IriOrBNode, RdfError}
-import io.circe.syntax._
-import io.circe.{Json, JsonObject}
-import monix.bio.IO
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode
+import io.circe.Json
 
 /**
-  * Base trait for JSON-LD implementation. This specific implementation is entity centric, having always only one root @id
+  * Base trait for JSON-LD implementation. This specific implementation is entity centric, having always one root id
   */
 trait JsonLd extends Product with Serializable {
-  type This >: this.type <: JsonLd
-
-  /**
-    * The predicate or property will depend on the JSON-LD implementation. Compacted JSON-LD will have short form keys
-    * while expanded JSON-LD will have expanded IRIs as keys
-    */
-  protected type Predicate
 
   /**
     * The Circe Json Document representation of this JSON-LD
@@ -35,151 +19,12 @@ trait JsonLd extends Product with Serializable {
   def rootId: IriOrBNode
 
   /**
-    * Adds a ''key'' with its '@id ''iri'' value.
-    */
-  def add(key: Predicate, iri: Iri): This
-
-  /**
-    * Adds the passed ''iri'' value to the reserved key @type.
-    */
-  def addType(iri: Iri): This
-
-  /**
-    * Adds a ''key'' with its ''literal'' string.
-    */
-  def add(key: Predicate, literal: String): This
-
-  /**
-    * Adds a ''key'' with its ''literal'' long.
-    */
-  def add(key: Predicate, literal: Long): This
-
-  /**
-    * Adds a ''key'' with its ''literal'' double.
-    */
-  def add(key: Predicate, literal: Double): This
-
-  /**
-    * Adds a ''key'' with its ''literal'' integer.
-    */
-  def add(key: Predicate, literal: Int): This
-
-  /**
-    * Adds a ''key'' with its ''literal'' boolean.
-    */
-  def add(key: Predicate, literal: Boolean): This
-
-  /**
     * Checks if the current [[JsonLd]] is empty
     */
   def isEmpty: Boolean
-}
-object JsonLd {
 
   /**
-    * Creates an [[CompactedJsonLd]] unsafely.
-    *
-    * @param compacted    an already compacted Json-LD object
-    * @param contextValue the Json-LD context value
-    * @param rootId       the top @id value
+    * Checks if the current [[JsonLd]] is not empty
     */
-  final def compactedUnsafe(
-      compacted: JsonObject,
-      contextValue: ContextValue,
-      rootId: IriOrBNode
-  ): CompactedJsonLd =
-    CompactedJsonLd(compacted, contextValue, rootId)
-
-  /**
-    * Creates an [[ExpandedJsonLd]] unsafely.
-    *
-    * @param value    an already expanded Json-LD document. It must be a Json array with a single Json Object inside
-    * @param rootId   the top @id value
-    * @throws IllegalArgumentException when the provided ''expanded'' json does not match the expected value
-    */
-  final def expandedUnsafe(value: Json, rootId: IriOrBNode): ExpandedJsonLd =
-    expanded(value, rootId) match {
-      case Right(expandedJsonLd) => expandedJsonLd
-      case Left(err)             => throw new IllegalArgumentException(err)
-    }
-
-  /**
-    * Creates an [[ExpandedJsonLd]] with the explicit passed rootId and the already expanded json.
-    *
-    * @param expanded an already expanded Json-LD document. It must be a Json array with a single Json Object inside
-    * @param rootId   the top @id value
-    */
-  final def expanded(expanded: Json, rootId: IriOrBNode): Either[String, ExpandedJsonLd] =
-    expanded.asArray
-      .flatMap(_.singleEntryOr(Json.obj()))
-      .flatMap(_.asObject)
-      .map(obj => ExpandedJsonLd(obj, rootId))
-      .toRight("Expected a sequence of Json Objects with a single value")
-
-  /**
-    * Create an expanded ExpandedJsonLd document using the passed ''input''.
-    *
-    * If the Json-LD document has more than one Json Object inside the array, it fails (@graph with more than an element).
-    */
-  final def expand(input: Json)(implicit
-      api: JsonLdApi,
-      resolution: RemoteContextResolution,
-      opts: JsonLdOptions
-  ): IO[RdfError, ExpandedJsonLd] =
-    for {
-      expanded <- api.expand(input)
-      obj      <- IO.fromOption(
-                    expanded.singleEntryOr(JsonObject.empty),
-                    UnexpectedJsonLd("Expected a sequence of Json Objects with a single value")
-                  )
-      idOpt    <- IO.fromEither(obj.asJson.hcursor.get[Option[Iri]](keywords.id).leftMap(e => InvalidIri(e.message)))
-    } yield ExpandedJsonLd(obj, idOpt.getOrElse(BNode.random))
-
-  /**
-    * Create compacted JSON-LD document using the passed ''input'' and ''context'' value.
-    *
-    * This method does NOT verify the passed ''rootId'' is present in the compacted form. It just verifies the compacted
-    * form has the expected format (a Json Object without a top @graph only key)
-    */
-  final def compact(
-      input: Json,
-      contextValue: ContextValue,
-      rootId: IriOrBNode
-  )(implicit
-      api: JsonLdApi,
-      resolution: RemoteContextResolution,
-      opts: JsonLdOptions
-  ): IO[RdfError, CompactedJsonLd] =
-    for {
-      compacted <- api.compact(input, contextValue)
-      _         <- topGraphErr(compacted)
-    } yield CompactedJsonLd(compacted.remove(keywords.context), contextValue, rootId)
-
-  /**
-    * Create compacted JSON-LD document using the passed ''input'' and ''context'' value.
-    *
-    * The ''rootId'' is enforced using a framing on it.
-    */
-  final def frame(
-      input: Json,
-      contextValue: ContextValue,
-      rootId: IriOrBNode
-  )(implicit
-      api: JsonLdApi,
-      resolution: RemoteContextResolution,
-      opts: JsonLdOptions
-  ): IO[RdfError, CompactedJsonLd] = {
-    val jsonId = rootId.asIri.fold(Json.obj())(rootIri => Json.obj(keywords.id -> rootIri.asJson))
-    val frame  = contextValue.contextObj.arrayOrObject(jsonId, arr => (arr :+ jsonId).asJson, _.asJson.deepMerge(jsonId))
-    for {
-      compacted <- api.frame(input, frame)
-      _         <- topGraphErr(compacted)
-    } yield CompactedJsonLd(compacted.remove(keywords.context), contextValue, rootId)
-  }
-
-  private def topGraphErr(obj: JsonObject): IO[RdfError, Unit] =
-    if (obj.nonEmpty && obj.remove(keywords.context).remove(keywords.graph).isEmpty)
-      IO.raiseError(UnexpectedJsonLd(s"Expected a Json Object without a single top '${keywords.graph}' field"))
-    else
-      IO.unit
+  def nonEmpty: Boolean = !isEmpty
 }

--- a/delta/rdf/src/test/resources/graph/expanded-multiple-roots.json
+++ b/delta/rdf/src/test/resources/graph/expanded-multiple-roots.json
@@ -1,0 +1,14 @@
+[
+  {
+    "@id": "http://nexus.example.com/john-doé",
+    "@type": [
+      "http://schema.org/Person"
+    ]
+  },
+  {
+    "@id": "http://nexus.example.com/batman",
+    "@type": [
+      "http://schema.org/Hero"
+    ]
+  }
+]

--- a/delta/rdf/src/test/resources/jsonld/expanded/input-multiple-roots.json
+++ b/delta/rdf/src/test/resources/jsonld/expanded/input-multiple-roots.json
@@ -6,7 +6,7 @@
   "@graph": [
     {
       "@id": "http://nexus.example.com/john-doé",
-      "friends": "http://example.com/robin"
+      "name": "John"
     },
     {
       "@id": "http://example.com/batman",

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/Fixtures.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/Fixtures.scala
@@ -1,7 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.rdf
 
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
-import ch.epfl.bluebrain.nexus.delta.rdf.Triple.predicate
+import ch.epfl.bluebrain.nexus.delta.rdf.Triple.{predicate, subject}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
@@ -48,7 +48,7 @@ trait Fixtures
   def bNode(graph: Graph): BNode =
     BNode.unsafe(
       graph
-        .find { case (s, p, _) => s == graph.rootResource && p == predicate(vocab + "address") }
+        .find { case (s, p, _) => s == subject(graph.rootNode) && p == predicate(vocab + "address") }
         .map(_._3.asNode().getBlankNodeLabel)
         .value
     )

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLdSpec.scala
@@ -41,13 +41,13 @@ class CompactedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures wi
     "be framed from a multi-root json" in {
       val input = jsonContentOf("/jsonld/compacted/input-multiple-roots.json")
 
-      CompactedJsonLd(iri, context, input, frameOnRootId = true).accepted.json.removeKeys(keywords.context) shouldEqual
+      CompactedJsonLd.frame(iri, context, input).accepted.json.removeKeys(keywords.context) shouldEqual
         json"""{"id": "john-doé", "@type": "Person"}"""
     }
 
     "be constructed successfully from a multi-root json when using framing" in {
       val input     = jsonContentOf("/jsonld/compacted/input-multiple-roots.json")
-      val compacted = CompactedJsonLd(iri, context, input, frameOnRootId = true).accepted
+      val compacted = CompactedJsonLd.frame(iri, context, input).accepted
       compacted.json.removeKeys(keywords.context) shouldEqual json"""{"id": "john-doé", "@type": "Person"}"""
     }
 

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/CompactedJsonLdSpec.scala
@@ -2,12 +2,8 @@ package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
 import ch.epfl.bluebrain.nexus.delta.rdf.Fixtures
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
-import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.UnexpectedJsonLd
-import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schema
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import io.circe.JsonObject
-import io.circe.syntax._
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -23,63 +19,50 @@ class CompactedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures wi
     val rootBNode             = BNode.random
 
     "be constructed successfully" in {
-      val compacted = JsonLd.compact(expanded, context, iri).accepted
+      val compacted = CompactedJsonLd(iri, context, expanded).accepted
       compacted.json.removeKeys(keywords.context) shouldEqual expectedCompacted.removeKeys(keywords.context)
       compacted.ctx shouldEqual context
       compacted.rootId shouldEqual iri
     }
 
     "be constructed successfully with a root blank node" in {
-      val compacted = JsonLd.compact(expandedNoId, context, rootBNode).accepted
+      val compacted = CompactedJsonLd(rootBNode, context, expandedNoId).accepted
       compacted.json.removeKeys(keywords.context) shouldEqual expectedCompactedNoId.removeKeys(keywords.context)
       compacted.rootId shouldEqual rootBNode
     }
 
-    "fail to find the root Iri from a multi-root json" in {
+    "be constructed from a multi-root json" in {
       val input = jsonContentOf("/jsonld/compacted/input-multiple-roots.json")
-      JsonLd.compact(input, context, iri).rejectedWith[UnexpectedJsonLd]
+
+      CompactedJsonLd(iri, context, input).accepted.json.removeKeys(keywords.context) shouldEqual
+        json"""{"@graph": [{"id": "john-doé", "@type": "Person"}, {"id": "batman", "@type": "schema:Hero"} ] }"""
+    }
+
+    "be framed from a multi-root json" in {
+      val input = jsonContentOf("/jsonld/compacted/input-multiple-roots.json")
+
+      CompactedJsonLd(iri, context, input, frameOnRootId = true).accepted.json.removeKeys(keywords.context) shouldEqual
+        json"""{"id": "john-doé", "@type": "Person"}"""
     }
 
     "be constructed successfully from a multi-root json when using framing" in {
       val input     = jsonContentOf("/jsonld/compacted/input-multiple-roots.json")
-      val compacted = JsonLd.frame(input, context, iri).accepted
+      val compacted = CompactedJsonLd(iri, context, input, frameOnRootId = true).accepted
       compacted.json.removeKeys(keywords.context) shouldEqual json"""{"id": "john-doé", "@type": "Person"}"""
     }
 
-    "add literals" in {
-      val compacted =
-        CompactedJsonLd(JsonObject("@id" -> iri.asJson), context, iri)
-      val result    = compacted.add("tags", "first").add("tags", 2).add("tags", 30L).add("tags", false)
-      result.json.removeKeys(keywords.context) shouldEqual json"""{"@id": "$iri", "tags": [ "first", 2, 30, false ]}"""
-    }
-
-    "add @type Iri to existing @type" in {
-      val (person, hero) = (schema.Person, schema + "Hero")
-      val obj            = json"""{"@id": "$iri", "@type": "$person"}""".asObject.value
-      val compacted      = CompactedJsonLd(obj, context, iri)
-      val result         = compacted.addType(hero)
-      result.json.removeKeys(keywords.context) shouldEqual json"""{"@id": "$iri", "@type": ["$person", "$hero"]}"""
-    }
-
-    "add @type Iri" in {
-      val obj       = json"""{"@id": "$iri"}""".asObject.value
-      val compacted = CompactedJsonLd(obj, context, iri)
-      val result    = compacted.addType(schema.Person)
-      result.json.removeKeys(keywords.context) shouldEqual json"""{"@id": "$iri", "@type": "${schema.Person}"}"""
-    }
-
     "be converted to expanded form" in {
-      val compacted = JsonLd.compact(expanded, context, iri).accepted
-      compacted.toExpanded.accepted shouldEqual JsonLd.expandedUnsafe(expanded, iri)
+      val compacted = CompactedJsonLd(iri, context, expanded).accepted
+      compacted.toExpanded.accepted shouldEqual ExpandedJsonLd(expanded).accepted
     }
 
     "be converted to expanded form with a root blank node" in {
-      val compacted = JsonLd.compact(expandedNoId, context, rootBNode).accepted
-      compacted.toExpanded.accepted shouldEqual JsonLd.expandedUnsafe(expandedNoId, rootBNode)
+      val compacted = CompactedJsonLd(rootBNode, context, expandedNoId).accepted
+      compacted.toExpanded.accepted shouldEqual ExpandedJsonLd.expanded(expandedNoId).rightValue.replaceId(rootBNode)
     }
 
     "be converted to graph" in {
-      val compacted = JsonLd.compact(expanded, context, iri).accepted
+      val compacted = CompactedJsonLd(iri, context, expanded).accepted
       val graph     = compacted.toGraph.accepted
       val expected  = contentOf("ntriples.nt", "bnode" -> bNode(graph).rdfFormat, "rootNode" -> iri.rdfFormat)
       graph.rootNode shouldEqual iri
@@ -87,7 +70,7 @@ class CompactedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures wi
     }
 
     "be converted to graph with a root blank node" in {
-      val compacted = JsonLd.compact(expandedNoId, context, rootBNode).accepted
+      val compacted = CompactedJsonLd(rootBNode, context, expandedNoId).accepted
       val graph     = compacted.toGraph.accepted
       val expected  = contentOf("ntriples.nt", "bnode" -> bNode(graph).rdfFormat, "rootNode" -> rootBNode.rdfFormat)
       graph.rootNode shouldEqual rootBNode

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdCursorSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdCursorSpec.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schema
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError.DecodingFailure
 import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, EitherValuable, TestHelpers}
@@ -18,7 +17,7 @@ class ExpandedJsonLdCursorSpec
 
   "An ExpandedJsonLdCursor" should {
     val json   = jsonContentOf("/jsonld/decoder/cocktail.json")
-    val jsonLd = JsonLd.expandedUnsafe(json, BNode.random)
+    val jsonLd = ExpandedJsonLd.expanded(json).rightValue
     val cursor = ExpandedJsonLdCursor(jsonLd)
 
     val drinks      = schema + "drinks"

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/ExpandedJsonLdSpec.scala
@@ -1,13 +1,14 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld
 
 import ch.epfl.bluebrain.nexus.delta.rdf.Fixtures
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
-import ch.epfl.bluebrain.nexus.delta.rdf.RdfError.UnexpectedJsonLd
-import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{schema, xsd}
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schema
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.collection.immutable.VectorMap
 
 class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
 
@@ -17,121 +18,65 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
     val expectedExpanded = jsonContentOf("expanded.json")
 
     "be constructed successfully" in {
-      JsonLd.expand(compacted).accepted shouldEqual JsonLd.expandedUnsafe(expectedExpanded, iri)
+      ExpandedJsonLd(compacted).accepted shouldEqual ExpandedJsonLd.expanded(expectedExpanded).rightValue
     }
 
     "be constructed successfully without @id" in {
       val name             = vocab + "name"
       val expectedExpanded = json"""[{"@type": ["${schema.Person}"], "$name": [{"@value": "Me"} ] } ]"""
       val compacted        = json"""{"@type": "Person", "name": "Me"}""".addContext(context.contextObj)
-      val expanded         = JsonLd.expand(compacted).accepted
-      expanded shouldEqual JsonLd.expandedUnsafe(expectedExpanded, expanded.rootId)
+      val expanded         = ExpandedJsonLd(compacted).accepted
+      expanded.json shouldEqual expectedExpanded
       expanded.rootId shouldBe a[BNode]
     }
 
     "be constructed successfully with remote contexts" in {
       val compacted = jsonContentOf("/jsonld/expanded/input-with-remote-context.json")
-      JsonLd.expand(compacted).accepted shouldEqual JsonLd.expandedUnsafe(expectedExpanded, iri)
+      ExpandedJsonLd(compacted).accepted shouldEqual ExpandedJsonLd.expanded(expectedExpanded).rightValue
     }
 
     "be constructed successfully with injected @id" in {
       val compactedNoId = compacted.removeKeys("id")
-      JsonLd.expand(compactedNoId).accepted.replaceId(iri) shouldEqual JsonLd.expandedUnsafe(expectedExpanded, iri)
+      ExpandedJsonLd(compactedNoId).accepted.replaceId(iri) shouldEqual
+        ExpandedJsonLd.expanded(expectedExpanded).rightValue
     }
 
     "be constructed empty (ignoring @id)" in {
       val compacted = json"""{"@id": "$iri"}"""
-      val expanded  = JsonLd.expand(compacted).accepted
-      expanded shouldEqual JsonLd.expandedUnsafe(json"""[ {} ]""", expanded.rootId)
+      val expanded  = ExpandedJsonLd(compacted).accepted
+      expanded.json shouldEqual json"""[ {} ]"""
       expanded.rootId shouldBe a[BNode]
     }
 
-    "fail to be constructed when there are multiple root objects" in {
-      val wrongInput = jsonContentOf("/jsonld/expanded/wrong-input-multiple-roots.json")
-      JsonLd.expand(wrongInput).rejectedWith[UnexpectedJsonLd]
+    "be constructed with multiple root objects" in {
+      val multiRoot = jsonContentOf("/jsonld/expanded/input-multiple-roots.json")
+      val batmanIri = iri"http://example.com/batman"
+      val john      = json"""{"@id": "$iri", "http://example.com/name": [{"@value": "John"} ] }""".asObject.value
+      val batman    = json"""{"@id": "$batmanIri", "http://example.com/name": [{"@value": "Batman"} ] }""".asObject.value
+
+      ExpandedJsonLd(multiRoot).accepted shouldEqual ExpandedJsonLd(iri, VectorMap(iri -> john, batmanIri -> batman))
+    }
+
+    "change its root object" in {
+      val multiRoot = jsonContentOf("/jsonld/expanded/input-multiple-roots.json")
+      val batmanIri = iri"http://example.com/batman"
+      val john      = json"""{"@id": "$iri", "http://example.com/name": [{"@value": "John"} ] }""".asObject.value
+      val batman    = json"""{"@id": "$batmanIri", "http://example.com/name": [{"@value": "Batman"} ] }""".asObject.value
+      val expanded  = ExpandedJsonLd(multiRoot).accepted
+      expanded.changeRootIfExists(batmanIri).value shouldEqual
+        ExpandedJsonLd(batmanIri, VectorMap(batmanIri -> batman, iri -> john))
+      expanded.changeRootIfExists(schema.base) shouldEqual None
     }
 
     "replace @id" in {
       val newIri   = iri"http://example.com/myid"
-      val expanded = JsonLd.expand(compacted).accepted.replaceId(newIri)
+      val expanded = ExpandedJsonLd(compacted).accepted.replaceId(newIri)
       expanded.rootId shouldEqual newIri
       expanded.json shouldEqual expectedExpanded.replace(keywords.id -> iri, newIri)
     }
 
-    "fetch root @type" in {
-      val compacted = json"""{"@id": "$iri", "@type": "Person"}""".addContext(context.contextObj)
-      val expanded  = JsonLd.expand(compacted).accepted
-      expanded.types shouldEqual List(schema.Person)
-
-      val compactedMultipleTypes = json"""{"@id": "$iri", "@type": ["Person", "Hero"]}""".addContext(context.contextObj)
-      val resultMultiple         = JsonLd.expand(compactedMultipleTypes).accepted
-      resultMultiple.types shouldEqual List(schema.Person, vocab + "Hero")
-    }
-
-    "fetch @id values" in {
-      val compacted = json"""{"@id": "$iri", "customid": "Person"}""".addContext(context.contextObj)
-      val expanded  = JsonLd.expand(compacted).accepted
-      expanded.ids(vocab + "customid") shouldEqual List(base + "Person")
-
-      val compactedMultipleCustomId =
-        json"""{"@id": "$iri", "customid": ["Person", "Hero"]}""".addContext(context.contextObj)
-      val resultMultiple            = JsonLd.expand(compactedMultipleCustomId).accepted
-      resultMultiple.ids(vocab + "customid") shouldEqual List(base + "Person", base + "Hero")
-    }
-
-    "fetch @value values" in {
-      val compacted = json"""{"@id": "$iri", "tags": "a"}""".addContext(context.contextObj)
-      val expanded  = JsonLd.expand(compacted).accepted
-      expanded.literals[String](vocab + "tags") shouldEqual List("a")
-
-      val compactedMultipleTags = json"""{"@id": "$iri", "tags": ["a", "b", "c"]}""".addContext(context.contextObj)
-      val resultMultiple        = JsonLd.expand(compactedMultipleTags).accepted
-      resultMultiple.literals[String](vocab + "tags") shouldEqual List("a", "b", "c")
-    }
-
-    "return empty fetching non existing keys" in {
-      val expanded = JsonLd.expand(compacted.removeKeys("@type")).accepted
-      expanded.literals[String](vocab + "non-existing") shouldEqual List.empty[String]
-      expanded.ids(vocab + "non-existing") shouldEqual List.empty[Iri]
-      expanded.types shouldEqual List.empty[Iri]
-    }
-
-    "add @id value" in {
-      val expanded = JsonLd.expandedUnsafe(json"""[{"@id": "$iri"}]""", iri)
-      val friends  = vocab + "friends"
-      val batman   = base + "batman"
-      val robin    = base + "robin"
-      expanded.add(friends, batman).add(friends, robin).json shouldEqual
-        json"""[{"@id": "$iri", "$friends": [{"@id": "$batman"}, {"@id": "$robin"} ] } ]"""
-    }
-
-    "add @type Iri to existing @type" in {
-      val (person, animal, hero) = (schema.Person, schema + "Animal", schema + "Hero")
-      val expanded               = JsonLd.expandedUnsafe(json"""[{"@id": "$iri", "@type": ["$person", "$animal"] } ]""", iri)
-      expanded.addType(hero).types shouldEqual List(person, animal, hero)
-    }
-
-    "add @type Iri" in {
-      val expanded = JsonLd.expandedUnsafe(json"""[{"@id": "$iri"}]""", iri)
-      expanded.addType(schema.Person).types shouldEqual List(schema.Person)
-    }
-
-    "add @value value" in {
-      val expanded                       = JsonLd.expandedUnsafe(json"""[{"@id": "$iri"}]""", iri)
-      val tags                           = vocab + "tags"
-      val (tag1, tag2, tag3, tag4, tag5) = ("first", 2, false, 30L, 3.14)
-      expanded
-        .add(tags, tag1)
-        .add(tags, tag2, includeDataType = true)
-        .add(tags, tag3)
-        .add(tags, tag4)
-        .add(tags, tag5, includeDataType = true)
-        .json shouldEqual
-        json"""[{"@id": "$iri", "$tags": [{"@value": "$tag1"}, {"@type": "${xsd.integer}", "@value": $tag2 }, {"@value": $tag3}, {"@value": $tag4}, {"@type": "${xsd.double}", "@value": $tag5 } ] } ]"""
-    }
-
     "be converted to compacted form" in {
-      val expanded = JsonLd.expand(compacted).accepted
+      val expanded = ExpandedJsonLd(compacted).accepted
       val result   = expanded.toCompacted(context).accepted
       result.json.removeKeys(keywords.context) shouldEqual compacted.removeKeys(keywords.context)
     }
@@ -139,22 +84,22 @@ class ExpandedJsonLdSpec extends AnyWordSpecLike with Matchers with Fixtures {
     "be converted to compacted form without @id" in {
       val compacted = json"""{"@type": "Person", "name": "Me"}""".addContext(context.contextObj)
 
-      val expanded = JsonLd.expand(compacted).accepted
+      val expanded = ExpandedJsonLd(compacted).accepted
       val result   = expanded.toCompacted(context).accepted
       result.rootId shouldEqual expanded.rootId
       result.json.removeKeys(keywords.context) shouldEqual compacted.removeKeys(keywords.context)
     }
 
     "be empty" in {
-      JsonLd.expand(json"""[{"@id": "http://example.com/id", "a": "b"}]""").accepted.isEmpty shouldEqual true
+      ExpandedJsonLd(json"""[{"@id": "http://example.com/id", "a": "b"}]""").accepted.isEmpty shouldEqual true
     }
 
     "not be empty" in {
-      JsonLd.expand(compacted).accepted.isEmpty shouldEqual false
+      ExpandedJsonLd(compacted).accepted.isEmpty shouldEqual false
     }
 
     "be converted to graph" in {
-      val expanded = JsonLd.expand(compacted).accepted
+      val expanded = ExpandedJsonLd(compacted).accepted
       val graph    = expanded.toGraph.rightValue
       val expected = contentOf("ntriples.nt", "bnode" -> bNode(graph).rdfFormat, "rootNode" -> iri.rdfFormat)
       graph.rootNode shouldEqual iri

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/decoder/JsonLdDecoderSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/decoder/JsonLdDecoderSpec.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import cats.data.NonEmptyList
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schema
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{JsonLdContext, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError.DecodingDerivationFailure
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderSpec.Drink.{Cocktail, Volume}
@@ -38,7 +38,7 @@ class JsonLdDecoderSpec
   "A JsonLdDecoder" should {
 
     val json                                          = jsonContentOf("/jsonld/decoder/cocktail.json")
-    val jsonLd                                        = JsonLd.expand(json).accepted
+    val jsonLd                                        = ExpandedJsonLd(json).accepted
     val context                                       = jsonContentOf("/jsonld/decoder/context.json")
     val ctx                                           = JsonLdContext(context.topContextValueOrEmpty).accepted
     implicit val config: Configuration                = Configuration.default.copy(context = ctx)

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngineSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngineSpec.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.rdf.shacl
 
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
@@ -20,8 +20,8 @@ class ShaclEngineSpec extends AnyWordSpecLike with Matchers with TestHelpers wit
 
     implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(contexts.shacl -> shaclResolvedCtx)
 
-    val schemaGraph   = Graph(JsonLd.expand(schema).accepted).rightValue
-    val resourceGraph = Graph(JsonLd.expand(resource).accepted).rightValue
+    val schemaGraph   = Graph(ExpandedJsonLd(schema).accepted).rightValue
+    val resourceGraph = Graph(ExpandedJsonLd(resource).accepted).rightValue
 
     "validate data" in {
       val report = ShaclEngine(resourceGraph.model, schemaGraph.model, reportDetails = true).accepted
@@ -34,13 +34,13 @@ class ShaclEngineSpec extends AnyWordSpecLike with Matchers with TestHelpers wit
 
     "fail validating shapes if unexpected field value" in {
       val wrongSchema = schema.replace("minCount" -> 1, "wrong")
-      val graph       = Graph(JsonLd.expand(wrongSchema).accepted).rightValue
+      val graph       = Graph(ExpandedJsonLd(wrongSchema).accepted).rightValue
       ShaclEngine(graph.model, reportDetails = true).accepted.isValid() shouldEqual false
     }
 
     "fail validating data if not matching nodes" in {
       val resourceChangedType = resource.replace(keywords.tpe -> "Custom", "Other")
-      val resourceGraph       = Graph(JsonLd.expand(resourceChangedType).accepted).rightValue
+      val resourceGraph       = Graph(ExpandedJsonLd(resourceChangedType).accepted).rightValue
       val report              = ShaclEngine(resourceGraph.model, schemaGraph.model, reportDetails = true).accepted
       report.isValid() shouldEqual false
       report.targetedNodes shouldEqual 0
@@ -48,7 +48,7 @@ class ShaclEngineSpec extends AnyWordSpecLike with Matchers with TestHelpers wit
 
     "fail validating data if wrong field type" in {
       val resourceChangedNumber = resource.replace("number" -> 24, "Other")
-      val resourceGraph         = Graph(JsonLd.expand(resourceChangedNumber).accepted).rightValue
+      val resourceGraph         = Graph(ExpandedJsonLd(resourceChangedNumber).accepted).rightValue
       ShaclEngine(resourceGraph.model, schemaGraph.model, reportDetails = true).accepted shouldEqual
         ValidationReport(false, 10, jsonContentOf("shacl/failed_number.json"))
     }

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReportSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReportSpec.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.rdf.shacl
 
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.testkit.{EitherValuable, IOValues, TestHelpers}
 import io.circe.Json
@@ -26,7 +26,7 @@ class ValidationReportSpec
     RemoteContextResolution.fixed(contexts.shacl -> shaclResolvedCtx)
 
   private def resource(json: Json): Resource        =
-    Graph(JsonLd.expand(json).accepted).rightValue.model.createResource()
+    Graph(ExpandedJsonLd(json).accepted).rightValue.model.createResource()
 
   "A ValidationReport" should {
     val conforms = jsonContentOf("/shacl/conforms.json")

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resources.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resources.scala
@@ -269,7 +269,7 @@ object Resources {
           for {
             graph <- toGraph(c.id, c.expanded)
             _     <- validate(c.project, c.schema, c.id, graph)
-            types  = c.expanded.types.toSet
+            types  = c.expanded.cursor.getTypes.getOrElse(Set.empty)
             t     <- IOUtils.instant
           } yield ResourceCreated(c.id, c.project, c.schema, types, c.source, c.compacted, c.expanded, 1L, t, c.subject)
 
@@ -290,7 +290,7 @@ object Resources {
           for {
             graph <- toGraph(c.id, c.expanded)
             _     <- validate(s.project, s.schema, c.id, graph)
-            types  = c.expanded.types.toSet
+            types  = c.expanded.cursor.getTypes.getOrElse(Set.empty)
             time  <- IOUtils.instant
           } yield ResourceUpdated(c.id, c.project, types, c.source, c.compacted, c.expanded, s.rev + 1, time, c.subject)
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{nxv, schemas}
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.DataResource
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourceRef.Latest
@@ -31,7 +31,7 @@ object ResourceGen extends OptionValues with IOValues {
       deprecated: Boolean = false,
       subject: Subject = Anonymous
   )(implicit resolution: RemoteContextResolution): Current = {
-    val expanded  = JsonLd.expand(source).accepted.replaceId(id)
+    val expanded  = ExpandedJsonLd(source).accepted.replaceId(id)
     val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
     Current(
       id,
@@ -58,7 +58,7 @@ object ResourceGen extends OptionValues with IOValues {
       schema: ResourceRef = Latest(schemas.resources),
       tags: Map[Label, Long] = Map.empty
   )(implicit resolution: RemoteContextResolution): Resource = {
-    val expanded  = JsonLd.expand(source).accepted.replaceId(id)
+    val expanded  = ExpandedJsonLd(source).accepted.replaceId(id)
     val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
     Resource(id, project, tags, schema, source, compacted, expanded)
   }

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/SchemaGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/SchemaGen.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.SchemaResource
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Label
@@ -48,7 +48,7 @@ object SchemaGen extends OptionValues with IOValues with EitherValuable {
       source: Json,
       tags: Map[Label, Long] = Map.empty
   )(implicit resolution: RemoteContextResolution): Schema = {
-    val expanded  = JsonLd.expand(source).accepted.replaceId(id)
+    val expanded  = ExpandedJsonLd(source).accepted.replaceId(id)
     val graph     = expanded.toGraph.rightValue
     val compacted = expanded.toCompacted(source.topContextValueOrEmpty).accepted
     Schema(id, project, tags, source, compacted, expanded, graph)

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/serialization/KryoSerializationInitSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/serialization/KryoSerializationInitSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.serialization.SerializationExtension
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.JsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.service.syntax._
@@ -30,7 +30,7 @@ class KryoSerializerInitSpec
   private val serialization                         = SerializationExtension(system)
   implicit private val rcr: RemoteContextResolution = RemoteContextResolution.fixed()
 
-  private val expanded = JsonLd.expand(jsonContentOf("/kryo/expanded.json")).accepted
+  private val expanded = ExpandedJsonLd(jsonContentOf("/kryo/expanded.json")).accepted
   private val graph    = Graph(expanded).rightValue
   private val iri      = iri"http://nexus.example.com/john-doé"
 
@@ -54,7 +54,7 @@ class KryoSerializerInitSpec
 
   "An Anonymous Graph Kryo serialization" should {
     val expandedJson = jsonContentOf("/kryo/expanded.json").removeAll(keywords.id -> iri)
-    val graphNoId    = Graph(JsonLd.expand(expandedJson).accepted).rightValue
+    val graphNoId    = Graph(ExpandedJsonLd(expandedJson).accepted).rightValue
 
     "succeed" in {
       // Find the Serializer for it
@@ -105,7 +105,7 @@ class KryoSerializerInitSpec
       val deserialized      = serialization.deserialize(serialized.get, graph.model.getClass)
       deserialized.isSuccess shouldEqual true
       val deserializedModel = deserialized.success.value
-      Graph(graph.rootNode, deserializedModel).triples shouldEqual graph.triples
+      Graph(graph.rootNode, deserializedModel, singleRoot = true).triples shouldEqual graph.triples
     }
   }
 

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/serialization/KryoSerializationInitSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/serialization/KryoSerializationInitSpec.scala
@@ -105,7 +105,7 @@ class KryoSerializerInitSpec
       val deserialized      = serialization.deserialize(serialized.get, graph.model.getClass)
       deserialized.isSuccess shouldEqual true
       val deserializedModel = deserialized.success.value
-      Graph(graph.rootNode, deserializedModel, singleRoot = true).triples shouldEqual graph.triples
+      Graph.unsafe(graph.rootNode, deserializedModel).triples shouldEqual graph.triples
     }
   }
 


### PR DESCRIPTION
This work allows to have Json-LD documents with [single](https://json-ld.org/playground/#startTab=tab-expanded&json-ld=%7B%22%40context%22%3A%22http%3A%2F%2Fschema.org%2F%22%2C%22%40type%22%3A%22Person%22%2C%22name%22%3A%22Jane%20Doe%22%7D) or [multiple](https://json-ld.org/playground/#startTab=tab-expanded&json-ld=%7B%22%40context%22%3A%7B%22%40vocab%22%3A%22http%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%22%7D%2C%22%40graph%22%3A%5B%7B%22%40id%22%3A%22http%3A%2F%2Fexample.org%2Flibrary%2Fthe-republic%22%2C%22title%22%3A%22The%20Republic%22%7D%2C%7B%22%40id%22%3A%22http%3A%2F%2Fexample.org%2Flibrary%2Fthe-hobbit%22%2C%22title%22%3A%22The%20Hobbit%22%7D%5D%7D) root entries.

This can be useful for posting resources in certain situations (this work is currently only partially supported on 1.4.x) and also enables us to have the "fat schema" containing all the owl:imports resolved in the same expanded jsonld document.

I've also removed unnecessary methods on compaction/expansion