### PR TITLE
Added support to use '_' endpoints

### DIFF
--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutesSpec.scala
@@ -491,9 +491,13 @@ class ResolversRoutesSpec
       val resolverMetaContext = json""" {"@context": ["${contexts.resolvers}", "${contexts.metadata}"]} """
 
       "get the latest version of an in-project resolver" in {
-        Get(s"/v1/resolvers/${project.ref}/in-project-put") ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.OK
-          response.asJson shouldEqual inProjectLast.deepMerge(resolverMetaContext)
+        val endpoints =
+          List(s"/v1/resolvers/${project.ref}/in-project-put", s"/v1/resources/${project.ref}/_/in-project-put")
+        forAll(endpoints) { endpoint =>
+          Get(endpoint) ~> asBob ~> routes ~> check {
+            status shouldEqual StatusCodes.OK
+            response.asJson shouldEqual inProjectLast.deepMerge(resolverMetaContext)
+          }
         }
       }
 
@@ -518,40 +522,65 @@ class ResolversRoutesSpec
       }
 
       "get the version by revision" in {
-        Get(s"/v1/resolvers/${project.ref}/in-project-put?rev=1") ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.OK
-          val id       = nxv + "in-project-put"
-          val expected = inProjectPayload
-            .deepMerge(resolverMetadata(id, InProject, project.ref, createdBy = bob, updatedBy = bob))
-            .deepMerge(resolverMetaContext)
-          response.asJson shouldEqual expected
+        val endpoints = List(
+          s"/v1/resolvers/${project.ref}/in-project-put?rev=1",
+          s"/v1/resources/${project.ref}/_/in-project-put?rev=1"
+        )
+        forAll(endpoints) { endpoint =>
+          Get(endpoint) ~> asBob ~> routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val id       = nxv + "in-project-put"
+            val expected = inProjectPayload
+              .deepMerge(resolverMetadata(id, InProject, project.ref, createdBy = bob, updatedBy = bob))
+              .deepMerge(resolverMetaContext)
+            response.asJson shouldEqual expected
+          }
         }
+
       }
 
       "get the version by tag" in {
-        Get(s"/v1/resolvers/${project.ref}/in-project-put?tag=my-tag") ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.OK
-          val id       = nxv + "in-project-put"
-          val expected = inProjectPayload
-            .deepMerge(resolverMetadata(id, InProject, project.ref, createdBy = bob, updatedBy = bob))
-            .deepMerge(resolverMetaContext)
-          response.asJson shouldEqual expected
+        val endpoints = List(
+          s"/v1/resolvers/${project.ref}/in-project-put?tag=my-tag",
+          s"/v1/resources/${project.ref}/_/in-project-put?tag=my-tag"
+        )
+        forAll(endpoints) { endpoint =>
+          Get(endpoint) ~> asBob ~> routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val id       = nxv + "in-project-put"
+            val expected = inProjectPayload
+              .deepMerge(resolverMetadata(id, InProject, project.ref, createdBy = bob, updatedBy = bob))
+              .deepMerge(resolverMetaContext)
+            response.asJson shouldEqual expected
+          }
         }
       }
 
       "get the original payload" in {
-        Get(s"/v1/resolvers/${project.ref}/in-project-put/source") ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.OK
-          val expected = inProjectPayload.deepMerge(json"""{"priority": 34}""")
-          response.asJson shouldEqual expected
+        val endpoints = List(
+          s"/v1/resolvers/${project.ref}/in-project-put/source",
+          s"/v1/resources/${project.ref}/_/in-project-put/source"
+        )
+        forAll(endpoints) { endpoint =>
+          Get(endpoint) ~> asBob ~> routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val expected = inProjectPayload.deepMerge(json"""{"priority": 34}""")
+            response.asJson shouldEqual expected
+          }
         }
       }
 
       "get the original payload by revision" in {
-        Get(s"/v1/resolvers/${project.ref}/in-project-put/source?rev=1") ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.OK
-          val expected = inProjectPayload
-          response.asJson shouldEqual expected
+        val endpoints = List(
+          s"/v1/resolvers/${project.ref}/in-project-put/source?rev=1",
+          s"/v1/resources/${project.ref}/_/in-project-put/source?rev=1"
+        )
+        forAll(endpoints) { endpoint =>
+          Get(endpoint) ~> asBob ~> routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val expected = inProjectPayload
+            response.asJson shouldEqual expected
+          }
         }
       }
 
@@ -564,9 +593,15 @@ class ResolversRoutesSpec
       }
 
       "get the resolver tags" in {
-        Get(s"/v1/resolvers/${project.ref}/in-project-put/tags") ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.OK
-          response.asJson shouldEqual json"""{"tags": [{"rev": 1, "tag": "my-tag"}]}""".addContext(contexts.tags)
+        val endpoints = List(
+          s"/v1/resolvers/${project.ref}/in-project-put/tags",
+          s"/v1/resources/${project.ref}/_/in-project-put/tags"
+        )
+        forAll(endpoints) { endpoint =>
+          Get(endpoint) ~> asBob ~> routes ~> check {
+            status shouldEqual StatusCodes.OK
+            response.asJson shouldEqual json"""{"tags": [{"rev": 1, "tag": "my-tag"}]}""".addContext(contexts.tags)
+          }
         }
       }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutesSpec.scala
@@ -208,6 +208,7 @@ class SchemasRoutesSpec
 
     "fail to fetch a schema without resources/read permission" in {
       val endpoints = List(
+        "/v1/resources/myorg/myproject/_/myid2",
         "/v1/schemas/myorg/myproject/myid2",
         "/v1/schemas/myorg/myproject/myid2/tags"
       )
@@ -223,17 +224,23 @@ class SchemasRoutesSpec
 
     "fetch a schema" in {
       acls.append(Acl(AclAddress.Root, Anonymous -> Set(resources.read)), 6L).accepted
-      Get("/v1/schemas/myorg/myproject/myid") ~> routes ~> check {
-        status shouldEqual StatusCodes.OK
-        response.asJson shouldEqual jsonContentOf("schemas/schema-updated-response.json", "id" -> "nxv:myid")
+      val endpoints = List("/v1/schemas/myorg/myproject/myid", "/v1/resources/myorg/myproject/_/myid")
+      forAll(endpoints) { endpoint =>
+        Get(endpoint) ~> routes ~> check {
+          status shouldEqual StatusCodes.OK
+          response.asJson shouldEqual jsonContentOf("schemas/schema-updated-response.json", "id" -> "nxv:myid")
+        }
       }
     }
 
     "fetch a schema by rev and tag" in {
       val endpoints = List(
         s"/v1/schemas/$uuid/$uuid/myid2",
+        s"/v1/resources/$uuid/$uuid/_/myid2",
         "/v1/schemas/myorg/myproject/myid2",
-        s"/v1/schemas/myorg/myproject/$myId2Encoded"
+        "/v1/resources/myorg/myproject/_/myid2",
+        s"/v1/schemas/myorg/myproject/$myId2Encoded",
+        s"/v1/resources/myorg/myproject/_/$myId2Encoded"
       )
       forAll(endpoints) { endpoint =>
         forAll(List("rev=1", "tag=mytag")) { param =>
@@ -248,8 +255,11 @@ class SchemasRoutesSpec
     "fetch a schema original payload" in {
       val endpoints = List(
         s"/v1/schemas/$uuid/$uuid/myid2/source",
+        s"/v1/resources/$uuid/$uuid/_/myid2/source",
         "/v1/schemas/myorg/myproject/myid2/source",
-        s"/v1/schemas/myorg/myproject/$myId2Encoded/source"
+        "/v1/resources/myorg/myproject/_/myid2/source",
+        s"/v1/schemas/myorg/myproject/$myId2Encoded/source",
+        s"/v1/resources/myorg/myproject/_/$myId2Encoded/source"
       )
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> routes ~> check {
@@ -261,8 +271,11 @@ class SchemasRoutesSpec
     "fetch a schema original payload by rev or tag" in {
       val endpoints = List(
         s"/v1/schemas/$uuid/$uuid/myid2/source",
+        s"/v1/resources/$uuid/$uuid/_/myid2/source",
         "/v1/schemas/myorg/myproject/myid2/source",
-        s"/v1/schemas/myorg/myproject/$myId2Encoded/source"
+        "/v1/resources/myorg/myproject/_/myid2/source",
+        s"/v1/schemas/myorg/myproject/$myId2Encoded/source",
+        s"/v1/resources/myorg/myproject/_/$myId2Encoded/source"
       )
       forAll(endpoints) { endpoint =>
         forAll(List("rev=1", "tag=mytag")) { param =>
@@ -279,7 +292,7 @@ class SchemasRoutesSpec
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual json"""{"tags": []}""".addContext(contexts.tags)
       }
-      Get("/v1/schemas/myorg/myproject/myid2/tags") ~> routes ~> check {
+      Get("/v1/resources/myorg/myproject/_/myid2/tags") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual json"""{"tags": [{"rev": 1, "tag": "mytag"}]}""".addContext(contexts.tags)
       }

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutes.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutes.scala
@@ -79,7 +79,7 @@ class BlazegraphViewsRoutes(
     JsonLdEncoder.computeFromCirce(ContextValue(contexts.statistics))
 
   def routes: Route =
-    baseUriPrefix(baseUri.prefix) {
+    (baseUriPrefix(baseUri.prefix) & replaceUriOnUnderscore("views")) {
       extractCaller { implicit caller =>
         concat(
           pathPrefix("views") {

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutesSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutesSpec.scala
@@ -400,32 +400,44 @@ class BlazegraphViewsRoutesSpec
       }
     }
     "fetch a view by rev or tag" in {
-      forAll(List(Get("/v1/views/org/proj/indexing-view?tag=mytag"), Get("/v1/views/org/proj/indexing-view?rev=1"))) {
-        req =>
-          req ~> asBob ~> routes ~> check {
-            response.status shouldEqual StatusCodes.OK
-            response.asJson shouldEqual jsonContentOf(
-              "routes/responses/indexing-view.json",
-              "uuid"       -> uuid,
-              "deprecated" -> false,
-              "rev"        -> 1
-            ).mapObject(_.remove("resourceTag"))
-          }
+      val endpoints = List(
+        "/v1/views/org/proj/indexing-view?tag=mytag",
+        "/v1/resources/org/proj/_/indexing-view?tag=mytag",
+        "/v1/views/org/proj/indexing-view?rev=1",
+        "/v1/resources/org/proj/_/indexing-view?rev=1"
+      )
+      forAll(endpoints) { endpoint =>
+        Get(endpoint) ~> asBob ~> routes ~> check {
+          response.status shouldEqual StatusCodes.OK
+          response.asJson shouldEqual jsonContentOf(
+            "routes/responses/indexing-view.json",
+            "uuid"       -> uuid,
+            "deprecated" -> false,
+            "rev"        -> 1
+          ).mapObject(_.remove("resourceTag"))
+        }
       }
 
     }
     "fetch a view source" in {
-      Get("/v1/views/org/proj/indexing-view/source") ~> asBob ~> routes ~> check {
-        response.status shouldEqual StatusCodes.OK
-        response.asJson shouldEqual updatedIndexingSource
+      val endpoints = List("/v1/views/org/proj/indexing-view/source", "/v1/resources/org/proj/_/indexing-view/source")
+      forAll(endpoints) { endpoint =>
+        Get(endpoint) ~> asBob ~> routes ~> check {
+          response.status shouldEqual StatusCodes.OK
+          response.asJson shouldEqual updatedIndexingSource
+        }
       }
     }
     "fetch the view tags" in {
-      Get("/v1/views/org/proj/indexing-view/tags") ~> asBob ~> routes ~> check {
-        response.status shouldEqual StatusCodes.OK
-        response.asJson shouldEqual json"""{"tags": [{"rev": 1, "tag": "mytag"}]}""".addContext(
-          Vocabulary.contexts.tags
-        )
+      val endpoints = List("/v1/views/org/proj/indexing-view/tags", "/v1/resources/org/proj/_/indexing-view/tags")
+      forAll(endpoints) { endpoint =>
+        Get(endpoint) ~> asBob ~> routes ~> check {
+          response.status shouldEqual StatusCodes.OK
+          response.asJson shouldEqual
+            json"""{"tags": [{"rev": 1, "tag": "mytag"}]}""".addContext(
+              Vocabulary.contexts.tags
+            )
+        }
       }
     }
     "reject if provided rev and tag simultaneously" in {

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutes.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutes.scala
@@ -81,7 +81,7 @@ final class ElasticSearchViewsRoutes(
     JsonLdEncoder.computeFromCirce(ContextValue(contexts.statistics))
 
   def routes: Route =
-    baseUriPrefix(baseUri.prefix) {
+    (baseUriPrefix(baseUri.prefix) & replaceUriOnUnderscore("views")) {
       extractCaller { implicit caller =>
         concat(viewsRoutes, resourcesListings, genericResourcesRoutes)
       }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -321,8 +321,11 @@ class ElasticSearchViewsRoutesSpec
     "fetch a view by rev and tag" in {
       val endpoints = List(
         s"/v1/views/$uuid/$uuid/myid2",
+        s"/v1/resources/$uuid/$uuid/_/myid2",
         "/v1/views/myorg/myproject/myid2",
-        s"/v1/views/myorg/myproject/$myId2Encoded"
+        "/v1/resources/myorg/myproject/_/myid2",
+        s"/v1/views/myorg/myproject/$myId2Encoded",
+        s"/v1/resources/myorg/myproject/_/$myId2Encoded"
       )
       forAll(endpoints) { endpoint =>
         forAll(List("rev=1", "tag=mytag")) { param =>
@@ -337,8 +340,11 @@ class ElasticSearchViewsRoutesSpec
     "fetch a view original payload" in {
       val endpoints = List(
         s"/v1/views/$uuid/$uuid/myid2/source",
+        s"/v1/resources/$uuid/$uuid/_/myid2/source",
         "/v1/views/myorg/myproject/myid2/source",
-        s"/v1/views/myorg/myproject/$myId2Encoded/source"
+        "/v1/resources/myorg/myproject/_/myid2/source",
+        s"/v1/views/myorg/myproject/$myId2Encoded/source",
+        s"/v1/resources/myorg/myproject/_/$myId2Encoded/source"
       )
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> routes ~> check {
@@ -364,7 +370,7 @@ class ElasticSearchViewsRoutesSpec
     }
 
     "fetch the view tags" in {
-      Get("/v1/views/myorg/myproject/myid2/tags?rev=1") ~> routes ~> check {
+      Get("/v1/resources/myorg/myproject/_/myid2/tags?rev=1") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual json"""{"tags": []}""".addContext(contexts.tags)
       }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutes.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutes.scala
@@ -82,7 +82,7 @@ final class StoragesRoutes(
 
   @SuppressWarnings(Array("OptionGet"))
   def routes: Route                                                          =
-    baseUriPrefix(baseUri.prefix) {
+    (baseUriPrefix(baseUri.prefix) & replaceUriOnUnderscore("storages")) {
       extractCaller { implicit caller =>
         pathPrefix("storages") {
           concat(
@@ -222,9 +222,12 @@ final class StoragesRoutes(
     authorizeFor(AclAddress.Project(ref), permissions.read).apply {
       (parameter("rev".as[Long].?) & parameter("tag".as[TagLabel].?)) {
         case (Some(_), Some(_)) => emit(simultaneousTagAndRevRejection)
-        case (Some(rev), _)     => emit(storages.fetchAt(id, ref, rev).leftWiden[StorageRejection].map(f))
-        case (_, Some(tag))     => emit(storages.fetchBy(id, ref, tag).leftWiden[StorageRejection].map(f))
-        case _                  => emit(storages.fetch(id, ref).leftWiden[StorageRejection].map(f))
+        case (Some(rev), _)     =>
+          emit(storages.fetchAt(id, ref, rev).leftWiden[StorageRejection].map(f).rejectOn[StorageNotFound])
+        case (_, Some(tag))     =>
+          emit(storages.fetchBy(id, ref, tag).leftWiden[StorageRejection].map(f).rejectOn[StorageNotFound])
+        case _                  =>
+          emit(storages.fetch(id, ref).leftWiden[StorageRejection].map(f).rejectOn[StorageNotFound])
       }
     }
 }

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutesSpec.scala
@@ -257,8 +257,11 @@ class StoragesRoutesSpec
     "fetch a storage by rev and tag" in {
       val endpoints = List(
         s"/v1/storages/$uuid/$uuid/remote-disk-storage",
+        s"/v1/resources/$uuid/$uuid/_/remote-disk-storage",
         "/v1/storages/myorg/myproject/remote-disk-storage",
-        s"/v1/storages/myorg/myproject/$remoteIdEncoded"
+        "/v1/resources/myorg/myproject/_/remote-disk-storage",
+        s"/v1/storages/myorg/myproject/$remoteIdEncoded",
+        s"/v1/resources/myorg/myproject/_/$remoteIdEncoded"
       )
       forAll(endpoints) { endpoint =>
         forAll(List("rev=1", "tag=mytag")) { param =>
@@ -274,8 +277,11 @@ class StoragesRoutesSpec
       val expectedSource = remoteFieldsJson.map(_ deepMerge json"""{"default": false}""")
       val endpoints      = List(
         s"/v1/storages/$uuid/$uuid/remote-disk-storage/source",
+        s"/v1/resources/$uuid/$uuid/_/remote-disk-storage/source",
         "/v1/storages/myorg/myproject/remote-disk-storage/source",
-        s"/v1/storages/myorg/myproject/$remoteIdEncoded/source"
+        "/v1/resources/myorg/myproject/_/remote-disk-storage/source",
+        s"/v1/storages/myorg/myproject/$remoteIdEncoded/source",
+        s"/v1/resources/myorg/myproject/_/$remoteIdEncoded/source"
       )
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> routes ~> check {
@@ -324,7 +330,7 @@ class StoragesRoutesSpec
     }
 
     "fetch the storage tags" in {
-      Get("/v1/storages/myorg/myproject/remote-disk-storage/tags?rev=1") ~> routes ~> check {
+      Get("/v1/resources/myorg/myproject/_/remote-disk-storage/tags?rev=1") ~> routes ~> check {
         status shouldEqual StatusCodes.OK
         response.asJson shouldEqual json"""{"tags": []}""".addContext(contexts.tags)
       }


### PR DESCRIPTION
Uses a rewrite of the `uncosumedPath` form the context when the current unconsumed path is `/resources/{org}/{proj}/_/{id}`

Fixes https://github.com/BlueBrain/nexus/issues/1824