### PR TITLE
Update sourcing settings for new akka-persistence-cassandra tagger

### DIFF
--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -233,7 +233,7 @@ app {
     aggregate {
       snapshot-strategy = ${app.defaults.snapshot-default}
       stop-strategy = ${app.defaults.passivate-never}
-      ask-timeout = 15 seconds
+      ask-timeout = 25 seconds
       evaluation-max-duration = 14 seconds
       stash-size = 10
     }

--- a/delta/app/src/main/resources/application-cassandra.conf
+++ b/delta/app/src/main/resources/application-cassandra.conf
@@ -23,20 +23,29 @@ akka {
       events-by-tag {
         first-time-bucket = "20181213T00:00"
         # This delay helps to order events. Setting this to anything lower than 2s is highly discouraged.
-        eventual-consistency-delay = 4s
+        eventual-consistency-delay = 10s
 
         # Tagged events are written to a separate Cassandra table in unlogged batches
         # Max size of these batches. The best value for this will depend on the size of
         # the serialized events. Cassandra logs a warning for batches above a certain
         # size and this should be reduced if that warning is seen.
-        max-message-batch-size = 60
+        max-message-batch-size = 30
 
         # Max time to buffer events for before writing.
         # Larger valeues will increase cassandra write efficiency but increase the delay before
         # seeing events in EventsByTag queries.
         # Setting this to 0 means that tag writes will get written immediately but will still be asynchronous
         # with respect to the PersistentActor's persist call. However, this will be very bad for throughput.
-        flush-interval = 250ms
+        flush-interval = 100ms
+
+        # Tagged events are written to a separate table after the write to the messages table has completed.
+        # If the write to the tag_views table fails it is retried. If it hasn't succeeded within this timeout
+        # then the actor will be stopped and the write will be retried again to the tag_views table when the actor
+        # is restarted
+        # A default of 4 seconds as that is greater than a typical write timeout in C* (2 seconds) and less than
+        # the default eventual consistency delay
+        # This behavior is new in 1.0.4 where before the write to the tag_views was completely asynchronous.
+        tag-write-timeout = 8s
 
         # Update the tag_scanning table with this interval. Shouldn't be done too often to
         # avoid unecessary load. The tag_scanning table keeps track of a starting point for tag


### PR DESCRIPTION
Fixes #2195 

I increased the timeouts and reduced the params to write smaller batches