### PR TITLE
Allow getting cache per project (or whatever composite key we want)

### DIFF
--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -220,7 +220,7 @@ app {
     key-value-store {
       ask-timeout = 15 seconds
       consistency-timeout = 5 seconds
-      retry = ${app.defaults.retry-strategy}
+      retry = ${app.defaults.exponential-retry-strategy}
     }
     # default pagination configuration
     pagination {

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/MainSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/MainSpec.scala
@@ -2,20 +2,43 @@ package ch.epfl.bluebrain.nexus.delta
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.typed.ActorSystem
-import ch.epfl.bluebrain.nexus.delta.config.AppConfig
 import ch.epfl.bluebrain.nexus.delta.service.plugin.PluginsLoader.PluginLoaderConfig
 import ch.epfl.bluebrain.nexus.testkit.{IORef, IOValues}
 import com.typesafe.config.impl.ConfigImpl
 import izumi.distage.model.Locator
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{Inspectors, OptionValues}
+import org.scalatest.{BeforeAndAfterAll, Inspectors, OptionValues}
 
-import java.nio.file.Files
+import java.io.File
+import java.nio.file.{Files, Path}
+import java.util.UUID
+import scala.reflect.io.Directory
 
-class MainSpec extends AnyWordSpecLike with Matchers with Inspectors with IOValues with OptionValues {
+class MainSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with Inspectors
+    with IOValues
+    with OptionValues {
 
-  private val folder = Files.createTempDirectory("ddata")
+  private val folder = s"/tmp/delta-cache/${UUID.randomUUID()}"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    Files.createDirectories(Path.of(folder))
+    System.clearProperty("app.database.flavour")
+    System.clearProperty("akka.cluster.distributed-data.durable.lmdb.dir")
+    ConfigImpl.reloadSystemPropertiesConfig()
+  }
+
+  override protected def afterAll(): Unit = {
+    System.clearProperty("app.database.flavour")
+    System.clearProperty("akka.cluster.distributed-data.durable.lmdb.dir")
+    new Directory(new File(folder)).deleteRecursively()
+    super.afterAll()
+  }
 
   "Main" should {
 
@@ -23,8 +46,7 @@ class MainSpec extends AnyWordSpecLike with Matchers with Inspectors with IOValu
       val flavours = List("cassandra", "postgres")
       forAll(flavours) { flavour =>
         System.setProperty("app.database.flavour", flavour)
-        System.setProperty("akka.remote.artery.canonical.port", "0")
-        System.setProperty("akka.cluster.distributed-data.durable.lmdb.dir", folder.toString)
+        System.setProperty("akka.cluster.distributed-data.durable.lmdb.dir", folder)
         ConfigImpl.reloadSystemPropertiesConfig()
 
         val ref: IORef[Option[Locator]] = IORef.unsafe(None)
@@ -32,8 +54,6 @@ class MainSpec extends AnyWordSpecLike with Matchers with Inspectors with IOValu
         Main.start(locator => ref.set(Some(locator)), PluginLoaderConfig()).accepted
 
         val locator = ref.get.accepted.value
-        locator.get[AppConfig].database.flavour.toString.toLowerCase shouldEqual flavour
-
         // Testing the actor system and shut it down
         val system  = locator.get[ActorSystem[Nothing]]
         val testkit = ActorTestKit(system)
@@ -42,10 +62,6 @@ class MainSpec extends AnyWordSpecLike with Matchers with Inspectors with IOValu
         probe.ref ! "Message"
         probe.expectMessage("Message")
         testkit.shutdownTestKit()
-
-        System.clearProperty("app.database.flavour")
-        System.clearProperty("akka.remote.artery.canonical.port")
-        System.clearProperty("akka.cluster.distributed-data.durable.lmdb.dir")
       }
     }
   }

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViews.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViews.scala
@@ -15,7 +15,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewValu
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
-import ch.epfl.bluebrain.nexus.delta.sdk.cache.{KeyValueStore, KeyValueStoreConfig}
+import ch.epfl.bluebrain.nexus.delta.sdk.cache.{CompositeKeyValueStore, KeyValueStoreConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.ExpandIri
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdSourceProcessor.JsonLdSourceDecoder
@@ -239,7 +239,7 @@ final class BlazegraphViews(
       ordering: Ordering[BlazegraphViewResource]
   ): UIO[UnscoredSearchResults[BlazegraphViewResource]] = index.values
     .map { resources =>
-      val results = resources.filter(params.matches).toVector.sorted(ordering)
+      val results = resources.filter(params.matches).sorted(ordering)
       UnscoredSearchResults(
         results.size.toLong,
         results.map(UnscoredResultEntry(_)).slice(pagination.from, pagination.from + pagination.size)
@@ -285,7 +285,7 @@ final class BlazegraphViews(
       evaluationResult <- agg.evaluate(identifier(cmd.project, cmd.id), cmd).mapError(_.value)
       resourceOpt       = evaluationResult.state.toResource(project.apiMappings, project.base)
       res              <- IO.fromOption(resourceOpt, UnexpectedInitialState(cmd.id, project.ref))
-      _                <- index.put(BlazegraphViewKey(cmd.project, cmd.id), res)
+      _                <- index.put(cmd.project, cmd.id, res)
     } yield res
 
   private def identifier(project: ProjectRef, id: Iri): String =
@@ -326,12 +326,10 @@ object BlazegraphViews {
   type ValidatePermission = Permission => IO[PermissionIsNotDefined, Unit]
   type ValidateRef        = ViewRef => IO[InvalidViewReference, Unit]
 
-  final private[blazegraph] case class BlazegraphViewKey(project: ProjectRef, iri: Iri)
-
   type BlazegraphViewsAggregate =
     Aggregate[String, BlazegraphViewState, BlazegraphViewCommand, BlazegraphViewEvent, BlazegraphViewRejection]
 
-  type BlazegraphViewsCache = KeyValueStore[BlazegraphViewKey, BlazegraphViewResource]
+  type BlazegraphViewsCache = CompositeKeyValueStore[ProjectRef, Iri, BlazegraphViewResource]
 
   private[blazegraph] def next(
       state: BlazegraphViewState,
@@ -528,7 +526,7 @@ object BlazegraphViews {
   private def cache(config: BlazegraphViewsConfig)(implicit as: ActorSystem[Nothing]): BlazegraphViewsCache = {
     implicit val cfg: KeyValueStoreConfig             = config.keyValueStore
     val clock: (Long, BlazegraphViewResource) => Long = (_, resource) => resource.rev
-    KeyValueStore.distributed(moduleType, clock)
+    CompositeKeyValueStore(moduleType, clock)
   }
   private def startIndexing(
       config: BlazegraphViewsConfig,
@@ -544,7 +542,7 @@ object BlazegraphViews {
           .mapAsync(config.indexing.concurrency)(envelope =>
             views
               .fetch(IriSegment(envelope.event.id), envelope.event.project)
-              .redeemCauseWith(_ => IO.unit, res => index.put(BlazegraphViewKey(res.value.project, res.value.id), res))
+              .redeemCauseWith(_ => IO.unit, res => index.put(res.value.project, res.value.id, res))
           )
       ),
       retryStrategy = RetryStrategy(

--- a/delta/plugins/storage/src/main/resources/storage.conf
+++ b/delta/plugins/storage/src/main/resources/storage.conf
@@ -8,7 +8,7 @@ akka.actor {
   serialization-bindings {
     "ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageEvent"     = "circeStorage"
     "ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.FileEvent"           = "circeStorage"
-    "ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.Storages$StorageKey"    = "kryo"
+    "ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode$Iri"                              = "kryo"
   }
 }
 storage {

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/Storages.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/Storages.scala
@@ -17,7 +17,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model._
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.StorageAccess
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
-import ch.epfl.bluebrain.nexus.delta.sdk.cache.{KeyValueStore, KeyValueStoreConfig}
+import ch.epfl.bluebrain.nexus.delta.sdk.cache.{CompositeKeyValueStore, KeyValueStoreConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.ExpandIri
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdSourceProcessor.JsonLdSourceDecoder
@@ -280,7 +280,7 @@ final class Storages private (
       .named("fetchStorageByTag", moduleType)
 
   private def fetchDefaults(project: ProjectRef): IO[DefaultStorageNotFound, List[StorageResource]] =
-    cache.values
+    cache.get(project)
       .map { resources =>
         resources
           .filter(res => res.value.project == project && res.value.default && !res.deprecated)
@@ -314,9 +314,9 @@ final class Storages private (
       params: StorageSearchParams,
       ordering: Ordering[StorageResource]
   ): UIO[UnscoredSearchResults[StorageResource]] =
-    cache.values
+    params.project.fold(cache.values)(cache.get)
       .map { resources =>
-        val results = resources.filter(params.matches).toVector.sorted(ordering)
+        val results = resources.filter(params.matches).sorted(ordering)
         UnscoredSearchResults(
           results.size.toLong,
           results.map(UnscoredResultEntry(_)).slice(pagination.from, pagination.from + pagination.size)
@@ -413,7 +413,7 @@ final class Storages private (
       evaluationResult <- aggregate.evaluate(identifier(cmd.project, cmd.id), cmd).mapError(_.value)
       resourceOpt       = evaluationResult.state.toResource(project.apiMappings, project.base)
       res              <- IO.fromOption(resourceOpt, UnexpectedInitialState(cmd.id, project.ref))
-      _                <- cache.put(StorageKey(cmd.project, cmd.id), res)
+      _                <- cache.put(cmd.project, cmd.id, res)
     } yield res
 
   private def currentState(project: ProjectRef, iri: Iri): IO[StorageFetchRejection, StorageState] =
@@ -432,9 +432,8 @@ object Storages {
 
   private[storages] type StoragesAggregate =
     Aggregate[String, StorageState, StorageCommand, StorageEvent, StorageRejection]
-  private[storages] type StoragesCache     = KeyValueStore[StorageKey, StorageResource]
+  private[storages] type StoragesCache     = CompositeKeyValueStore[ProjectRef, Iri, StorageResource]
   private[storages] type StorageAccess     = (Iri, StorageValue) => IO[StorageNotAccessible, Unit]
-  final private[storages] case class StorageKey(project: ProjectRef, iri: Iri)
 
   /**
     * The storages module type.
@@ -500,7 +499,7 @@ object Storages {
   private def cache(config: StoragesConfig)(implicit as: ActorSystem[Nothing]): StoragesCache = {
     implicit val cfg: KeyValueStoreConfig      = config.keyValueStore
     val clock: (Long, StorageResource) => Long = (_, resource) => resource.rev
-    KeyValueStore.distributed(moduleType, clock)
+    CompositeKeyValueStore(moduleType, clock)
   }
 
   private def startIndexing(
@@ -517,7 +516,7 @@ object Storages {
           .mapAsync(config.indexing.concurrency)(envelope =>
             storages
               .fetch(IriSegment(envelope.event.id), envelope.event.project)
-              .redeemCauseWith(_ => IO.unit, res => index.put(StorageKey(res.value.project, res.value.id), res))
+              .redeemCauseWith(_ => IO.unit, res => index.put(res.value.project, res.value.id, res))
           )
       ),
       retryStrategy = RetryStrategy(

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/Storages.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/Storages.scala
@@ -280,7 +280,8 @@ final class Storages private (
       .named("fetchStorageByTag", moduleType)
 
   private def fetchDefaults(project: ProjectRef): IO[DefaultStorageNotFound, List[StorageResource]] =
-    cache.get(project)
+    cache
+      .get(project)
       .map { resources =>
         resources
           .filter(res => res.value.project == project && res.value.default && !res.deprecated)
@@ -314,7 +315,8 @@ final class Storages private (
       params: StorageSearchParams,
       ordering: Ordering[StorageResource]
   ): UIO[UnscoredSearchResults[StorageResource]] =
-    params.project.fold(cache.values)(cache.get)
+    params.project
+      .fold(cache.values)(cache.get)
       .map { resources =>
         val results = resources.filter(params.matches).sorted(ordering)
         UnscoredSearchResults(

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ConfigFixtures.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ConfigFixtures.scala
@@ -33,7 +33,7 @@ trait ConfigFixtures extends OptionValues {
     KeyValueStoreConfig(
       askTimeout = 5.seconds,
       consistencyTimeout = 2.seconds,
-      RetryStrategyConfig.AlwaysGiveUp
+      RetryStrategyConfig.ExponentialStrategyConfig(50.millis, 30.seconds, 20)
     )
 
   def indexing: IndexingConfig = IndexingConfig(1, RetryStrategyConfig.ConstantStrategyConfig(1.second, 10))

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/CompositeKeyValueStore.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/CompositeKeyValueStore.scala
@@ -1,0 +1,62 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.cache
+
+import akka.actor.typed.ActorSystem
+import cats.implicits._
+import monix.bio.UIO
+import scala.collection.concurrent.Map
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+
+/**
+  * Cache based on composite keys which distributes the entries on the two levels
+  * @param baseName the unique base name for the cache
+  * @param clock    a clock function that determines the next timestamp for a provided value
+  * @param firstLevelCache the first level cache which distributes the first level of keys
+  */
+final class CompositeKeyValueStore[K1, K2, V] private (
+    baseName: String,
+    clock: (Long, V) => Long,
+    firstLevelCache: Map[K1, KeyValueStore[K2, V]]
+)(implicit as: ActorSystem[Nothing], config: KeyValueStoreConfig) {
+
+  /**
+    * Fetches values for the provided first-level key.
+    */
+  def get(key1: K1): UIO[Vector[V]] = getOrCreate(key1).values
+
+  /**
+    * Fetches values for the composite key
+    */
+  def get(key1: K1, key2: K2): UIO[Option[V]] = getOrCreate(key1).get(key2)
+
+  /**
+    * Add or update the value for the provided composite key
+    */
+  def put(key1: K1, key2: K2, value: V): UIO[Unit] =
+    getOrCreate(key1).put(key2, value)
+
+  /**
+    * Returns all entries of the cache
+    */
+  def values: UIO[Vector[V]] = UIO.pure(firstLevelCache.values.toVector).flatMap(_.flatTraverse(_.values))
+
+  private def getOrCreate(key1: K1): KeyValueStore[K2, V] =
+    firstLevelCache.getOrElse(
+      key1, {
+        val keyValueStore = KeyValueStore.distributed[K2, V](s"$baseName-$key1", clock)
+        firstLevelCache.put(key1, keyValueStore)
+        keyValueStore
+      }
+    )
+}
+
+object CompositeKeyValueStore {
+
+  def apply[K1, K2, V](baseName: String, clock: (Long, V) => Long)(implicit
+      as: ActorSystem[Nothing],
+      config: KeyValueStoreConfig
+  ) =
+    new CompositeKeyValueStore[K1, K2, V](baseName, clock, new ConcurrentHashMap[K1, KeyValueStore[K2, V]]().asScala)
+
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/KeyValueStore.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/KeyValueStore.scala
@@ -88,8 +88,8 @@ trait KeyValueStore[K, V] {
     entries.map(_.values.toVector)
 
   /**
-   * @return a set of all the values in the store
-   */
+    * @return a set of all the values in the store
+    */
   def valuesSet: UIO[Set[V]] =
     entries.map(_.values.toSet)
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/KeyValueStore.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/KeyValueStore.scala
@@ -82,9 +82,15 @@ trait KeyValueStore[K, V] {
   def flushChanges: UIO[Unit]
 
   /**
-    * @return a set of all the values in the store
+    * @return a vector of all the values in the store
     */
-  def values: UIO[Set[V]] =
+  def values: UIO[Vector[V]] =
+    entries.map(_.values.toVector)
+
+  /**
+   * @return a set of all the values in the store
+   */
+  def valuesSet: UIO[Set[V]] =
     entries.map(_.values.toSet)
 
   /**

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/KeyValueStoreSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/cache/KeyValueStoreSpec.scala
@@ -119,7 +119,7 @@ class KeyValueStoreSpec
 
     "return all values" in {
       store.values.map {
-        _ shouldEqual Set(RevisionedValue(1, "b"), RevisionedValue(2, "aa"))
+        _ should contain theSameElementsAs Vector(RevisionedValue(1, "b"), RevisionedValue(2, "aa"))
       }
     }
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/utils/RouteHelpers.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/utils/RouteHelpers.scala
@@ -27,6 +27,9 @@ trait RouteHelpers extends AnyWordSpecLike with ScalatestRouteTest with ScalaFut
   private def consume(source: Source[ByteString, Any]): String =
     source.runFold("")(_ ++ _.utf8String).futureValue
 
+  // No need to persist any cache for tests related to routes
+  override def testConfigSource: String = "akka.cluster.distributed-data.durable.keys=[]"
+
   def asString(source: Source[ByteString, Any]): String =
     consume(source)
 

--- a/delta/service/src/main/resources/service.conf
+++ b/delta/service/src/main/resources/service.conf
@@ -5,11 +5,11 @@ service {
     "org.apache.jena.iri.IRI"                                                       = "kryo"
     "org.apache.jena.rdf.model.Model"                                               = "kryo"
     "ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph"                                 = "kryo"
+    "ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode$Iri"                              = "kryo"
     "ch.epfl.bluebrain.nexus.delta.sdk.model.ResourceF"                             = "kryo"
     "ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclAddress"                       = "kryo"
     "ch.epfl.bluebrain.nexus.delta.sdk.model.Label"                                 = "kryo"
     "ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef"                   = "kryo"
-    "ch.epfl.bluebrain.nexus.delta.service.resolvers.ResolversImpl$ResolverKey"     = "kryo"
     "ch.epfl.bluebrain.nexus.delta.service.identity.IdentitiesImpl$FetchGroups"     = "kryo"
     "ch.epfl.bluebrain.nexus.sourcing.projections.StreamSupervisor$Stop$"           = "kryo"
   }

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/acls/AclsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/acls/AclsImpl.scala
@@ -55,7 +55,7 @@ final class AclsImpl private (
   override def list(filter: AclAddressFilter): UIO[AclCollection]                              =
     index.values
       .map { as =>
-        val col             = AclCollection(as.toSeq: _*)
+        val col             = AclCollection(as: _*)
         val rootResourceOpt = col.value.get(AclAddress.Root) match {
           case None if filter.withAncestors => Initial.toResource(AclAddress.Root, minimum)
           case resourceOpt                  => resourceOpt

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/organizations/OrganizationsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/organizations/OrganizationsImpl.scala
@@ -101,7 +101,7 @@ final class OrganizationsImpl private (
   ): UIO[SearchResults.UnscoredSearchResults[OrganizationResource]] =
     cache.values
       .map { resources =>
-        val results = resources.filter(params.matches).toVector.sorted(ordering)
+        val results = resources.filter(params.matches).sorted(ordering)
         UnscoredSearchResults(
           results.size.toLong,
           results.map(UnscoredResultEntry(_)).slice(pagination.from, pagination.from + pagination.size)

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectsImpl.scala
@@ -121,7 +121,7 @@ final class ProjectsImpl private (
   ): UIO[SearchResults.UnscoredSearchResults[ProjectResource]]            =
     index.values
       .map { resources =>
-        val results = resources.filter(params.matches).toVector.sorted(ordering)
+        val results = resources.filter(params.matches).sorted(ordering)
         SearchResults(
           results.size.toLong,
           results.slice(pagination.from, pagination.from + pagination.size)

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/realms/RealmsImpl.scala
@@ -86,7 +86,7 @@ final class RealmsImpl private (
   ): UIO[SearchResults.UnscoredSearchResults[RealmResource]] =
     index.values
       .map { resources =>
-        val results = resources.filter(params.matches).toVector.sorted(ordering)
+        val results = resources.filter(params.matches).sorted(ordering)
         UnscoredSearchResults(
           results.size.toLong,
           results.map(UnscoredResultEntry(_)).slice(pagination.from, pagination.from + pagination.size)
@@ -182,7 +182,7 @@ object RealmsImpl {
   )(implicit as: ActorSystem[Nothing], sc: Scheduler, clock: Clock[UIO]): UIO[Realms] =
     for {
       i     <- UIO.delay(index(realmsConfig))
-      agg   <- aggregate(resolveWellKnown, i.values, realmsConfig)
+      agg   <- aggregate(resolveWellKnown, i.valuesSet, realmsConfig)
       realms = apply(agg, eventLog, i)
       _     <- UIO.delay(startIndexing(realmsConfig, eventLog, i, realms))
     } yield realms

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
@@ -9,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers._
 import ch.epfl.bluebrain.nexus.delta.sdk._
-import ch.epfl.bluebrain.nexus.delta.sdk.cache.{KeyValueStore, KeyValueStoreConfig}
+import ch.epfl.bluebrain.nexus.delta.sdk.cache.{CompositeKeyValueStore, KeyValueStoreConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdSourceProcessor.JsonLdSourceResolvingDecoder
 import ch.epfl.bluebrain.nexus.delta.sdk.model.IdSegment.IriSegment
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.{Caller, Identity}
@@ -24,7 +24,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchParams.ResolverSearc
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchResults.UnscoredSearchResults
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{Envelope, IdSegment, TagLabel}
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.UUIDF
-import ch.epfl.bluebrain.nexus.delta.service.resolvers.ResolversImpl.{ResolverKey, ResolversAggregate, ResolversCache}
+import ch.epfl.bluebrain.nexus.delta.service.resolvers.ResolversImpl.{ResolversAggregate, ResolversCache}
 import ch.epfl.bluebrain.nexus.delta.service.syntax._
 import ch.epfl.bluebrain.nexus.sourcing._
 import ch.epfl.bluebrain.nexus.sourcing.config.AggregateConfig
@@ -153,9 +153,10 @@ final class ResolversImpl private (
       params: ResolverSearchParams,
       ordering: Ordering[ResolverResource]
   ): UIO[UnscoredSearchResults[ResolverResource]] =
-    index.values
+    params.project
+      .fold(index.values)(index.get)
       .map { resources =>
-        val results = resources.filter(params.matches).toVector.sorted(ordering)
+        val results = resources.filter(params.matches).sorted(ordering)
         UnscoredSearchResults(
           results.size.toLong,
           results.map(UnscoredResultEntry(_)).slice(pagination.from, pagination.from + pagination.size)
@@ -179,7 +180,7 @@ final class ResolversImpl private (
       evaluationResult <- agg.evaluate(identifier(cmd.project, cmd.id), cmd).mapError(_.value)
       (am, base)        = project.apiMappings -> project.base
       res              <- IO.fromOption(evaluationResult.state.toResource(am, base), UnexpectedInitialState(cmd.id, project.ref))
-      _                <- index.put(ResolverKey(cmd.project, cmd.id), res)
+      _                <- index.put(cmd.project, cmd.id, res)
     } yield res
 
   private def identifier(projectRef: ProjectRef, id: Iri): String =
@@ -188,10 +189,8 @@ final class ResolversImpl private (
 
 object ResolversImpl {
 
-  final private[resolvers] case class ResolverKey(project: ProjectRef, iri: Iri)
-
   type ResolversAggregate = Aggregate[String, ResolverState, ResolverCommand, ResolverEvent, ResolverRejection]
-  type ResolversCache     = KeyValueStore[ResolverKey, ResolverResource]
+  type ResolversCache     = CompositeKeyValueStore[ProjectRef, Iri, ResolverResource]
 
   private val logger: Logger = Logger[ResolversImpl]
 
@@ -201,7 +200,7 @@ object ResolversImpl {
   private def cache(config: ResolversConfig)(implicit as: ActorSystem[Nothing]): ResolversCache = {
     implicit val cfg: KeyValueStoreConfig       = config.keyValueStore
     val clock: (Long, ResolverResource) => Long = (_, resource) => resource.rev
-    KeyValueStore.distributed(moduleType, clock)
+    CompositeKeyValueStore(moduleType, clock)
   }
 
   private def startIndexing(
@@ -218,7 +217,7 @@ object ResolversImpl {
           .mapAsync(config.indexing.concurrency)(envelope =>
             resolvers
               .fetch(IriSegment(envelope.event.id), envelope.event.project)
-              .redeemCauseWith(_ => IO.unit, res => index.put(ResolverKey(res.value.project, res.value.id), res))
+              .redeemCauseWith(_ => IO.unit, res => index.put(res.value.project, res.value.id, res))
           )
       ),
       retryStrategy = RetryStrategy(


### PR DESCRIPTION
Allows to speed up retrieving resolvers/storages per project as we don't need to scan them all anymore.