### PR TITLE
Allow plugins to depend on other plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val http4sClient         = "org.http4s"                 %% "http4s-blaze-cl
 lazy val http4sDsl            = "org.http4s"                 %% "http4s-dsl"                      % http4sVersion
 lazy val jenaArq              = "org.apache.jena"             % "jena-arq"                        % jenaVersion
 lazy val jsonldjava           = "com.github.jsonld-java"      % "jsonld-java"                     % jsonldjavaVersion
+lazy val kamonAkkaHttp        = "io.kamon"                   %% "kamon-akka-http"                 % kamonVersion
 lazy val kamonCore            = "io.kamon"                   %% "kamon-core"                      % kamonVersion
 lazy val kanelaAgent          = "io.kamon"                    % "kanela-agent"                    % kanelaAgentVersion
 lazy val kindProjector        = "org.typelevel"              %% "kind-projector"                  % kindProjectorVersion cross CrossVersion.full
@@ -510,7 +511,7 @@ lazy val elasticsearchPlugin = project
     assembly / assemblyJarName := "elasticsearch.jar",
     assembly / assemblyOption  := (assembly / assemblyOption).value.copy(includeScala = false),
     libraryDependencies       ++= Seq(
-      "io.kamon"       %% "kamon-akka-http" % kamonVersion % Provided,
+      kamonAkkaHttp     % Provided,
       akkaTestKitTyped  % Test,
       akkaSlf4j         % Test,
       dockerTestKit     % Test,
@@ -539,7 +540,7 @@ lazy val blazegraphPlugin = project
     name                       := "delta-blazegraph-plugin",
     moduleName                 := "delta-blazegraph-plugin",
     libraryDependencies       ++= Seq(
-      "io.kamon"       %% "kamon-akka-http" % kamonVersion % Provided,
+      kamonAkkaHttp     % Provided,
       akkaSlf4j         % Test,
       dockerTestKit     % Test,
       dockerTestKitImpl % Test,
@@ -570,7 +571,7 @@ lazy val compositeViewsPlugin = project
     name                       := "delta-composite-views-plugin",
     moduleName                 := "delta-composite-views-plugin",
     libraryDependencies       ++= Seq(
-      "io.kamon"       %% "kamon-akka-http" % kamonVersion % Provided,
+      kamonAkkaHttp     % Provided,
       akkaSlf4j         % Test,
       dockerTestKit     % Test,
       dockerTestKitImpl % Test,
@@ -605,7 +606,7 @@ lazy val storagePlugin = project
         ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13"),
         ExclusionRule(organization = "org.slf4j", name = "slf4j-api")
       ),
-      "io.kamon"       %% "kamon-akka-http" % kamonVersion % Provided,
+      kamonAkkaHttp     % Provided,
       akkaSlf4j         % Test,
       akkaHttpTestKit   % Test,
       dockerTestKit     % Test,
@@ -638,7 +639,10 @@ lazy val archivePlugin = project
     name                       := "delta-archive-plugin",
     moduleName                 := "delta-archive-plugin",
     libraryDependencies       ++= Seq(
-      alpakkaFile,
+      kamonAkkaHttp     % Provided,
+      alpakkaFile excludeAll (
+        ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
+      ),
       akkaSlf4j         % Test,
       dockerTestKit     % Test,
       dockerTestKitImpl % Test,
@@ -791,8 +795,8 @@ lazy val shared = Seq(
 
 lazy val kamonSettings = Seq(
   libraryDependencies ++= Seq(
+    kamonAkkaHttp,
     "io.kamon" %% "kamon-akka"           % kamonVersion,
-    "io.kamon" %% "kamon-akka-http"      % kamonVersion,
     // "io.kamon" %% "kamon-cassandra"      % kamonVersion, // does not support v4.x of the cassandra driver
     "io.kamon" %% "kamon-core"           % kamonVersion,
     "io.kamon" %% "kamon-executors"      % kamonVersion,

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/PluginError.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/PluginError.scala
@@ -1,5 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.error
 
+import ch.epfl.bluebrain.nexus.delta.sdk.model.NonEmptySet
+
 import java.io.File
 
 /**
@@ -40,4 +42,19 @@ object PluginError {
     * @param reason a descriptive reason for the error
     */
   final case class ClassNotFoundError(reason: String) extends PluginError(reason, None)
+
+  /**
+    * Plugin initialization phase failure caused by a set of plugins that could not be loaded.
+    *
+    * @param errors the non empty collection of failures
+    */
+  final case class PluginLoadErrors(errors: NonEmptySet[(File, PluginError)])
+      extends PluginError(
+        "Some plugins could not be loaded.",
+        Some(
+          errors.value
+            .map { case (file, error) => s"\t - Plugin: $file\n\t - Cause: ${error.getMessage}" }
+            .mkString("\n")
+        )
+      )
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/PluginError.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/PluginError.scala
@@ -25,12 +25,19 @@ object PluginError {
   /**
     * Multiple [[PluginDef]] classes found in the jar.
     *
-    * @param file     the jar file where multiple [[PluginDef]]s were found.
-    * @param classes  the classes implementing [[PluginDef]]
+    * @param file    the jar file where multiple [[PluginDef]]s were found.
+    * @param classes the classes implementing [[PluginDef]]
     */
   final case class MultiplePluginDefClassesFound(file: File, classes: Set[String])
       extends PluginError(
         s"Multiple plugin def classes found in ${file.getPath}, classes found: ${classes.mkString(",")}",
         None
       )
+
+  /**
+    * Plugin intialization error caused by a missing class.
+    *
+    * @param reason a descriptive reason for the error
+    */
+  final case class ClassNotFoundError(reason: String) extends PluginError(reason, None)
 }

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginClassLoader.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginClassLoader.scala
@@ -1,7 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.service.plugin
 
 import java.net.URL
-
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.util.{Failure, Success, Try}
 
@@ -26,7 +25,7 @@ class PluginClassLoader(url: URL, parent: ClassLoader) extends URLClassLoader(Se
     * @return The resulting [[Class]] object
     */
   override def loadClass(className: String): Class[_] =
-    loadClassFromPlugin(className).getOrElse(super.loadClass(className))
+    loadClassFromPlugin(className).getOrElse(parent.loadClass(className))
 
   /**
     * Loads the class with the specified class name from the Jar file.
@@ -60,7 +59,7 @@ class PluginClassLoader(url: URL, parent: ClassLoader) extends URLClassLoader(Se
     * @return the URL to the resource, null if the resource was not found.
     */
   override def getResource(name: String): URL =
-    getResourceFromPlugin(name).getOrElse(super.getResource(name))
+    getResourceFromPlugin(name).getOrElse(parent.getResource(name))
 
   /**
     * Finds the resource with the given name in the Jar file

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginsLoader.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginsLoader.scala
@@ -52,16 +52,16 @@ class PluginsLoader(loaderConfig: PluginLoaderConfig) {
 
             partitioned match {
               // everything was loaded, adding each plugin class loader and return all plugin defs
-              case (Nil, loaded)    =>
+              case (Nil, loaded)          =>
                 UIO.delay {
                   loaded.foreach { case (_, pcl) => cl.addPluginClassLoader(pcl) }
                   Left((Nil, cl, plugins ++ loaded.map(_._1)))
                 }
               // nothing resolved, pick the first error and return
-              case ((_, error) :: _, Nil)    =>
+              case ((_, error) :: _, Nil) =>
                 IO.raiseError(error)
               // some new plugins were loaded, but not all, adding the loaded ones and executing another pass
-              case (errors, loaded) =>
+              case (errors, loaded)       =>
                 UIO.delay {
                   loaded.foreach { case (_, pcl) => cl.addPluginClassLoader(pcl) }
                   Left((errors.map { case (file, _) => file }, cl, plugins ++ loaded.map { case (pdef, _) => pdef }))

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginsLoader.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/plugin/PluginsLoader.scala
@@ -1,7 +1,8 @@
 package ch.epfl.bluebrain.nexus.delta.service.plugin
 
+import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.error.PluginError
-import ch.epfl.bluebrain.nexus.delta.sdk.error.PluginError.MultiplePluginDefClassesFound
+import ch.epfl.bluebrain.nexus.delta.sdk.error.PluginError.{ClassNotFoundError, MultiplePluginDefClassesFound}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.PluginDef
 import ch.epfl.bluebrain.nexus.delta.service.plugin.PluginsLoader.PluginLoaderConfig
 import com.typesafe.scalalogging.Logger
@@ -9,6 +10,7 @@ import io.github.classgraph.ClassGraph
 import monix.bio.{IO, UIO}
 
 import java.io.{File, FilenameFilter}
+import java.lang.reflect.InvocationTargetException
 import scala.jdk.CollectionConverters._
 
 /**
@@ -25,22 +27,73 @@ class PluginsLoader(loaderConfig: PluginLoaderConfig) {
   private val parentClassLoader = this.getClass.getClassLoader
 
   /**
-    * Loads all the available [[PluginDef]] from each of the discovered jar files
+    * Loads all the available [[PluginDef]] from each of the discovered jar files. In order to solve class loading
+    * issues caused by plugin dependencies, the load operation accumulates all independent plugin classloaders and
+    * adds them to a mutable [[PluginsClassLoader]] which is the parent of all plugin class loaders. It traverses all
+    * the plugin jar files and attempts to load them in multiple passes where a new pass is attempted if the previous
+    * one managed to load some classes but not all.
     */
-  def load: IO[PluginError, (PluginsClassLoader, List[PluginDef])] =
-    for {
-      jarFiles                   <- UIO.delay(loaderConfig.directories.flatMap(loadFiles))
-      (pluginsDef, classLoaders) <- IO.traverse(jarFiles)(loadPluginDef).map(_.flatten.sortBy(_._1).unzip)
-      accClassLoader              = new PluginsClassLoader(classLoaders, parentClassLoader)
-    } yield (accClassLoader, pluginsDef)
+  def load: IO[PluginError, (ClassLoader, List[PluginDef])] = {
+    UIO.delay(loaderConfig.directories.flatMap(loadFiles)).flatMap { jarFiles =>
+      // recursively load the jar files, retrying in case of errors if there's at least on plugin loaded per pass
+      // this enables handling of plugin dependencies
+      IO.tailRecM((jarFiles, new PluginsClassLoader(Nil, parentClassLoader), Nil: List[PluginDef])) {
+        case (Nil, cl, plugins)       => IO.pure(Right((cl, plugins)))
+        case (remaining, cl, plugins) =>
+          // attempt to load the remaining files
+          remaining.traverse(file => loadPluginDef(file, cl).attempt.map(v => (file, v))).flatMap { results =>
+            // partition the load results into List(file -> error) and List(plugin def -> plugin class loader)
+            val partitioned =
+              results.foldLeft((Nil: List[(File, PluginError)], Nil: List[(PluginDef, PluginClassLoader)])) {
+                case ((errors, loaded), (f, Left(err)))          => ((f, err) :: errors, loaded)
+                case ((errors, loaded), (_, Right(None)))        => (errors, loaded)
+                case ((errors, loaded), (_, Right(Some(value)))) => (errors, value :: loaded)
+              }
 
-  private def loadPluginDef(jar: File): IO[PluginError, Option[(PluginDef, PluginClassLoader)]] =
+            partitioned match {
+              // everything was loaded, adding each plugin class loader and return all plugin defs
+              case (Nil, loaded)    =>
+                UIO.delay {
+                  loaded.foreach { case (_, pcl) => cl.addPluginClassLoader(pcl) }
+                  Left((Nil, cl, plugins ++ loaded.map(_._1)))
+                }
+              // nothing resolved, pick the first error and return
+              case ((_, error) :: _, Nil)    =>
+                IO.raiseError(error)
+              // some new plugins were loaded, but not all, adding the loaded ones and executing another pass
+              case (errors, loaded) =>
+                UIO.delay {
+                  loaded.foreach { case (_, pcl) => cl.addPluginClassLoader(pcl) }
+                  Left((errors.map { case (file, _) => file }, cl, plugins ++ loaded.map { case (pdef, _) => pdef }))
+                }
+            }
+          }
+      }
+    }
+  }
+
+  private def loadPluginDef(jar: File, parent: ClassLoader): IO[PluginError, Option[(PluginDef, PluginClassLoader)]] =
     for {
-      pluginClassLoader <- UIO.delay(new PluginClassLoader(jar.toURI.toURL, parentClassLoader))
+      pluginClassLoader <- UIO.delay(new PluginClassLoader(jar.toURI.toURL, parent))
       pluginDefClasses  <- UIO.delay(loadPluginDefClasses(pluginClassLoader))
       pluginDef         <- pluginDefClasses match {
                              case pluginDef :: Nil =>
-                               IO.pure(Some(pluginClassLoader.create[PluginDef](pluginDef, println)()))
+                               IO.delay( // delayed because it can throw
+                                 Some(pluginClassLoader.create[PluginDef](pluginDef, _ => ())())
+                               ).redeemWith(
+                                 {
+                                   // raise class not found in the typed error channel as it may be recoverable
+                                   case ex: ClassNotFoundException    => IO.raiseError(ClassNotFoundError(ex.getMessage))
+                                   case ex: InvocationTargetException =>
+                                     ex.getCause match {
+                                       case ncdf: NoClassDefFoundError =>
+                                         IO.raiseError(ClassNotFoundError("Could not find class: " + ncdf.getMessage))
+                                       case _                          => IO.terminate(ex)
+                                     }
+                                   case other                         => IO.terminate(other)
+                                 },
+                                 value => IO.pure(value)
+                               )
                              case Nil              =>
                                logger.warn(s"Jar file '$jar' does not contain a 'PluginDef' implementation.")
                                IO.pure(None)
@@ -50,7 +103,7 @@ class PluginsLoader(loaderConfig: PluginLoaderConfig) {
                            }
     } yield pluginDef.map(_ -> pluginClassLoader)
 
-  private def loadPluginDefClasses(loader: ClassLoader)                                         =
+  private def loadPluginDefClasses(loader: ClassLoader)                                                              =
     new ClassGraph()
       .overrideClassLoaders(loader)
       .enableAllInfo()


### PR DESCRIPTION
During service bootstrapping the plugins are discovered through scanning `PluginDef` instances in their respective jar files and loaded in separate classloaders. If the `PluginDef` makes use of any classes from a different plugin, the plugin initialization fails due to lack of access to other plugin's classes.

The change allows the initialization of plugins with a mutable ClassLoader configured as a parent to all plugin classloaders that is modified while plugins are loaded, adding each successful plugin classloader to the scope that is looked up.