### PR TITLE
Added support for all resources listings on elasticsearch module

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
@@ -59,7 +59,7 @@ object Main extends BIOApp {
           UIO.delay(log.info("Starting Delta in normal mode")) >>
             UIO.delay(DeltaModule(appConfig, mergedConfig, classLoader))
 
-      (plugins, locator) <- WiringInitializer(modules, pluginsDef)(classLoader).handleError
+      (plugins, locator) <- WiringInitializer(modules, pluginsDef).handleError
       _                  <- preStart(locator).handleError
       _                  <- bootstrap(locator, plugins.flatMap(_.route)).handleError
     } yield ()

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/DeltaModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/DeltaModule.scala
@@ -9,16 +9,20 @@ import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler}
 import akka.stream.{Materializer, SystemMaterializer}
 import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.config.AppConfig
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioJsonContentOf
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk._
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils.databaseEventLog
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.{EventExchange, EventExchangeCollection}
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.{RdfExceptionHandler, RdfRejectionHandler}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.ServiceAccount
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectCountsCollection
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, ProjectCountsCollection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, Event}
+import ch.epfl.bluebrain.nexus.delta.sdk.plugin.PluginDef
 import ch.epfl.bluebrain.nexus.delta.service.utils.OwnerPermissionsScopeInitialization
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLog
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.DatabaseFlavour
@@ -45,6 +49,31 @@ class DeltaModule(appCfg: AppConfig, config: Config)(implicit classLoader: Class
   make[DatabaseFlavour].from { appCfg.database.flavour }
   make[BaseUri].from { appCfg.http.baseUri }
   make[ServiceAccount].from { appCfg.serviceAccount.value }
+  make[List[PluginDescription]].from { (pluginsDef: List[PluginDef]) => pluginsDef.map(_.info) }
+
+  make[RemoteContextResolution].from { (pluginsDef: List[PluginDef]) =>
+    RemoteContextResolution
+      .fixedIOResource(
+        contexts.acls          -> ioJsonContentOf("contexts/acls.json").memoizeOnSuccess,
+        contexts.error         -> ioJsonContentOf("contexts/error.json").memoizeOnSuccess,
+        contexts.identities    -> ioJsonContentOf("contexts/identities.json").memoizeOnSuccess,
+        contexts.offset        -> ioJsonContentOf("contexts/offset.json").memoizeOnSuccess,
+        contexts.organizations -> ioJsonContentOf("contexts/organizations.json").memoizeOnSuccess,
+        contexts.permissions   -> ioJsonContentOf("contexts/permissions.json").memoizeOnSuccess,
+        contexts.projects      -> ioJsonContentOf("contexts/projects.json").memoizeOnSuccess,
+        contexts.realms        -> ioJsonContentOf("contexts/realms.json").memoizeOnSuccess,
+        contexts.resolvers     -> ioJsonContentOf("contexts/resolvers.json").memoizeOnSuccess,
+        contexts.metadata      -> ioJsonContentOf("contexts/metadata.json").memoizeOnSuccess,
+        contexts.search        -> ioJsonContentOf("contexts/search.json").memoizeOnSuccess,
+        contexts.shacl         -> ioJsonContentOf("contexts/shacl.json").memoizeOnSuccess,
+        contexts.statistics    -> ioJsonContentOf("contexts/statistics.json").memoizeOnSuccess,
+        contexts.tags          -> ioJsonContentOf("contexts/tags.json").memoizeOnSuccess,
+        contexts.version       -> ioJsonContentOf("contexts/version.json").memoizeOnSuccess
+      )
+      .merge(pluginsDef.map(_.remoteContextResolution): _*)
+  }
+
+  many[ApiMappings].addSet { (pluginsDef: List[PluginDef]) => pluginsDef.map(_.apiMappings).toSet }
 
   make[Clock[UIO]].from(Clock[UIO])
   make[UUIDF].from(UUIDF.random)

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResolversModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResolversModule.scala
@@ -12,7 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventExchange
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils.databaseEventLog
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.{MultiResolution, ResolverContextResolution, ResolverEvent}
-import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.service.resolvers.ResolversImpl
 import ch.epfl.bluebrain.nexus.delta.service.utils.ResolverScopeInitialization
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLog
@@ -47,6 +47,8 @@ object ResolversModule extends ModuleDef {
   }
 
   many[ApiMappings].add(Resolvers.mappings)
+
+  many[ResourceToSchemaMappings].add(Resolvers.resourcesToSchemas)
 
   many[EventExchange].add { (resolvers: Resolvers, baseUri: BaseUri, cr: RemoteContextResolution) =>
     Resolvers.eventExchange(resolvers)(baseUri, cr)

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/SchemasModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/SchemasModule.scala
@@ -13,7 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils.databaseEventLog
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.SchemaEvent
-import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.service.schemas.SchemasImpl
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLog
 import izumi.distage.model.definition.ModuleDef
@@ -50,6 +50,8 @@ object SchemasModule extends ModuleDef {
   }
 
   many[ApiMappings].add(Schemas.mappings)
+
+  many[ResourceToSchemaMappings].add(Schemas.resourcesToSchemas)
 
   many[EventExchange].add { (schemas: Schemas) => Schemas.eventExchange(schemas) }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutesSpec.scala
@@ -614,7 +614,7 @@ class ResolversRoutesSpec
       }
 
       "return the deprecated resolvers the user has access to" in {
-        Get(s"/v1/resolvers/${project.ref}?deprecated=true") ~> asBob ~> routes ~> check {
+        Get(s"/v1/resolvers/${project.ref}/caches?deprecated=true") ~> asBob ~> routes ~> check {
           status shouldEqual StatusCodes.OK
           response.asJson shouldEqual expectedResults(inProjectLast)
         }
@@ -624,7 +624,7 @@ class ResolversRoutesSpec
         val encodedResolver          = UrlUtils.encode(nxv.Resolver.toString)
         val encodedInProjectResolver = UrlUtils.encode(nxv.InProject.toString)
         Get(
-          s"/v1/resolvers/${project.ref}?type=$encodedResolver&type=$encodedInProjectResolver"
+          s"/v1/resolvers/${project.ref}/caches?type=$encodedResolver&type=$encodedInProjectResolver"
         ) ~> asBob ~> routes ~> check {
           status shouldEqual StatusCodes.OK
           response.asJson shouldEqual expectedResults(
@@ -636,7 +636,7 @@ class ResolversRoutesSpec
       }
 
       "return the resolvers with revision 2" in {
-        Get(s"/v1/resolvers/${project2.ref}?rev=2") ~> asAlice ~> routes ~> check {
+        Get(s"/v1/resolvers/${project2.ref}/caches?rev=2") ~> asAlice ~> routes ~> check {
           status shouldEqual StatusCodes.OK
           response.asJson should equalIgnoreArrayOrder(
             expectedResults(
@@ -653,8 +653,8 @@ class ResolversRoutesSpec
       "fail to list resolvers if the user has not access resolvers/read on the project" in {
         forAll(
           List(
-            Get(s"/v1/resolvers/${project.ref}?deprecated=true") ~> routes,
-            Get(s"/v1/resolvers/${project2.ref}") ~> asBob ~> routes
+            Get(s"/v1/resolvers/${project.ref}/caches?deprecated=true") ~> routes,
+            Get(s"/v1/resolvers/${project2.ref}/caches") ~> asBob ~> routes
           )
         ) { request =>
           request ~> check {

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginDef.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginDef.scala
@@ -1,15 +1,15 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.archive
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioJsonContentOf
-import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.contexts
+import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.{contexts, schema => archivesSchemaId}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
-import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, Name, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
-
 class ArchivePluginDef extends PluginDef {
 
   implicit private val classLoader: ClassLoader = getClass.getClassLoader
@@ -22,6 +22,11 @@ class ArchivePluginDef extends PluginDef {
     )
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("archive"), BuildInfo.version)
+
+  override val resourcesToSchemas: ResourceToSchemaMappings =
+    ResourceToSchemaMappings(Label.unsafe("archives") -> archivesSchemaId.iri)
+
+  override val apiMappings: ApiMappings                     = Archives.mappings
 
   override def initialize(locator: Locator): Task[Plugin] = Task.delay(locator.get[ArchivePlugin])
 }

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginModule.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginModule.scala
@@ -5,7 +5,6 @@ import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.Projects
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
 import com.typesafe.config.Config
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.UIO
@@ -28,8 +27,6 @@ object ArchivePluginModule extends ModuleDef {
     ) =>
       Archives(projects, cfg)(as, uuidF, rcr, clock)
   }
-
-  many[ApiMappings].add(Archives.mappings)
 
   // TODO: update this when the routes are defined
   make[ArchivePlugin]

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginDef.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginDef.scala
@@ -1,10 +1,11 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.blazegraph
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioJsonContentOf
-import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.contexts
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.{contexts, schema => viewsSchemaId}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
-import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, Name, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
@@ -22,6 +23,11 @@ class BlazegraphPluginDef extends PluginDef {
     RemoteContextResolution.fixedIOResource(
       contexts.blazegraph -> ioJsonContentOf("contexts/blazegraph.json").memoizeOnSuccess
     )
+
+  override val resourcesToSchemas: ResourceToSchemaMappings =
+    ResourceToSchemaMappings(Label.unsafe("views") -> viewsSchemaId.iri)
+
+  override val apiMappings: ApiMappings                     = BlazegraphViews.mappings
 
   override def initialize(locator: Locator): Task[Plugin] = Task.delay(locator.get[BlazegraphPlugin])
 

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
@@ -16,7 +16,6 @@ import ch.epfl.bluebrain.nexus.delta.sdk.cache.KeyValueStore
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.{EventExchange, EventExchangeCollection, GlobalEventLog}
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils.databaseEventLog
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClient
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, Event, ResourceF}
 import ch.epfl.bluebrain.nexus.delta.sdk.{Acls, Identities, Organizations, Permissions, ProgressesStatistics, Projects, ProjectsCounts, ScopeInitialization, ServiceDependency}
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLog
@@ -102,8 +101,6 @@ object BlazegraphPluginModule extends ModuleDef {
       ) =>
         BlazegraphViews(cfg, log, permissions, orgs, projects, coordinator)(uuidF, clock, scheduler, as, cr)
     }
-
-  many[ApiMappings].add(BlazegraphViews.mappings)
 
   many[EventExchange].add { (views: BlazegraphViews) => views.eventExchange }
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginDef.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginDef.scala
@@ -1,10 +1,11 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioJsonContentOf
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.contexts
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts, schema => viewsSchemaId}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
-import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, Name, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
@@ -23,6 +24,11 @@ class ElasticSearchPluginDef extends PluginDef {
       contexts.elasticsearch         -> ioJsonContentOf("contexts/elasticsearch.json").memoizeOnSuccess,
       contexts.elasticsearchIndexing -> ioJsonContentOf("contexts/elasticsearch-indexing.json").memoizeOnSuccess
     )
+
+  override val resourcesToSchemas: ResourceToSchemaMappings =
+    ResourceToSchemaMappings(Label.unsafe("views") -> viewsSchemaId.iri)
+
+  override val apiMappings: ApiMappings                     = ElasticSearchViews.mappings
 
   override def initialize(locator: Locator): Task[Plugin] = Task.delay(locator.get[ElasticSearchPlugin])
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutes.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutes.scala
@@ -12,7 +12,6 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model._
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.routes.ElasticSearchViewsRoutes.responseFieldsElasticSearchRejections
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViews, ElasticSearchViewsQuery}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
-import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schemas
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -31,7 +30,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection.Project
 import ch.epfl.bluebrain.nexus.delta.sdk.model.routes.{JsonSource, Tag, Tags}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchResults.{searchResultsEncoder, SearchEncoder}
-import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, IdSegment, TagLabel}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{permissions => _, _}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.ExternalIndexingConfig
 import io.circe.{Json, JsonObject}
@@ -41,13 +40,14 @@ import monix.execution.Scheduler
 /**
   * The elasticsearch views routes
   *
-  * @param identities  the identity module
-  * @param acls        the ACLs module
-  * @param projects    the projects module
-  * @param views       the elasticsearch views operations bundle
-  * @param viewsQuery  the elasticsearch views query operations bundle
-  * @param progresses  the statistics of the progresses for the elasticsearch views
-  * @param coordinator the elasticsearch indexing coordinator in order to restart a view indexing process triggered by a client
+  * @param identities         the identity module
+  * @param acls               the ACLs module
+  * @param projects           the projects module
+  * @param views              the elasticsearch views operations bundle
+  * @param viewsQuery         the elasticsearch views query operations bundle
+  * @param progresses         the statistics of the progresses for the elasticsearch views
+  * @param coordinator        the elasticsearch indexing coordinator in order to restart a view indexing process triggered by a client
+  * @param resourcesToSchemas a collection of root resource segment with their corresponding schema
   */
 final class ElasticSearchViewsRoutes(
     identities: Identities,
@@ -56,7 +56,8 @@ final class ElasticSearchViewsRoutes(
     views: ElasticSearchViews,
     viewsQuery: ElasticSearchViewsQuery,
     progresses: ProgressesStatistics,
-    coordinator: ElasticSearchIndexingCoordinator
+    coordinator: ElasticSearchIndexingCoordinator,
+    resourcesToSchemas: ResourceToSchemaMappings
 )(implicit
     baseUri: BaseUri,
     paginationConfig: PaginationConfig,
@@ -75,166 +76,169 @@ final class ElasticSearchViewsRoutes(
   def routes: Route =
     baseUriPrefix(baseUri.prefix) {
       extractCaller { implicit caller =>
+        concat(viewsRoutes, resourcesListings, genericResourcesRoutes)
+      }
+    }
+
+  private def viewsRoutes(implicit caller: Caller): Route =
+    pathPrefix("views") {
+      // TODO: SSE for all view events/all view events in an org and all view events in a project needs to happen
+      // using some sort of globalEventExchange for SSEs that includes elasticsearch, blazegraph and composite events
+      projectRef(projects).apply { implicit ref =>
         concat(
-          pathPrefix("views") {
-            // TODO: SSE for all view events/all view events in an org and all view events in a project needs to happen
-            // using some sort of globalEventExchange for SSEs that includes elasticsearch, blazegraph and composite events
-            projectRef(projects).apply { implicit ref =>
-              concat(
-                (pathEndOrSingleSlash & operationName(s"$prefixSegment/views/{org}/{project}")) {
-                  concat(
-                    // List all views
-                    list(schema.iri),
-                    // Create an elasticsearch view without id segment
-                    (post & pathEndOrSingleSlash & noParameter("rev") & entity(as[Json])) { source =>
-                      authorizeFor(AclAddress.Project(ref), permissions.write).apply {
-                        emit(Created, views.create(ref, source).map(_.void).rejectWhen(decodingFailedOrViewNotFound))
-                      }
-                    }
-                  )
-                },
-                idSegment { id =>
-                  concat(
-                    pathEndOrSingleSlash {
-                      operationName(s"$prefixSegment/views/{org}/{project}/{id}") {
-                        concat(
-                          // Create or update an elasticsearch view
-                          put {
-                            authorizeFor(AclAddress.Project(ref), permissions.write).apply {
-                              (parameter("rev".as[Long].?) & pathEndOrSingleSlash & entity(as[Json])) {
-                                case (None, source)      =>
-                                  // Create an elasticsearch view with id segment
-                                  emit(
-                                    Created,
-                                    views.create(id, ref, source).map(_.void).rejectWhen(decodingFailedOrViewNotFound)
-                                  )
-                                case (Some(rev), source) =>
-                                  // Update a view
-                                  emit(
-                                    views
-                                      .update(id, ref, rev, source)
-                                      .map(_.void)
-                                      .rejectWhen(decodingFailedOrViewNotFound)
-                                  )
-                              }
-                            }
-                          },
-                          // Deprecate an elasticsearch view
-                          (delete & parameter("rev".as[Long])) { rev =>
-                            authorizeFor(AclAddress.Project(ref), permissions.write).apply {
-                              emit(views.deprecate(id, ref, rev).map(_.void).rejectOn[ViewNotFound])
-                            }
-                          },
-                          // Fetch an elasticsearch view
-                          get {
-                            fetch(id, ref)
-                          }
-                        )
-                      }
-                    },
-                    // Fetch an elasticsearch view statistics
-                    (pathPrefix("statistics") & get & pathEndOrSingleSlash) {
-                      operationName(s"$prefixSegment/views/{org}/{project}/{id}/statistics") {
-                        authorizeFor(AclAddress.Project(ref), permissions.read).apply {
-                          emit(
-                            views
-                              .fetchIndexingView(id, ref)
-                              .flatMap(v => progresses.statistics(ref, v.projectionId))
-                              .rejectOn[ViewNotFound]
-                          )
-                        }
-                      }
-                    },
-                    // Manage an elasticsearch view offset
-                    (pathPrefix("offset") & pathEndOrSingleSlash) {
-                      operationName(s"$prefixSegment/views/{org}/{project}/{id}/offset") {
-                        concat(
-                          // Fetch an elasticsearch view offset
-                          (get & authorizeFor(AclAddress.Project(ref), permissions.read)) {
-                            emit(
-                              views
-                                .fetchIndexingView(id, ref)
-                                .flatMap(v => progresses.offset(v.projectionId))
-                                .rejectOn[ViewNotFound]
-                            )
-                          },
-                          // Remove an elasticsearch view offset (restart the view)
-                          (delete & authorizeFor(AclAddress.Project(ref), permissions.write)) {
-                            emit(
-                              views
-                                .fetchIndexingView(id, ref)
-                                .flatMap(coordinator.restart)
-                                .as(NoOffset)
-                                .rejectOn[ViewNotFound]
-                            )
-                          }
-                        )
-                      }
-                    },
-                    // Query an elasticsearch view
-                    (pathPrefix("_search") & post & pathEndOrSingleSlash) {
-                      operationName(s"$prefixSegment/views/{org}/{project}/{id}/_search") {
-                        (extractQueryParams & sortList & entity(as[JsonObject])) { (qp, sort, query) =>
-                          emit(viewsQuery.query(id, ref, query, qp, sort))
-                        }
-                      }
-                    },
-                    // Fetch an elasticsearch view original source
-                    (pathPrefix("source") & get & pathEndOrSingleSlash) {
-                      operationName(s"$prefixSegment/views/{org}/{project}/{id}/source") {
-                        fetchMap(id, ref, resource => JsonSource(resource.value.source, resource.value.id))
-                      }
-                    },
-                    (pathPrefix("tags") & pathEndOrSingleSlash) {
-                      operationName(s"$prefixSegment/views/{org}/{project}/{id}/tags") {
-                        concat(
-                          // Fetch an elasticsearch view tags
-                          get {
-                            fetchMap(id, ref, resource => Tags(resource.value.tags))
-                          },
-                          // Tag an elasticsearch view
-                          (post & parameter("rev".as[Long])) { rev =>
-                            authorizeFor(AclAddress.Project(ref), permissions.write).apply {
-                              entity(as[Tag]) { case Tag(tagRev, tag) =>
-                                emit(Created, views.tag(id, ref, tag, tagRev, rev).map(_.void).rejectOn[ViewNotFound])
-                              }
-                            }
-                          }
-                        )
-                      }
-                    }
-                  )
-                }
-              )
-            }
-          },
-          pathPrefix("schemas") {
-            projectRef(projects).apply { implicit ref =>
-              // List all schemas
-              (pathEndOrSingleSlash & operationName(s"$prefixSegment/schemas/{org}/{project}")) {
-                list(schemas.shacl)
+          (pathEndOrSingleSlash & operationName(s"$prefixSegment/views/{org}/{project}")) {
+            // Create an elasticsearch view without id segment
+            (post & pathEndOrSingleSlash & noParameter("rev") & entity(as[Json])) { source =>
+              authorizeFor(AclAddress.Project(ref), permissions.write).apply {
+                emit(Created, views.create(ref, source).map(_.void).rejectWhen(decodingFailedOrViewNotFound))
               }
             }
           },
-          pathPrefix("resources") {
-            projectRef(projects).apply { implicit ref =>
-              concat(
-                // List all resources
-                (pathEndOrSingleSlash & operationName(s"$prefixSegment/resources/{org}/{project}")) {
-                  list()
-                },
-                idSegment { schema =>
-                  // List all resources filtering by its schema type
-                  (pathEndOrSingleSlash & operationName(s"$prefixSegment/resources/{org}/{project}/{schema}")) {
-                    list(underscoreToOption(schema))
+          idSegment { id =>
+            concat(
+              pathEndOrSingleSlash {
+                operationName(s"$prefixSegment/views/{org}/{project}/{id}") {
+                  concat(
+                    // Create or update an elasticsearch view
+                    put {
+                      authorizeFor(AclAddress.Project(ref), permissions.write).apply {
+                        (parameter("rev".as[Long].?) & pathEndOrSingleSlash & entity(as[Json])) {
+                          case (None, source)      =>
+                            // Create an elasticsearch view with id segment
+                            emit(
+                              Created,
+                              views.create(id, ref, source).map(_.void).rejectWhen(decodingFailedOrViewNotFound)
+                            )
+                          case (Some(rev), source) =>
+                            // Update a view
+                            emit(
+                              views.update(id, ref, rev, source).map(_.void).rejectWhen(decodingFailedOrViewNotFound)
+                            )
+                        }
+                      }
+                    },
+                    // Deprecate an elasticsearch view
+                    (delete & parameter("rev".as[Long])) { rev =>
+                      authorizeFor(AclAddress.Project(ref), permissions.write).apply {
+                        emit(views.deprecate(id, ref, rev).map(_.void).rejectWhen(decodingFailedOrViewNotFound))
+                      }
+                    },
+                    // Fetch an elasticsearch view
+                    get {
+                      fetch(id, ref)
+                    }
+                  )
+                }
+              },
+              // Fetch an elasticsearch view statistics
+              (pathPrefix("statistics") & get & pathEndOrSingleSlash) {
+                operationName(s"$prefixSegment/views/{org}/{project}/{id}/statistics") {
+                  authorizeFor(AclAddress.Project(ref), permissions.read).apply {
+                    emit(
+                      views
+                        .fetchIndexingView(id, ref)
+                        .flatMap(v => progresses.statistics(ref, v.projectionId))
+                        .rejectWhen(decodingFailedOrViewNotFound)
+                    )
                   }
                 }
-              )
+              },
+              // Manage an elasticsearch view offset
+              (pathPrefix("offset") & pathEndOrSingleSlash) {
+                operationName(s"$prefixSegment/views/{org}/{project}/{id}/offset") {
+                  concat(
+                    // Fetch an elasticsearch view offset
+                    (get & authorizeFor(AclAddress.Project(ref), permissions.read)) {
+                      emit(
+                        views
+                          .fetchIndexingView(id, ref)
+                          .flatMap(v => progresses.offset(v.projectionId))
+                          .rejectWhen(decodingFailedOrViewNotFound)
+                      )
+                    },
+                    // Remove an elasticsearch view offset (restart the view)
+                    (delete & authorizeFor(AclAddress.Project(ref), permissions.write)) {
+                      emit(
+                        views
+                          .fetchIndexingView(id, ref)
+                          .flatMap(coordinator.restart)
+                          .as(NoOffset)
+                          .rejectWhen(decodingFailedOrViewNotFound)
+                      )
+                    }
+                  )
+                }
+              },
+              // Query an elasticsearch view
+              (pathPrefix("_search") & post & pathEndOrSingleSlash) {
+                operationName(s"$prefixSegment/views/{org}/{project}/{id}/_search") {
+                  (extractQueryParams & sortList & entity(as[JsonObject])) { (qp, sort, query) =>
+                    emit(viewsQuery.query(id, ref, query, qp, sort))
+                  }
+                }
+              },
+              // Fetch an elasticsearch view original source
+              (pathPrefix("source") & get & pathEndOrSingleSlash) {
+                operationName(s"$prefixSegment/views/{org}/{project}/{id}/source") {
+                  fetchMap(id, ref, resource => JsonSource(resource.value.source, resource.value.id))
+                }
+              },
+              (pathPrefix("tags") & pathEndOrSingleSlash) {
+                operationName(s"$prefixSegment/views/{org}/{project}/{id}/tags") {
+                  concat(
+                    // Fetch an elasticsearch view tags
+                    get {
+                      fetchMap(id, ref, resource => Tags(resource.value.tags))
+                    },
+                    // Tag an elasticsearch view
+                    (post & parameter("rev".as[Long])) { rev =>
+                      authorizeFor(AclAddress.Project(ref), permissions.write).apply {
+                        entity(as[Tag]) { case Tag(tagRev, tag) =>
+                          emit(
+                            Created,
+                            views.tag(id, ref, tag, tagRev, rev).map(_.void).rejectWhen(decodingFailedOrViewNotFound)
+                          )
+                        }
+                      }
+                    }
+                  )
+                }
+              }
+            )
+          }
+        )
+      }
+    }
+
+  private def genericResourcesRoutes(implicit caller: Caller): Route =
+    pathPrefix("resources") {
+      projectRef(projects).apply { implicit ref =>
+        concat(
+          // List all resources
+          (pathEndOrSingleSlash & operationName(s"$prefixSegment/resources/{org}/{project}")) {
+            list()
+          },
+          idSegment { schema =>
+            // List all resources filtering by its schema type
+            (pathEndOrSingleSlash & operationName(s"$prefixSegment/resources/{org}/{project}/{schema}")) {
+              list(underscoreToOption(schema))
             }
           }
         )
       }
     }
+
+  private def resourcesListings(implicit caller: Caller): Route =
+    concat(resourcesToSchemas.value.map { case (Label(resourceSegment), resourceSchema) =>
+      pathPrefix(resourceSegment) {
+        projectRef(projects).apply { implicit ref =>
+          // List all resource of type resourceSegment
+          (pathEndOrSingleSlash & operationName(s"$prefixSegment/$resourceSegment/{org}/{project}")) {
+            list(resourceSchema)
+          }
+        }
+      }
+    }.toSeq: _*)
 
   private def fetch(id: IdSegment, ref: ProjectRef)(implicit caller: Caller) =
     fetchMap(id, ref, identity)
@@ -287,7 +291,8 @@ object ElasticSearchViewsRoutes {
       views: ElasticSearchViews,
       viewsQuery: ElasticSearchViewsQuery,
       progresses: ProgressesStatistics,
-      coordinator: ElasticSearchIndexingCoordinator
+      coordinator: ElasticSearchIndexingCoordinator,
+      resourcesToSchemas: ResourceToSchemaMappings
   )(implicit
       baseUri: BaseUri,
       paginationConfig: PaginationConfig,
@@ -295,7 +300,17 @@ object ElasticSearchViewsRoutes {
       s: Scheduler,
       cr: RemoteContextResolution,
       ordering: JsonKeyOrdering
-  ): Route = new ElasticSearchViewsRoutes(identities, acls, projects, views, viewsQuery, progresses, coordinator).routes
+  ): Route =
+    new ElasticSearchViewsRoutes(
+      identities,
+      acls,
+      projects,
+      views,
+      viewsQuery,
+      progresses,
+      coordinator,
+      resourcesToSchemas
+    ).routes
 
   implicit val responseFieldsElasticSearchRejections: HttpResponseFields[ElasticSearchViewRejection] =
     HttpResponseFields {

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -31,7 +31,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.{AuthToken, Caller, Id
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectCountsCollection.ProjectCount
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, ProjectCountsCollection, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
-import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, Label}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, Label, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.delta.sdk.testkit._
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.RouteHelpers
@@ -155,17 +155,28 @@ class ElasticSearchViewsRoutesSpec
     override def get(project: ProjectRef): UIO[Option[ProjectCount]] = get().map(_.get(project))
   }
 
-  private val viewsQuery        = DummyElasticSearchViewsQuery
-  private val coordinatorCounts = Ref.of[Task, Map[ProjectionId, CoordinatorCounts]](Map.empty).accepted
-  private val coordinator       = new DummyIndexingCoordinator[IndexingViewResource](coordinatorCounts)
-
-  private val viewsProgressesCache =
+  private val viewsQuery              = DummyElasticSearchViewsQuery
+  private val coordinatorCounts       = Ref.of[Task, Map[ProjectionId, CoordinatorCounts]](Map.empty).accepted
+  private val coordinator             = new DummyIndexingCoordinator[IndexingViewResource](coordinatorCounts)
+  private val resourceToSchemaMapping = ResourceToSchemaMappings(Label.unsafe("views") -> elasticSearchSchema.iri)
+  private val viewsProgressesCache    =
     KeyValueStore.localLRU[ProjectionId, ProjectionProgress[Unit]]("view-progress", 10).accepted
 
   private val statisticsProgress = new ProgressesStatistics(viewsProgressesCache, projectsCounts)
 
   private val routes =
-    Route.seal(ElasticSearchViewsRoutes(identities, acls, projs, views, viewsQuery, statisticsProgress, coordinator))
+    Route.seal(
+      ElasticSearchViewsRoutes(
+        identities,
+        acls,
+        projs,
+        views,
+        viewsQuery,
+        statisticsProgress,
+        coordinator,
+        resourceToSchemaMapping
+      )
+    )
 
   "Elasticsearch views routes" should {
 

--- a/delta/plugins/storage/src/main/resources/storage.conf
+++ b/delta/plugins/storage/src/main/resources/storage.conf
@@ -37,44 +37,44 @@ storage {
       # the default maximum allowed file size (in bytes) for uploaded files. 10 GB 
       default-max-file-size = 10737418240
     }
-    # Amazon S3 storage configuration
-    amazon {
+    # Amazon S3 storage configuration (uncomment if you have an S3 storage that you want to use)
+    #amazon {
       # the default digest algorithm
-      digest-algorithm = "SHA-256"
+      #digest-algorithm = "SHA-256"
       # the default permission required in order to download a file from an S3 storage
-      default-read-permission = "resources/read"
+      #default-read-permission = "resources/read"
       # the default permission required in order to upload a file to a S3 storage
-      default-write-permission = "files/write"
+      #default-write-permission = "files/write"
       # flag to decide whether or not to show the absolute location of the files in the metadata response
-      show-location = true
+      #show-location = true
       # the default maximum allowed file size (in bytes) for uploaded files. 10 GB 
-      default-max-file-size = 10737418240
-    }
-    # Remote disk storage configuration
-    remote-disk {
+      #default-max-file-size = 10737418240
+    #}
+    # Remote disk storage configuration (uncomment if you have a remote disk storage that you want to use)
+    #remote-disk {
       # the default endpoint
-      default-endpoint = "http://localhost:8084/v1"
+      #default-endpoint = "http://localhost:8084/v1"
       # the default credentials for the endpoint
-      default-credentials = null
+      #default-credentials = null
       # the default digest algorithm
-      digest-algorithm = "SHA-256"
+      #digest-algorithm = "SHA-256"
       # the default permission required in order to download a file from a remote disk storage
-      default-read-permission = "resources/read"
+      #default-read-permission = "resources/read"
       # the default permission required in order to upload a file to a remote disk storage
-      default-write-permission = "files/write"
+      #default-write-permission = "files/write"
       # flag to decide whether or not to show the absolute location of the files in the metadata response
-      show-location = true
+      #show-location = true
       # the default maximum allowed file size (in bytes) for uploaded files. 10 GB 
-      default-max-file-size = 10737418240
+      #default-max-file-size = 10737418240
       # configuration of the remote disk client
-      client {
+      #client {
         # the retry strategy for the http client
-        retry = ${app.defaults.constant-retry-strategy}
+        #retry = ${app.defaults.constant-retry-strategy}
         # the strategy to decide if it is worth retrying when an Http error occurs.
         # allowed strategies are 'always', 'never' or 'onServerError'.
-        is-worth-retrying = "onServerError"
-      }
-    }
+        #is-worth-retrying = "onServerError"
+      #}
+    #}
     # the storages aggregate configuration
     aggregate = ${app.defaults.aggregate}
     # the storages cache config

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginDef.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginDef.scala
@@ -1,11 +1,16 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioJsonContentOf
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.Files
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.contexts.files
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.schemas.{files => filesSchemaId}
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.Storages
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.contexts.storages
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.schemas.{storage => storagesSchemaId}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
-import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, Name, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
@@ -24,6 +29,11 @@ class StoragePluginDef extends PluginDef {
       storages -> ioJsonContentOf("contexts/storages.json").memoizeOnSuccess,
       files    -> ioJsonContentOf("contexts/files.json").memoizeOnSuccess
     )
+
+  override val resourcesToSchemas: ResourceToSchemaMappings =
+    ResourceToSchemaMappings(Label.unsafe("storages") -> storagesSchemaId, Label.unsafe("files") -> filesSchemaId)
+
+  override val apiMappings: ApiMappings                     = Storages.mappings + Files.mappings
 
   override def initialize(locator: Locator): Task[Plugin] = Task.delay(locator.get[StoragePlugin])
 

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginModule.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginModule.scala
@@ -18,7 +18,6 @@ import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventExchange
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils.databaseEventLog
 import ch.epfl.bluebrain.nexus.delta.sdk.http.{HttpClient, HttpClientConfig, HttpClientWorthRetry}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.ServiceAccount
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope}
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLog
@@ -67,8 +66,6 @@ object StoragePluginModule extends ModuleDef {
   make[Crypto].from { (cfg: StoragePluginConfig) =>
     cfg.storages.storageTypeConfig.encryption.crypto
   }
-
-  many[ApiMappings].add(Storages.mappings + Files.mappings)
 
   many[EventExchange].add { (storages: Storages, crypto: Crypto, cr: RemoteContextResolution) =>
     Storages.eventExchange(storages)(crypto, cr)

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutes.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutes.scala
@@ -126,14 +126,16 @@ final class StoragesRoutes(
                   }
                 },
                 (pathEndOrSingleSlash & operationName(s"$prefixSegment/storages/{org}/{project}")) {
-                  concat(
-                    // Create a storage without id segment
-                    (post & noParameter("rev") & entity(as[Json])) { source =>
-                      authorizeFor(AclAddress.Project(ref), permissions.write).apply {
-                        emit(Created, storages.create(ref, Secret(source)).map(_.void))
-                      }
-                    },
-                    // List storages
+                  // Create a storage without id segment
+                  (post & noParameter("rev") & entity(as[Json])) { source =>
+                    authorizeFor(AclAddress.Project(ref), permissions.write).apply {
+                      emit(Created, storages.create(ref, Secret(source)).map(_.void))
+                    }
+                  }
+                },
+                (pathPrefix("caches") & pathEndOrSingleSlash) {
+                  operationName(s"$prefixSegment/storages/{org}/{project}/caches") {
+                    // List storages in cache
                     (get & extractUri & fromPaginated & storagesSearchParams & sort[Storage]) {
                       (uri, pagination, params, order) =>
                         authorizeFor(AclAddress.Project(ref), permissions.read).apply {
@@ -142,7 +144,7 @@ final class StoragesRoutes(
                           emit(storages.list(pagination, params, order))
                         }
                     }
-                  )
+                  }
                 },
                 idSegment { id =>
                   concat(

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutesSpec.scala
@@ -229,7 +229,7 @@ class StoragesRoutesSpec
 
     "fail to fetch a storage and do listings without resources/read permission" in {
       val endpoints = List(
-        "/v1/storages/myorg/myproject",
+        "/v1/storages/myorg/myproject/caches",
         "/v1/storages/myorg/myproject/remote-disk-storage",
         "/v1/storages/myorg/myproject/remote-disk-storage/tags"
       )
@@ -299,7 +299,7 @@ class StoragesRoutesSpec
     }
 
     "list storages" in {
-      Get("/v1/storages/myorg/myproject") ~> routes ~> check {
+      Get("/v1/storages/myorg/myproject/caches") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual jsonContentOf("storage/storages-list.json")
       }
@@ -307,14 +307,14 @@ class StoragesRoutesSpec
 
     "list remote disk storages" in {
       val encodedStorage = UrlUtils.encode(nxvStorage.toString)
-      Get(s"/v1/storages/myorg/myproject?type=$encodedStorage&type=nxv:RemoteDiskStorage") ~> routes ~> check {
+      Get(s"/v1/storages/myorg/myproject/caches?type=$encodedStorage&type=nxv:RemoteDiskStorage") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual jsonContentOf("storage/storages-list-not-deprecated.json")
       }
     }
 
     "list not deprecated storages" in {
-      Get("/v1/storages/myorg/myproject?deprecated=false") ~> routes ~> check {
+      Get("/v1/storages/myorg/myproject/caches?deprecated=false") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual jsonContentOf("storage/storages-list-not-deprecated.json")
       }

--- a/delta/plugins/test-plugin/src/main/scala/ch/epfl/bluebrain/nexus/delta/testplugin/TestPluginDef.scala
+++ b/delta/plugins/test-plugin/src/main/scala/ch/epfl/bluebrain/nexus/delta/testplugin/TestPluginDef.scala
@@ -2,7 +2,8 @@ package ch.epfl.bluebrain.nexus.delta.testplugin
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
-import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{Name, ResourceToSchemaMappings}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
@@ -15,6 +16,10 @@ case class TestPluginDef() extends PluginDef {
   override val info: PluginDescription = PluginDescription(Name.unsafe("testplugin"), "0.1.0")
 
   override def remoteContextResolution: RemoteContextResolution = RemoteContextResolution.never
+
+  override val resourcesToSchemas: ResourceToSchemaMappings = ResourceToSchemaMappings.empty
+
+  override val apiMappings: ApiMappings = ApiMappings.empty
 
   override def initialize(locator: Locator): Task[Plugin] = Task.pure(locator.get[TestPlugin])
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resolvers.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resolvers.scala
@@ -20,7 +20,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.Pagination.FromPagination
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchParams.ResolverSearchParams
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchResults.UnscoredSearchResults
-import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, IdSegment, TagLabel}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Envelope, IdSegment, Label, ResourceToSchemaMappings, TagLabel}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import fs2.Stream
 import io.circe.Json
@@ -205,6 +205,13 @@ object Resolvers {
     * The default resolver API mappings
     */
   val mappings: ApiMappings = ApiMappings("resolver" -> schemas.resolvers, "defaultResolver" -> nxv.defaultResolver)
+
+  /**
+    * The resolver resource to schema mapping
+    */
+  val resourcesToSchemas: ResourceToSchemaMappings = ResourceToSchemaMappings(
+    Label.unsafe("resolvers") -> schemas.resolvers
+  )
 
   import ch.epfl.bluebrain.nexus.delta.kernel.utils.IOUtils.instant
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Schemas.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Schemas.scala
@@ -215,6 +215,11 @@ object Schemas {
     */
   val mappings: ApiMappings = ApiMappings("schema" -> schemas.shacl)
 
+  /**
+    * The schema resource to schema mapping
+    */
+  val resourcesToSchemas: ResourceToSchemaMappings = ResourceToSchemaMappings(Label.unsafe("schemas") -> schemas.shacl)
+
   @SuppressWarnings(Array("OptionGet"))
   private[delta] def next(state: SchemaState, event: SchemaEvent): SchemaState = {
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/ResourceToSchemaMappings.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/ResourceToSchemaMappings.scala
@@ -1,0 +1,16 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model
+
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+
+/**
+  * A mapping from resource segments to their schema
+  */
+final case class ResourceToSchemaMappings private (value: Map[Label, Iri]) {
+  def +(that: ResourceToSchemaMappings): ResourceToSchemaMappings = ResourceToSchemaMappings(value ++ that.value)
+}
+
+object ResourceToSchemaMappings {
+  val empty: ResourceToSchemaMappings = ResourceToSchemaMappings()
+
+  def apply(values: (Label, Iri)*): ResourceToSchemaMappings = ResourceToSchemaMappings(values.toMap)
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/plugin/PluginDef.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/plugin/PluginDef.scala
@@ -2,6 +2,8 @@ package ch.epfl.bluebrain.nexus.delta.sdk.plugin
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
+import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourceToSchemaMappings
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
 import com.typesafe.config.{ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
@@ -46,6 +48,17 @@ trait PluginDef {
       )
       .getConfig(info.name.value)
       .getInt("priority")
+
+  /**
+    * @return a list of root resource segment with their corresponding schema.
+    *         E.g.: 'resolvers' -> https://bluebrain.github.io/nexus/schemas/resolvers.json
+    */
+  def resourcesToSchemas: ResourceToSchemaMappings
+
+  /**
+    * The plugin API mappings
+    */
+  def apiMappings: ApiMappings
 
   /**
     * Initialize the plugin.

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/WiringInitializer.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/WiringInitializer.scala
@@ -1,10 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.service.plugin
 
-import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioJsonContentOf
-import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.error.PluginError.PluginInitializationError
-import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
 import distage.{Injector, Roots}
 import izumi.distage.model.Locator
@@ -21,31 +17,8 @@ object WiringInitializer {
   def apply(
       serviceModule: ModuleDef,
       pluginsDef: List[PluginDef]
-  )(implicit classLoader: ClassLoader): IO[PluginInitializationError, (List[Plugin], Locator)] = {
-    val pluginsInfoModule = new ModuleDef {
-      make[List[PluginDescription]].from(pluginsDef.map(_.info))
-      make[RemoteContextResolution].from(
-        RemoteContextResolution
-          .fixedIOResource(
-            contexts.acls          -> ioJsonContentOf("contexts/acls.json").memoizeOnSuccess,
-            contexts.error         -> ioJsonContentOf("contexts/error.json").memoizeOnSuccess,
-            contexts.identities    -> ioJsonContentOf("contexts/identities.json").memoizeOnSuccess,
-            contexts.offset        -> ioJsonContentOf("contexts/offset.json").memoizeOnSuccess,
-            contexts.organizations -> ioJsonContentOf("contexts/organizations.json").memoizeOnSuccess,
-            contexts.permissions   -> ioJsonContentOf("contexts/permissions.json").memoizeOnSuccess,
-            contexts.projects      -> ioJsonContentOf("contexts/projects.json").memoizeOnSuccess,
-            contexts.realms        -> ioJsonContentOf("contexts/realms.json").memoizeOnSuccess,
-            contexts.resolvers     -> ioJsonContentOf("contexts/resolvers.json").memoizeOnSuccess,
-            contexts.metadata      -> ioJsonContentOf("contexts/metadata.json").memoizeOnSuccess,
-            contexts.search        -> ioJsonContentOf("contexts/search.json").memoizeOnSuccess,
-            contexts.shacl         -> ioJsonContentOf("contexts/shacl.json").memoizeOnSuccess,
-            contexts.statistics    -> ioJsonContentOf("contexts/statistics.json").memoizeOnSuccess,
-            contexts.tags          -> ioJsonContentOf("contexts/tags.json").memoizeOnSuccess,
-            contexts.version       -> ioJsonContentOf("contexts/version.json").memoizeOnSuccess
-          )
-          .merge(pluginsDef.map(_.remoteContextResolution): _*)
-      )
-    }
+  ): IO[PluginInitializationError, (List[Plugin], Locator)] = {
+    val pluginsInfoModule = new ModuleDef { make[List[PluginDef]].from(pluginsDef) }
     val appModules        = (serviceModule :: pluginsInfoModule :: pluginsDef.map(_.module)).merge
 
     // workaround for: java.lang.NoClassDefFoundError: zio/blocking/package$Blocking$Service

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginLoaderSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginLoaderSpec.scala
@@ -20,9 +20,9 @@ class PluginLoaderSpec extends AnyWordSpecLike with ScalatestRouteTest with Matc
   "A PluginLoader" should {
     val config = PluginLoaderConfig("../plugins/test-plugin/target")
     "load plugins from .jar in a directory" in {
-      val (cl, pluginsDef) = PluginsLoader(config).load.accepted
-      val (plugins, _)     = WiringInitializer(serviceModule, pluginsDef)(cl).accepted
-      val route            = plugins.flatMap(_.route).head
+      val (_, pluginsDef) = PluginsLoader(config).load.accepted
+      val (plugins, _)    = WiringInitializer(serviceModule, pluginsDef).accepted
+      val route           = plugins.flatMap(_.route).head
 
       pluginsDef.head.priority shouldEqual 10
       Get("/test-plugin") ~> route ~> check {


### PR DESCRIPTION
All the listings are consistently performed by elasticsearch (not by the caches sometimes and by es others).
In order to list the resources from caches I've added a `v1/storages/{org}/{project}/caches` and `v1/resolvers/{org}/{project}/caches` endpoint (we won't advertise it, that's just internal)