### PR TITLE
File paths now respect tar spec + add n-quads

### DIFF
--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/ArchiveReference.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/ArchiveReference.scala
@@ -1,5 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.archive.model
 
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.UrlUtils
 import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.ArchiveResourceRepresentation.{CompactedJsonLd, SourceJson}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.AbsolutePath
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
@@ -58,6 +59,10 @@ object ArchiveReference {
       representation: Option[ArchiveResourceRepresentation]
   ) extends ArchiveReference {
     override val tpe: ArchiveReferenceType = ArchiveReferenceType.Resource
+
+    def representationOrDefault: ArchiveResourceRepresentation = representation.getOrElse(CompactedJsonLd)
+
+    def defaultFileName = s"${UrlUtils.encode(ref.original.toString)}${representationOrDefault.extension}"
   }
 
   /**

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/ArchiveResourceRepresentation.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/ArchiveResourceRepresentation.scala
@@ -7,53 +7,83 @@ import io.circe.Encoder
 /**
   * Enumeration of representations for resource references.
   */
-sealed trait ArchiveResourceRepresentation extends Product with Serializable
+sealed trait ArchiveResourceRepresentation extends Product with Serializable {
+
+  /**
+    * Default extension for the format
+    */
+  def extension: String
+
+}
 
 object ArchiveResourceRepresentation {
 
   /**
     * Source representation of a resource.
     */
-  final case object SourceJson extends ArchiveResourceRepresentation
+  final case object SourceJson extends ArchiveResourceRepresentation {
+    override def extension: String = ".json"
+
+    override val toString: String = "source"
+  }
 
   /**
     * Compacted JsonLD representation of a resource.
     */
-  final case object CompactedJsonLd extends ArchiveResourceRepresentation
+  final case object CompactedJsonLd extends ArchiveResourceRepresentation {
+    override def extension: String = ".json"
+
+    override val toString: String = "compacted"
+  }
 
   /**
     * Expanded JsonLD representation of a resource.
     */
-  final case object ExpandedJsonLd extends ArchiveResourceRepresentation
+  final case object ExpandedJsonLd extends ArchiveResourceRepresentation {
+    override def extension: String = ".json"
+
+    override val toString: String = "expanded"
+  }
 
   /**
     * NTriples representation of a resource.
     */
-  final case object NTriples extends ArchiveResourceRepresentation
+  final case object NTriples extends ArchiveResourceRepresentation {
+    override def extension: String = ".nt"
+
+    override val toString: String = "n-triples"
+  }
+
+  final case object NQuads extends ArchiveResourceRepresentation {
+    override def extension: String = ".nq"
+
+    override val toString: String = "n-quads"
+  }
 
   /**
     * Dot representation of a resource.
     */
-  final case object Dot extends ArchiveResourceRepresentation
+  final case object Dot extends ArchiveResourceRepresentation {
+    override def extension: String = ".dot"
+
+    override val toString: String = "dot"
+  }
 
   implicit final val archiveResourceRepresentationJsonLdDecoder: JsonLdDecoder[ArchiveResourceRepresentation] =
     JsonLdDecoder.stringJsonLdDecoder.andThen { (cursor, str) =>
       str match {
-        case "source"    => Right(SourceJson)
-        case "compacted" => Right(CompactedJsonLd)
-        case "expanded"  => Right(ExpandedJsonLd)
-        case "n-triples" => Right(NTriples)
-        case "dot"       => Right(Dot)
-        case other       => Left(ParsingFailure("Format", other, cursor.history))
+        case SourceJson.toString      => Right(SourceJson)
+        case CompactedJsonLd.toString => Right(CompactedJsonLd)
+        case ExpandedJsonLd.toString  => Right(ExpandedJsonLd)
+        case NTriples.toString        => Right(NTriples)
+        case NQuads.toString          => Right(NQuads)
+        case Dot.toString             => Right(Dot)
+        case other                    => Left(ParsingFailure("Format", other, cursor.history))
       }
     }
 
   implicit final val archiveResourceRepresentationEncoder: Encoder[ArchiveResourceRepresentation] =
     Encoder.encodeString.contramap {
-      case SourceJson      => "source"
-      case CompactedJsonLd => "compacted"
-      case ExpandedJsonLd  => "expanded"
-      case NTriples        => "n-triples"
-      case Dot             => "dot"
+      _.toString
     }
 }

--- a/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveRoutesSpec.scala
+++ b/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveRoutesSpec.scala
@@ -281,17 +281,17 @@ class ArchiveRoutesSpec
               label = Some(encodedFileId.replaceAll("%3A", ":"))
             )
           result.keySet shouldEqual Set(
-            s"${project.ref}/file.txt",
-            s"${project.ref}/${UrlUtils.encode(fileId.toString)}.json"
+            s"${project.ref}/file/file.txt",
+            s"${project.ref}/compacted/${UrlUtils.encode(fileId.toString)}.json"
           )
 
           val expectedContent = content
-          val actualContent   = result.get(s"${project.ref}/file.txt").value
+          val actualContent   = result.get(s"${project.ref}/file/file.txt").value
           actualContent shouldEqual expectedContent
 
           val expectedMetadata = metadata
           val actualMetadata   =
-            parse(result.get(s"${project.ref}/${UrlUtils.encode(fileId.toString)}.json").value).rightValue
+            parse(result.get(s"${project.ref}/compacted/${UrlUtils.encode(fileId.toString)}.json").value).rightValue
           actualMetadata shouldEqual expectedMetadata
         }
       }


### PR DESCRIPTION
Fixes #2412 
Fixes #2363 

Also:
* Use the proper extension for n-triples, n-quads and dot
* For generated paths,  distribute the files according to the resource representation or if it is a file to be able to fetch both the source and the compacted form for example and to identify them better.