### PR TITLE
Fixed ViewRef reference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -415,10 +415,7 @@ lazy val sdkViews = project
     name       := "delta-sdk-views",
     moduleName := "delta-sdk-views"
   )
-  .dependsOn(
-    sdk     % Provided,
-    testkit % "test->compile"
-  )
+  .dependsOn(sdk, testkit % "test->compile")
   .settings(shared, compilation, assertJavaVersion, coverage, release)
   .settings(
     coverageFailOnMinimum := false,
@@ -438,7 +435,7 @@ lazy val service = project
     moduleName := "delta-service"
   )
   .settings(shared, compilation, assertJavaVersion, coverage, release)
-  .dependsOn(rdf, sdk, sdkTestkit % "test->compile;test->test", testkit % "test->compile")
+  .dependsOn(rdf, sdk, sdkViews, sdkTestkit % "test->compile;test->test", testkit % "test->compile")
   .settings(compile in Test := (compile in Test).dependsOn(assembly in testPlugin).value)
   .settings(
     libraryDependencies ++= Seq(
@@ -554,7 +551,7 @@ lazy val elasticsearchPlugin = project
   .dependsOn(
     migration  % Provided,
     sdk        % "provided;test->test",
-    sdkViews,
+    sdkViews   % Provided,
     sdkTestkit % "test->compile;test->test"
   )
   .settings(
@@ -587,7 +584,7 @@ lazy val blazegraphPlugin = project
   .dependsOn(
     migration  % Provided,
     sdk        % "provided;test->test",
-    sdkViews,
+    sdkViews   % Provided,
     sdkTestkit % "test->compile;test->test"
   )
   .settings(
@@ -617,7 +614,7 @@ lazy val compositeViewsPlugin = project
   .dependsOn(
     migration           % Provided,
     sdk                 % "provided;test->test",
-    sdkViews,
+    sdkViews            % Provided,
     sdkTestkit          % "test->compile;test->test",
     elasticsearchPlugin % Provided,
     blazegraphPlugin    % Provided

--- a/delta/plugins/blazegraph/src/main/resources/blazegraph.conf
+++ b/delta/plugins/blazegraph/src/main/resources/blazegraph.conf
@@ -7,9 +7,7 @@ akka.actor {
 
   serialization-bindings {
     "ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewEvent"                    = "circeBlazegraph"
-    "ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.IndexingStreamBehaviour$IndexingViewCommand"  = "kryo"
     "ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewValue"                    = "kryo"
-    "ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.ViewRef"                                = "kryo"
   }
 }
 

--- a/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
+++ b/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
@@ -7,9 +7,7 @@ akka.actor {
 
   serialization-bindings {
     "ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewEvent"              = "circeElasticSearch"
-    "ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.IndexingStreamBehaviour$IndexingViewCommand"  = "kryo"
     "ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue"              = "kryo"
-    "ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ViewRef"                             = "kryo"
   }
 }
 

--- a/delta/service/src/main/resources/service.conf
+++ b/delta/service/src/main/resources/service.conf
@@ -14,5 +14,8 @@ service {
     "ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.Schema"                                                = "kryo"
     "ch.epfl.bluebrain.nexus.delta.service.identity.IdentitiesImpl$FetchGroups"                             = "kryo"
     "ch.epfl.bluebrain.nexus.delta.sourcing.projections.stream.DaemonStreamBehaviour$SupervisorCommand"     = "kryo"
+    "ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewRef"                                                 = "kryo"
+    "ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.IndexingStreamBehaviour$IndexingViewCommand"          = "kryo"
+
   }
 }


### PR DESCRIPTION
First error:
```
app akka.actor.ActorInitializationException: akka://delta-1-4-1-256-5c95e392-20210325-1417/system/clusterReceptionist/replicator: exception during creation
app 	at akka.actor.ActorInitializationException$.apply(Actor.scala:196)
app 	at akka.actor.ActorCell.create(ActorCell.scala:661)
app 	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:513)
app 	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:535)
app 	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:295)
app 	at akka.dispatch.Mailbox.run(Mailbox.scala:230)
app 	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
app 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
app 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
app 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
app 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
app 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
app Caused by: java.lang.ClassNotFoundException: ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.ViewRef
```

Fixed by changing in `serialization-bindings` the reference to ViewRef

Second error:
```
app 2021-03-25 14:37:22 WARN  a.s.Serialization(akka://delta-1-4-1-256-5c95e392-20210325-1417) - Using the Java serializer for class [ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewRef] which is not recommended because of performance implications. Use another serializer or disable this warning using the setting 'akka.actor.warn-about-java-serializer-usage'
app 2021-03-25 14:37:22 WARN  a.s.DisabledJavaSerializer - Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewRef]
app 2021-03-25 14:37:22 ERROR akka.cluster.ddata.LmdbDurableStore - failed to store [elasticsearch]
app akka.serialization.DisabledJavaSerializer$JavaSerializationException: Attempted to serialize message using Java serialization while `akka.actor.allow-java-serialization` was disabled. Check WARNING logs for more details.
```

This seems to be due to the fact that serialization is still not kryo for some `ViewRef`. I suspected is because of the fact that we depend on `viewRef` module without the `Provided`. And yeah, changing the dependency structure of the modules [as suggested](https://github.com/BlueBrain/nexus/pull/2179#discussion_r600356915) by @bogdanromanx makes it work