### PR TITLE
Use only Circe encoding for events

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutes.scala
@@ -16,7 +16,6 @@ import ch.epfl.bluebrain.nexus.delta.sdk.directives.AuthDirectives
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.DeltaDirectives._
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.UriDirectives.searchParams
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.RdfMarshalling
-import ch.epfl.bluebrain.nexus.delta.sdk.model.IdSegment.StringSegment
 import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.AclAddress
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
@@ -210,12 +209,10 @@ final class ResolversRoutes(
                       }
                     },
                     // Fetch a resource using a resolver
-                    (idSegment & pathEndOrSingleSlash) {
-                      case StringSegment(str) if str == "tags" || str == "source" => reject()
-                      case resourceSegment                                        =>
-                        operationName(s"$prefixSegment/resolvers/{org}/{project}/{id}/{resourceId}") {
-                          resolve(resourceSegment, ref, underscoreToOption(id))
-                        }
+                    (idSegment & pathEndOrSingleSlash) { resourceSegment =>
+                      operationName(s"$prefixSegment/resolvers/{org}/{project}/{id}/{resourceId}") {
+                        resolve(resourceSegment, ref, underscoreToOption(id))
+                      }
                     }
                   )
                 }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
@@ -9,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.utils.{UUIDF, UrlUtils}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema, schemas}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.sdk.Permissions.{events, resources}
-import ch.epfl.bluebrain.nexus.delta.sdk.{JsonLdValue, ResourceResolution}
+import ch.epfl.bluebrain.nexus.delta.sdk.{JsonValue, ResourceResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceResolution.FetchResource
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, ResourceResolutionGen, SchemaGen}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.acls.{Acl, AclAddress}
@@ -112,7 +112,7 @@ class ResourcesRoutesSpec
       ),
       Envelope(ResourceDeprecated(myId, projectRef, Set.empty, 1, Instant.EPOCH, subject), Sequence(2), "p1", 2)
     ),
-    { case ev: ResourceEvent => JsonLdValue(ev) }
+    { case ev: ResourceEvent => JsonValue(ev) }
   )
 
   private val routes = Route.seal(ResourcesRoutes(identities, acls, orgs, projs, resourcesDummy, sseEventLog))

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewEventExchange.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewEventExchange.scala
@@ -3,10 +3,9 @@ package ch.epfl.bluebrain.nexus.delta.plugins.blazegraph
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model._
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class BlazegraphViewEventExchange(views: BlazegraphViews)(implicit base: BaseUri
   override type E = BlazegraphViewEvent
   override type M = BlazegraphView.Metadata
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: BlazegraphViewEvent => Some(JsonLdValue(ev))
+      case ev: BlazegraphViewEvent => Some(JsonValue(ev))
       case _                       => None
     }
 

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewEventExchangeSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewEventExchangeSpec.scala
@@ -86,9 +86,9 @@ class BlazegraphViewEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : [${Vocabulary.contexts.metadata}, ${contexts.blazegraph}],
           "@type" : "BlazegraphViewDeprecated",

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewEventExchange.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewEventExchange.scala
@@ -3,10 +3,9 @@ package ch.epfl.bluebrain.nexus.delta.plugins.compositeviews
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.{CompositeView, CompositeViewEvent, CompositeViewRejection, ViewResource}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class CompositeViewEventExchange(views: CompositeViews)(implicit base: BaseUri) 
   override type E = CompositeViewEvent
   override type M = CompositeView.Metadata
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: CompositeViewEvent => Some(JsonLdValue(ev))
+      case ev: CompositeViewEvent => Some(JsonValue(ev))
       case _                      => None
     }
 

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeViewEvent.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeViewEvent.scala
@@ -5,7 +5,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.ProjectScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
@@ -147,18 +146,16 @@ object CompositeViewEvent {
     })
 
   @nowarn("cat=unused")
-  implicit def compositeEventJsonLdEncoder(implicit baseUri: BaseUri): JsonLdEncoder[CompositeViewEvent] = {
+  implicit def compositeEventEncoder(implicit baseUri: BaseUri): Encoder[CompositeViewEvent] = {
     implicit val subjectEncoder: Encoder[Subject]              = Identity.subjectIdEncoder
     implicit val identityEncoder: Encoder.AsObject[Identity]   = Identity.persistIdentityDecoder
     implicit val viewValueEncoder: Encoder[CompositeViewValue] =
       Encoder.instance[CompositeViewValue](_ => Json.Null)
-    implicit val encoder: Encoder.AsObject[CompositeViewEvent] =
-      deriveConfiguredEncoder[CompositeViewEvent].mapJsonObject(
-        _.add(nxv.constrainedBy.prefix, schema.iri.asJson)
-          .add(nxv.types.prefix, Set(nxv.View, compositeViewType).asJson)
-      )
-
-    JsonLdEncoder.compactedFromCirce[CompositeViewEvent](context)
+    deriveConfiguredEncoder[CompositeViewEvent].mapJsonObject(
+      _.add(nxv.constrainedBy.prefix, schema.iri.asJson)
+        .add(nxv.types.prefix, Set(nxv.View, compositeViewType).asJson)
+        .add(keywords.context, context.value)
+    )
   }
 
 }

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewEventExchangeSpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewEventExchangeSpec.scala
@@ -60,9 +60,9 @@ class CompositeViewEventExchangeSpec extends AbstractDBSpec with Inspectors with
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : [${Vocabulary.contexts.metadata}, ${contexts.compositeViews}],
           "@type" : "CompositeViewDeprecated",

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewEventExchange.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewEventExchange.scala
@@ -3,10 +3,9 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchView, ElasticSearchViewEvent, ElasticSearchViewRejection, ViewResource}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class ElasticSearchViewEventExchange(views: ElasticSearchViews)(implicit base: B
   override type E = ElasticSearchViewEvent
   override type M = ElasticSearchView.Metadata
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: ElasticSearchViewEvent => Some(JsonLdValue(ev))
+      case ev: ElasticSearchViewEvent => Some(JsonValue(ev))
       case _                          => None
     }
 

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewEventExchangeSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewEventExchangeSpec.scala
@@ -102,9 +102,9 @@ class ElasticSearchViewEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : [${Vocabulary.contexts.metadata}, ${contexts.elasticsearch}],
           "@type" : "ElasticSearchViewDeprecated",

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -34,7 +34,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.delta.sdk.testkit._
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.RouteHelpers
-import ch.epfl.bluebrain.nexus.delta.sdk.{JsonLdValue, ProgressesStatistics, ProjectsCounts, SseEventLog}
+import ch.epfl.bluebrain.nexus.delta.sdk.{JsonValue, ProgressesStatistics, ProjectsCounts, SseEventLog}
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLog
 import ch.epfl.bluebrain.nexus.delta.sourcing.projections.ProjectionId.ViewProjectionId
 import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{ProjectionId, ProjectionProgress}
@@ -203,7 +203,7 @@ class ElasticSearchViewsRoutesSpec
         2
       )
     ),
-    { case ev: ElasticSearchViewEvent => JsonLdValue(ev) }
+    { case ev: ElasticSearchViewEvent => JsonValue(ev) }
   )
 
   private val routes =

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FileEventExchange.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FileEventExchange.scala
@@ -4,10 +4,9 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.{File, FileEven
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.StoragesConfig.StorageTypeConfig
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue}
 import io.circe.syntax._
 import monix.bio.{IO, UIO}
 
@@ -22,9 +21,9 @@ class FileEventExchange(files: Files)(implicit base: BaseUri, config: StorageTyp
   override type E = FileEvent
   override type M = File
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: FileEvent => Some(JsonLdValue(ev))
+      case ev: FileEvent => Some(JsonValue(ev))
       case _             => None
     }
 

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileEvent.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileEvent.scala
@@ -10,7 +10,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.ProjectScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
@@ -163,13 +162,10 @@ object FileEvent {
     })
 
   @nowarn("cat=unused")
-  implicit def fileEventJsonLdEncoder(implicit
-      baseUri: BaseUri,
-      config: StorageTypeConfig
-  ): JsonLdEncoder[FileEvent] = {
+  implicit def fileEventEncoder(implicit baseUri: BaseUri, config: StorageTypeConfig): Encoder[FileEvent] = {
     implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
 
-    implicit val encoder: Encoder.AsObject[FileEvent] = Encoder.encodeJsonObject.contramapObject { event =>
+    Encoder.encodeJsonObject.contramapObject { event =>
       val storageAndType       = event match {
         case created: FileCreated => Some(created.storage -> created.storageType)
         case updated: FileUpdated => Some(updated.storage -> updated.storageType)
@@ -189,8 +185,7 @@ object FileEvent {
         .remove("storage")
         .remove("storageType")
         .addIfExists("_storage", storageJsonOpt)
+        .add(keywords.context, context.value)
     }
-
-    JsonLdEncoder.computeFromCirce[FileEvent](context)
   }
 }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/StorageEventExchange.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/StorageEventExchange.scala
@@ -3,11 +3,10 @@ package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.{Storage, StorageEvent, StorageRejection}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.crypto.Crypto
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue}
 import monix.bio.{IO, UIO}
 
 /**
@@ -21,9 +20,9 @@ class StorageEventExchange(storages: Storages)(implicit base: BaseUri, crypto: C
   override type E = StorageEvent
   override type M = Storage.Metadata
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: StorageEvent => Some(JsonLdValue(ev))
+      case ev: StorageEvent => Some(JsonValue(ev))
       case _                => None
     }
 

--- a/delta/plugins/storage/src/test/resources/file/events/file-created.json
+++ b/delta/plugins/storage/src/test/resources/file/events/file-created.json
@@ -13,7 +13,7 @@
   "_rev" : 1,
   "_storage": {
     "@id": "https://bluebrain.github.io/nexus/vocabulary/disk-storage",
-    "@type": "DiskStorage",
+    "@type": "https://bluebrain.github.io/nexus/vocabulary/DiskStorage",
     "_rev": 1
   },
   "_subject" : "http://localhost/v1/realms/myrealm/users/username",

--- a/delta/plugins/storage/src/test/resources/file/events/file-updated.json
+++ b/delta/plugins/storage/src/test/resources/file/events/file-updated.json
@@ -24,7 +24,7 @@
   "_rev" : 2,
   "_storage": {
     "@id": "https://bluebrain.github.io/nexus/vocabulary/disk-storage",
-    "@type": "DiskStorage",
+    "@type": "https://bluebrain.github.io/nexus/vocabulary/DiskStorage",
     "_rev": 1
   },
   "_subject" : "http://localhost/v1/realms/myrealm/users/username",

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FileEventExchangeSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FileEventExchangeSpec.scala
@@ -122,9 +122,9 @@ class FileEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : ["${Vocabulary.contexts.metadata}", "${contexts.files}", {"@vocab": "${nxv.base}"}],
           "@type" : "FileDeprecated",

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileEventSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileEventSpec.scala
@@ -16,6 +16,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Label, ResourceRef, Tag
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
 import io.circe.Printer
+import io.circe.syntax._
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -55,7 +56,7 @@ class FileEventSpec extends AnyWordSpecLike with Matchers with Inspectors with S
         FileDeprecated(fileId, project, 5, epoch, subject)                                                                        -> jsonContentOf("file/events/file-deprecated.json")
       )
       forAll(list) { case (event, json) =>
-        printer.print(event.toCompactedJsonLd.accepted.json) shouldEqual printer.print(json)
+        printer.print(event.asJson) shouldEqual printer.print(json)
       }
     }
   }

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/StorageEventExchangeSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/StorageEventExchangeSpec.scala
@@ -97,9 +97,9 @@ class StorageEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : ["${Vocabulary.contexts.metadata}", "${contexts.storages}"],
           "@type" : "StorageDeprecated",

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/model/StorageEventSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/model/StorageEventSpec.scala
@@ -8,9 +8,9 @@ import ch.epfl.bluebrain.nexus.delta.sdk.crypto.Crypto
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.User
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Label, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
 import io.circe.Printer
+import io.circe.syntax._
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -49,7 +49,7 @@ class StorageEventSpec
         StorageDeprecated(s3Id, project, S3StorageType, 4, epoch, subject)                   -> jsonContentOf("storage/events/storage-deprecated.json")
       )
       forAll(list) { case (event, json) =>
-        printer.print(event.toCompactedJsonLd.accepted.json) shouldEqual printer.print(json)
+        printer.print(event.asJson) shouldEqual printer.print(json)
       }
     }
   }

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourceEventExchangeDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourceEventExchangeDummy.scala
@@ -2,11 +2,10 @@ package ch.epfl.bluebrain.nexus.delta.sdk.testkit
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.{Resource, ResourceEvent, ResourceRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{DataResource, EventExchange, JsonLdValue, Resources}
+import ch.epfl.bluebrain.nexus.delta.sdk.{DataResource, EventExchange, JsonLdValue, JsonValue, Resources}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class ResourceEventExchangeDummy(resources: Resources)(implicit base: BaseUri) e
   override type E = ResourceEvent
   override type M = Unit
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: ResourceEvent => Some(JsonLdValue(ev))
+      case ev: ResourceEvent => Some(JsonValue(ev))
       case _                 => None
     }
 

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SseEventLogDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SseEventLogDummy.scala
@@ -7,14 +7,14 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.{OrganizationScopedEvent, P
 import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.OrganizationRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ProjectRef, ProjectRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{Envelope, Event, Label}
-import ch.epfl.bluebrain.nexus.delta.sdk.{JsonLdValue, SseEventLog}
+import ch.epfl.bluebrain.nexus.delta.sdk.{JsonValue, SseEventLog}
 import fs2.Stream
 import monix.bio.{IO, Task, UIO}
 // $COVERAGE-OFF$
 
-final class SseEventLogDummy(envelopes: Seq[Envelope[Event]], f: PartialFunction[Event, JsonLdValue])
+final class SseEventLogDummy(envelopes: Seq[Envelope[Event]], f: PartialFunction[Event, JsonValue])
     extends SseEventLog {
-  override def stream(offset: Offset): Stream[Task, Envelope[JsonLdValue]]                         =
+  override def stream(offset: Offset): Stream[Task, Envelope[JsonValue]]                         =
     DummyHelpers
       .eventsFromJournal[Event](envelopes, offset, Long.MaxValue)
       .collect { case env if f.isDefinedAt(env.event) => env.map(f) }
@@ -22,7 +22,7 @@ final class SseEventLogDummy(envelopes: Seq[Envelope[Event]], f: PartialFunction
   override def stream[R](
       org: Label,
       offset: Offset
-  )(implicit mapper: Mapper[OrganizationRejection, R]): IO[R, Stream[Task, Envelope[JsonLdValue]]] =
+  )(implicit mapper: Mapper[OrganizationRejection, R]): IO[R, Stream[Task, Envelope[JsonValue]]] =
     UIO.delay(
       DummyHelpers
         .eventsFromJournal[Event](envelopes, offset, Long.MaxValue)
@@ -36,7 +36,7 @@ final class SseEventLogDummy(envelopes: Seq[Envelope[Event]], f: PartialFunction
   override def stream[R](
       project: ProjectRef,
       offset: Offset
-  )(implicit mapper: Mapper[ProjectRejection, R]): IO[R, Stream[Task, Envelope[JsonLdValue]]] =
+  )(implicit mapper: Mapper[ProjectRejection, R]): IO[R, Stream[Task, Envelope[JsonValue]]] =
     UIO.delay(
       DummyHelpers
         .eventsFromJournal[Event](envelopes, offset, Long.MaxValue)

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/EventExchange.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/EventExchange.scala
@@ -33,12 +33,12 @@ trait EventExchange {
   type M
 
   /**
-    * Exchange an event for the JSON-LD encoded event.
+    * Exchange an event for the JSON encoded event.
     *
     * @param event the event to exchange
     * @return some value if the event is defined for this instance, none otherwise
     */
-  def toJsonLdEvent(event: Event): Option[JsonLdValue.Aux[E]]
+  def toJsonEvent(event: Event): Option[JsonValue.Aux[E]]
 
   /**
     * Exchange an event for the latest resource in common formats.

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/JsonValue.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/JsonValue.scala
@@ -1,0 +1,27 @@
+package ch.epfl.bluebrain.nexus.delta.sdk
+
+import io.circe.Encoder
+
+/**
+  * A definition of a value that can be converted to Json
+  */
+sealed trait JsonValue {
+  type A
+  def value: A
+  def encoder: Encoder[A]
+}
+
+object JsonValue {
+
+  type Aux[A0] = JsonValue { type A = A0 }
+
+  /**
+    * Constructs a [[JsonValue]] form a value and its [[Encoder]]
+    */
+  def apply[A0: Encoder](v: A0): JsonValue.Aux[A0] =
+    new JsonValue {
+      override type A = A0
+      override val value: A            = v
+      override val encoder: Encoder[A] = implicitly[Encoder[A]]
+    }
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Projects.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Projects.scala
@@ -169,6 +169,7 @@ object Projects {
 
   type FetchProject       = ProjectRef => IO[ProjectNotFound, Project]
   type FetchProjectByUuid = UUID => IO[ProjectNotFound, Project]
+  type FetchUuids         = ProjectRef => UIO[(UUID, UUID)]
 
   implicit def toFetchProject(projects: Projects): FetchProject             = projects.fetchProject[ProjectNotFound](_)
   implicit def toFetchProjectByUuid(projects: Projects): FetchProjectByUuid = projects.fetch(_).map(_.value)

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/DeltaDirectives.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/DeltaDirectives.scala
@@ -44,6 +44,12 @@ trait DeltaDirectives extends UriDirectives {
     response()
 
   /**
+    * Completes the current Route with the provided conversion to SSEs
+    */
+  def emit(response: ResponseToSse): Route =
+    response()
+
+  /**
     * Completes the current Route with the provided conversion to Json-LD
     */
   def emit(response: ResponseToJsonLd): Route =

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToSse.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToSse.scala
@@ -1,0 +1,81 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.directives
+
+import akka.http.scaladsl.marshalling.sse.EventStreamMarshalling._
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.persistence.query.{NoOffset, Sequence, TimeBasedUUID}
+import akka.stream.scaladsl.Source
+import cats.syntax.functor._
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.sdk.JsonValue
+import ch.epfl.bluebrain.nexus.delta.sdk.directives.DeltaDirectives.emit
+import ch.epfl.bluebrain.nexus.delta.sdk.directives.Response.{Complete, Reject}
+import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.HttpResponseFields
+import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.RdfMarshalling._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Envelope
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import fs2.Stream
+import io.circe.Encoder
+import monix.bio.{IO, Task, UIO}
+import monix.execution.Scheduler
+import streamz.converter._
+
+sealed trait ResponseToSse {
+  def apply(): Route
+}
+
+object ResponseToSse {
+
+  private def apply[E: JsonLdEncoder](
+      io: IO[Response[E], Stream[Task, Envelope[JsonValue]]]
+  )(implicit s: Scheduler, jo: JsonKeyOrdering, cr: RemoteContextResolution): ResponseToSse =
+    new ResponseToSse {
+
+      private def toSse(envelope: Envelope[JsonValue]) = {
+        val json       = envelope.event.encoder(envelope.event.value)
+        val id: String = envelope.offset match {
+          case TimeBasedUUID(value) => value.toString
+          case Sequence(value)      => value.toString
+          case NoOffset             => "-1"
+        }
+        ServerSentEvent(defaultPrinter.print(json.sort), Some(envelope.eventType), Some(id))
+      }
+
+      override def apply(): Route =
+        onSuccess(io.attempt.runToFuture) {
+          case Left(complete: Complete[E]) => emit(complete)
+          case Left(reject: Reject[E])     => emit(reject)
+          case Right(stream)               => complete(OK, Source.fromGraph[ServerSentEvent, Any](stream.map(toSse).toSource))
+        }
+    }
+
+  private def apply[E: JsonLdEncoder, A: Encoder](
+      io: IO[Response[E], Stream[Task, Envelope[A]]]
+  )(implicit s: Scheduler, jo: JsonKeyOrdering, cr: RemoteContextResolution): ResponseToSse =
+    apply[E](io.map(_.map(_.map(JsonValue(_)))))
+
+  implicit def ioStream[E: JsonLdEncoder: HttpResponseFields, A: Encoder](
+      io: IO[E, Stream[Task, Envelope[A]]]
+  )(implicit s: Scheduler, jo: JsonKeyOrdering, cr: RemoteContextResolution): ResponseToSse =
+    ResponseToSse(io.mapError(Complete(_)))
+
+  implicit def streamValue[E: Encoder](
+      value: Stream[Task, Envelope[E]]
+  )(implicit s: Scheduler, jo: JsonKeyOrdering, cr: RemoteContextResolution): ResponseToSse =
+    ResponseToSse(UIO.pure(value))
+
+  implicit def ioStreamJsonValue[E: JsonLdEncoder: HttpResponseFields](
+      io: IO[E, Stream[Task, Envelope[JsonValue]]]
+  )(implicit s: Scheduler, jo: JsonKeyOrdering, cr: RemoteContextResolution): ResponseToSse =
+    ResponseToSse(io.mapError(Complete(_)))
+
+  implicit def streamValueJsonValue(
+      value: Stream[Task, Envelope[JsonValue]]
+  )(implicit s: Scheduler, jo: JsonKeyOrdering, cr: RemoteContextResolution): ResponseToSse =
+    ResponseToSse(UIO.pure(value))
+
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToSse.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToSse.scala
@@ -36,13 +36,13 @@ object ResponseToSse {
     new ResponseToSse {
 
       private def toSse(envelope: Envelope[JsonValue]) = {
-        val json       = envelope.event.encoder(envelope.event.value)
-        val id: String = envelope.offset match {
-          case TimeBasedUUID(value) => value.toString
-          case Sequence(value)      => value.toString
-          case NoOffset             => "-1"
+        val json               = envelope.event.encoder(envelope.event.value)
+        val id: Option[String] = envelope.offset match {
+          case TimeBasedUUID(value) => Some(value.toString)
+          case Sequence(value)      => Some(value.toString)
+          case NoOffset             => None
         }
-        ServerSentEvent(defaultPrinter.print(json.sort), Some(envelope.eventType), Some(id))
+        ServerSentEvent(defaultPrinter.print(json.sort), Some(envelope.eventType), id)
       }
 
       override def apply(): Route =

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/acls/AclEvent.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/acls/AclEvent.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.acls
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.UnScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
@@ -100,7 +99,7 @@ object AclEvent {
   private val context = ContextValue(contexts.metadata, contexts.acls)
 
   @nowarn("cat=unused")
-  implicit def aclEventJsonLdEncoder(implicit baseUri: BaseUri): JsonLdEncoder[AclEvent] = {
+  implicit def aclEventEncoder(implicit baseUri: BaseUri): Encoder[AclEvent] = {
     implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
 
     implicit val config: Configuration = Configuration.default
@@ -122,12 +121,12 @@ object AclEvent {
         )
       }
 
-    implicit val encoder: Encoder.AsObject[AclEvent] = Encoder.AsObject.instance { ev =>
+    Encoder.AsObject.instance { ev =>
       deriveConfiguredEncoder[AclEvent]
         .mapJsonObject(_.add("_aclId", ResourceUris.acl(ev.address).accessUri.asJson).add("_path", ev.address.asJson))
         .encodeObject(ev)
+        .add(keywords.context, context.value)
     }
 
-    JsonLdEncoder.computeFromCirce[AclEvent](context)
   }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/Organization.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/Organization.scala
@@ -1,7 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.model.organizations
 
 import java.util.UUID
-
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
@@ -10,6 +9,8 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.organizations.Organization.Metada
 import io.circe.Encoder
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
+
+import scala.annotation.nowarn
 
 /**
   * Representation of an organization.
@@ -37,7 +38,8 @@ object Organization {
     */
   final case class Metadata(label: Label, uuid: UUID)
 
-  implicit private[Organization] val config: Configuration = Configuration.default.copy(transformMemberNames = {
+  @nowarn("cat=unused")
+  implicit private val config: Configuration = Configuration.default.copy(transformMemberNames = {
     case "label" => nxv.label.prefix
     case "uuid"  => nxv.uuid.prefix
     case other   => other

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/OrganizationEvent.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/organizations/OrganizationEvent.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.organizations
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.OrganizationScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
@@ -116,15 +115,14 @@ object OrganizationEvent {
     })
 
   @nowarn("cat=unused")
-  implicit def organizationEventJsonLdEncoder(implicit base: BaseUri): JsonLdEncoder[OrganizationEvent] = {
-    implicit val subjectEncoder: Encoder[Subject]             = Identity.subjectIdEncoder
-    implicit val encoder: Encoder.AsObject[OrganizationEvent] = Encoder.AsObject.instance { ev =>
+  implicit def organizationEventEncoder(implicit base: BaseUri): Encoder[OrganizationEvent] = {
+    implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
+    Encoder.AsObject.instance { ev =>
       deriveConfiguredEncoder[OrganizationEvent]
         .mapJsonObject(_.add("_organizationId", ResourceUris.organization(ev.label).accessUri.asJson))
         .encodeObject(ev)
+        .add(keywords.context, context.value)
     }
 
-    JsonLdEncoder
-      .computeFromCirce[OrganizationEvent](context)
   }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsEvent.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsEvent.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.permissions
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.UnScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
@@ -85,7 +84,7 @@ object PermissionsEvent {
   private val context = ContextValue(contexts.metadata, contexts.permissions)
 
   @nowarn("cat=unused")
-  implicit final def permissionsEventJsonLdEncoder(implicit baseUri: BaseUri): JsonLdEncoder[PermissionsEvent] = {
+  implicit final def permissionsEventEncoder(implicit baseUri: BaseUri): Encoder[PermissionsEvent] = {
     implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
 
     implicit val derivationConfiguration: Configuration =
@@ -102,13 +101,11 @@ object PermissionsEvent {
         strictDecoding = false
       )
 
-    implicit val encoder: Encoder.AsObject[PermissionsEvent] = Encoder.AsObject.instance { ev =>
+    Encoder.AsObject.instance { ev =>
       deriveConfiguredEncoder[PermissionsEvent]
         .mapJsonObject(_.add("_permissionsId", ResourceUris.permissions.accessUri.asJson))
         .encodeObject(ev)
+        .add(keywords.context, context.value)
     }
-
-    ResourceUris.permissions.accessUri
-    JsonLdEncoder.computeFromCirce[PermissionsEvent](context)
   }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectEvent.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectEvent.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.sdk.model.projects
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.ProjectScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
@@ -157,15 +156,13 @@ object ProjectEvent {
     })
 
   @nowarn("cat=unused")
-  implicit def projectEventJsonLdEncoder(implicit
-      baseUri: BaseUri
-  ): JsonLdEncoder[ProjectEvent] = {
-    implicit val subjectEncoder: Encoder[Subject]        = Identity.subjectIdEncoder
-    implicit val encoder: Encoder.AsObject[ProjectEvent] = Encoder.AsObject.instance { ev =>
+  implicit def projectEventEncoder(implicit baseUri: BaseUri): Encoder[ProjectEvent] = {
+    implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
+    Encoder.AsObject.instance { ev =>
       deriveConfiguredEncoder[ProjectEvent]
         .mapJsonObject(_.add("_projectId", ResourceUris.project(ev.project).accessUri.asJson))
         .encodeObject(ev)
+        .add(keywords.context, context.value)
     }
-    JsonLdEncoder.computeFromCirce[ProjectEvent](context)
   }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmEvent.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/realms/RealmEvent.scala
@@ -4,7 +4,6 @@ import akka.http.scaladsl.model.Uri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.UnScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
@@ -143,15 +142,14 @@ object RealmEvent {
     })
 
   @nowarn("cat=unused")
-  implicit def realmEventJsonLdEncoder(implicit base: BaseUri): JsonLdEncoder[RealmEvent] = {
-    implicit val subjectEncoder: Encoder[Subject]      = Identity.subjectIdEncoder
-    implicit val encoder: Encoder.AsObject[RealmEvent] = Encoder.AsObject.instance { ev =>
+  implicit def realmEventEncoder(implicit base: BaseUri): Encoder[RealmEvent] = {
+    implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
+    Encoder.AsObject.instance { ev =>
       deriveConfiguredEncoder[RealmEvent]
         .mapJsonObject(_.add("_realmId", ResourceUris.realm(ev.label).accessUri.asJson).remove("keys"))
         .encodeObject(ev)
+        .add(keywords.context, context.value)
     }
-
-    JsonLdEncoder.computeFromCirce[RealmEvent](context)
   }
 
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/resources/ResourceEvent.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/resources/ResourceEvent.scala
@@ -4,7 +4,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Event.ProjectScopedEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
@@ -167,13 +166,13 @@ object ResourceEvent {
   implicit private val expandedJsonLdEncoder: Encoder[ExpandedJsonLd] = Encoder.instance(_.json)
 
   @nowarn("cat=unused")
-  implicit def resourceEventJsonLdEncoder(implicit base: BaseUri): JsonLdEncoder[ResourceEvent] = {
-    implicit val subjectEncoder: Encoder[Subject]         = Identity.subjectIdEncoder
-    implicit val encoder: Encoder.AsObject[ResourceEvent] =
-      Encoder.AsObject.instance(
-        deriveConfiguredEncoder[ResourceEvent].mapJsonObject(_.remove("compacted").remove("expanded")).encodeObject
-      )
-
-    JsonLdEncoder.compactedFromCirce[ResourceEvent](context)
+  implicit def resourceEventEncoder(implicit base: BaseUri): Encoder[ResourceEvent] = {
+    implicit val subjectEncoder: Encoder[Subject] = Identity.subjectIdEncoder
+    Encoder.AsObject.instance(ev =>
+      deriveConfiguredEncoder[ResourceEvent]
+        .mapJsonObject(_.remove("compacted").remove("expanded"))
+        .encodeObject(ev)
+        .add(keywords.context, context.value)
+    )
   }
 }

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsEventSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/permissions/PermissionsEventSpec.scala
@@ -1,12 +1,12 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.model.permissions
 
-import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.Permissions.acls
 import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Anonymous
 import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.PermissionsEvent._
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.Fixtures
 import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, IOValues, TestHelpers}
+import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -29,8 +29,8 @@ class PermissionsEventSpec
       Instant.EPOCH,
       Anonymous
     )
-    "be serialized correctly to compacted jsonld" in {
-      event.toCompactedJsonLd.accepted.json shouldEqual
+    "be serialized to json" in {
+      event.asJson shouldEqual
         json"""{
           "@context": [
             "https://bluebrain.github.io/nexus/contexts/metadata.json",
@@ -44,43 +44,6 @@ class PermissionsEventSpec
           "_subject": "${baseUri.endpoint}/anonymous"
         }"""
     }
-    "be serialized correctly to expanded jsonld" in {
-      event.toExpandedJsonLd.accepted.json shouldEqual
-        json"""[{
-          "https://bluebrain.github.io/nexus/vocabulary/permissionsId" : [
-            {
-              "@id" : "http://localhost/permissions"
-            }
-          ],
-          "@type" : [
-            "https://bluebrain.github.io/nexus/vocabulary/PermissionsAppended"
-          ],
-          "https://bluebrain.github.io/nexus/vocabulary/instant" : [
-            {
-              "@value" : "1970-01-01T00:00:00Z"
-            }
-          ],
-          "https://bluebrain.github.io/nexus/vocabulary/rev" : [
-            {
-              "@value" : 1
-            }
-          ],
-          "https://bluebrain.github.io/nexus/vocabulary/metadata/subject" : [
-            {
-              "@value" : "http://localhost/anonymous"
-            }
-          ],
-          "https://bluebrain.github.io/nexus/vocabulary/permissions" : [
-            {
-              "@value" : "acls/read"
-            },
-            {
-              "@value" : "acls/write"
-            }
-          ]
-         }]
-         """
-    }
   }
 
   "A PermissionsSubtracted" should {
@@ -91,7 +54,7 @@ class PermissionsEventSpec
       Anonymous
     )
     "be serialized correctly to compacted jsonld" in {
-      event.toCompactedJsonLd.accepted.json shouldEqual
+      event.asJson shouldEqual
         json"""{
           "@context": [
             "https://bluebrain.github.io/nexus/contexts/metadata.json",
@@ -105,9 +68,6 @@ class PermissionsEventSpec
           "_subject": "${baseUri.endpoint}/anonymous"
         }"""
     }
-    "be serialized to expanded jsonld" in {
-      event.toExpandedJsonLd.accepted
-    }
   }
 
   "A PermissionsReplaced" should {
@@ -118,7 +78,7 @@ class PermissionsEventSpec
       Anonymous
     )
     "be serialized correctly to compacted jsonld" in {
-      event.toCompactedJsonLd.accepted.json shouldEqual
+      event.asJson shouldEqual
         json"""{
           "@context": [
             "https://bluebrain.github.io/nexus/contexts/metadata.json",
@@ -132,9 +92,6 @@ class PermissionsEventSpec
           "_subject": "${baseUri.endpoint}/anonymous"
         }"""
     }
-    "be serialized to expanded jsonld" in {
-      event.toExpandedJsonLd.accepted
-    }
   }
 
   "A PermissionsDeleted" should {
@@ -144,7 +101,7 @@ class PermissionsEventSpec
       Anonymous
     )
     "be serialized correctly to compacted jsonld" in {
-      event.toCompactedJsonLd.accepted.json shouldEqual
+      event.asJson shouldEqual
         json"""{
           "@context": [
             "https://bluebrain.github.io/nexus/contexts/metadata.json",
@@ -156,9 +113,6 @@ class PermissionsEventSpec
           "_instant": "1970-01-01T00:00:00Z",
           "_subject": "${baseUri.endpoint}/anonymous"
         }"""
-    }
-    "be serialized to expanded jsonld" in {
-      event.toExpandedJsonLd.accepted
     }
   }
 

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectEventExchange.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectEventExchange.scala
@@ -2,12 +2,11 @@ package ch.epfl.bluebrain.nexus.delta.service.projects
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.Project.Metadata
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{Project, ProjectEvent, ProjectRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, ProjectResource, Projects}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue, ProjectResource, Projects}
 import io.circe.syntax.EncoderOps
 import monix.bio.{IO, UIO}
 
@@ -22,9 +21,9 @@ class ProjectEventExchange(projects: Projects)(implicit base: BaseUri) extends E
   override type A = Project
   override type M = Metadata
 
-  override def toJsonLdEvent(event: Event): Option[Aux[ProjectEvent]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[ProjectEvent]] =
     event match {
-      case ev: ProjectEvent => Some(JsonLdValue(ev))
+      case ev: ProjectEvent => Some(JsonValue(ev))
       case _                => None
     }
 

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverEventExchange.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverEventExchange.scala
@@ -2,11 +2,10 @@ package ch.epfl.bluebrain.nexus.delta.service.resolvers
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.{Resolver, ResolverEvent, ResolverRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, ResolverResource, Resolvers}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue, ResolverResource, Resolvers}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class ResolverEventExchange(resolvers: Resolvers)(implicit base: BaseUri) extend
   override type E = ResolverEvent
   override type M = Unit
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: ResolverEvent => Some(JsonLdValue(ev))
+      case ev: ResolverEvent => Some(JsonValue(ev))
       case _                 => None
     }
 

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceEventExchange.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceEventExchange.scala
@@ -2,11 +2,10 @@ package ch.epfl.bluebrain.nexus.delta.service.resources
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resources.{Resource, ResourceEvent, ResourceRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{DataResource, EventExchange, JsonLdValue, Resources}
+import ch.epfl.bluebrain.nexus.delta.sdk.{DataResource, EventExchange, JsonLdValue, JsonValue, Resources}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class ResourceEventExchange(resources: Resources)(implicit base: BaseUri) extend
   override type E = ResourceEvent
   override type M = Unit
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: ResourceEvent => Some(JsonLdValue(ev))
+      case ev: ResourceEvent => Some(JsonValue(ev))
       case _                 => None
     }
 

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaEventExchange.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaEventExchange.scala
@@ -2,11 +2,10 @@ package ch.epfl.bluebrain.nexus.delta.service.schemas
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
-import ch.epfl.bluebrain.nexus.delta.sdk.JsonLdValue.Aux
 import ch.epfl.bluebrain.nexus.delta.sdk.ReferenceExchange.ReferenceExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.model.schemas.{Schema, SchemaEvent, SchemaRejection}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Event, TagLabel}
-import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, SchemaResource, Schemas}
+import ch.epfl.bluebrain.nexus.delta.sdk.{EventExchange, JsonLdValue, JsonValue, SchemaResource, Schemas}
 import monix.bio.{IO, UIO}
 
 /**
@@ -20,9 +19,9 @@ class SchemaEventExchange(schemas: Schemas)(implicit base: BaseUri) extends Even
   override type E = SchemaEvent
   override type M = Unit
 
-  override def toJsonLdEvent(event: Event): Option[Aux[E]] =
+  override def toJsonEvent(event: Event): Option[JsonValue.Aux[E]] =
     event match {
-      case ev: SchemaEvent => Some(JsonLdValue(ev))
+      case ev: SchemaEvent => Some(JsonValue(ev))
       case _               => None
     }
 

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectEventExchangeSpec.scala
@@ -2,9 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.projects
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
-import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.Project.Metadata
@@ -37,12 +35,6 @@ class ProjectEventExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
-
-  implicit private def res: RemoteContextResolution =
-    RemoteContextResolution.fixed(
-      contexts.metadata -> jsonContentOf("contexts/metadata.json").topContextValueOrEmpty,
-      contexts.projects -> jsonContentOf("contexts/projects.json").topContextValueOrEmpty
-    )
 
   private val org     = Label.unsafe("myorg")
   private val project = ProjectGen.project("myorg", "myproject", base = nxv.base, uuid = uuid, orgUuid = uuid)
@@ -81,9 +73,9 @@ class ProjectEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : [${contexts.metadata}, ${contexts.projects}],
           "@type" : "ProjectDeprecated",

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverEventExchangeSpec.scala
@@ -91,9 +91,9 @@ class ResolverEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : [${contexts.metadata}, ${contexts.resolvers}],
           "@type" : "ResolverDeprecated",

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceEventExchangeSpec.scala
@@ -107,9 +107,9 @@ class ResourceEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : ${contexts.metadata},
           "@type" : "ResourceDeprecated",

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaEventExchangeSpec.scala
@@ -94,9 +94,9 @@ class SchemaEventExchangeSpec
     }
 
     "return the encoded event" in {
-      val result = exchange.toJsonLdEvent(deprecatedEvent).value
+      val result = exchange.toJsonEvent(deprecatedEvent).value
       result.value shouldEqual deprecatedEvent
-      result.encoder.compact(result.value).accepted.json shouldEqual
+      result.encoder(result.value) shouldEqual
         json"""{
           "@context" : [${contexts.metadata}, ${contexts.shacl}],
           "@type" : "SchemaDeprecated",


### PR DESCRIPTION
This is a work on direction to support uuids on SSEs events. Before that, I've simplified the dealing with SSEs.

SSEs response cannot be turned to expanded, n-triples or anything else. Since that's the case, we did not need all those jsonLdEncoding.