### PR TITLE
WIP Build changes for Apple Silicon

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -823,9 +823,9 @@ lazy val storage = project
     ),
     Test / testOptions       += Tests.Argument(TestFrameworks.ScalaTest, "-o", "-u", "target/test-reports"),
     Test / parallelExecution := false,
-    Universal / mappings     := {
-      (Universal / mappings).value :+ cargo.value
-    }
+//    Universal / mappings     := {
+//      (Universal / mappings).value :+ cargo.value
+//    }
   )
 
 lazy val dockerCompose = Seq(

--- a/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/influx/InfluxDocker.scala
+++ b/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/influx/InfluxDocker.scala
@@ -14,7 +14,7 @@ object InfluxDocker extends ContainerDef {
 
   override def config: InfluxDocker.Config =
     ContainerConfig(
-      image = "library/influxdb:1.8.0",
+      image = "library/influxdb:1.8.6",
       ports = Seq(primaryPort),
       env = Map("INFLUXDB_REPORTING_DISABLED" -> "true", "INFLUXDB_HTTP_FLUX_ENABLED" -> "true"),
       reuse = ReuseEnabled

--- a/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/postgres/PostgresDocker.scala
+++ b/cli/src/test/scala/ch/epfl/bluebrain/nexus/cli/postgres/PostgresDocker.scala
@@ -17,7 +17,7 @@ object PostgresDocker extends ContainerDef {
 
   override def config: PostgresDocker.Config =
     ContainerConfig(
-      image = "library/postgres:12.2",
+      image = "library/postgres:12.7",
       ports = Seq(primaryPort),
       env = Map("POSTGRES_PASSWORD" -> password),
       reuse = ReuseEnabled,

--- a/delta/app/src/main/resources/akka.conf
+++ b/delta/app/src/main/resources/akka.conf
@@ -35,8 +35,8 @@ akka {
     }
 
     distributed-data.durable {
-      keys = ["*"]
-      lmdb.dir = "/tmp/delta-cache"
+//      keys = ["*"]
+//      lmdb.dir = "/tmp/delta-cache"
     }
 
     downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"

--- a/delta/plugins/blazegraph/Dockerfile
+++ b/delta/plugins/blazegraph/Dockerfile
@@ -1,0 +1,37 @@
+FROM adoptopenjdk:11-jre-hotspot
+LABEL MAINTAINER="Nexus Team <noreply@epfl.ch>"
+ENV BLAZEGRAPH_VERSION=2_1_6_RC
+ENV JETTY_START_TIMEOUT=120
+ENV BLAZEGRAPH_HOME=/var/lib/blazegraph
+ENV BLAZEGRAPH_DATA=${BLAZEGRAPH_HOME}/data
+ADD https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_${BLAZEGRAPH_VERSION}/blazegraph.jar ${BLAZEGRAPH_HOME}/blazegraph.jar
+USER root
+RUN {\
+    echo "com.bigdata.journal.AbstractJournal.initialExtent=209715200"; \
+    echo "com.bigdata.journal.AbstractJournal.maximumExtent=209715200"; \
+    echo "com.bigdata.rdf.sail.truthMaintenance=false"; \
+    echo "com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms"; \
+    echo "com.bigdata.rdf.store.AbstractTripleStore.justify=false"; \
+    echo "com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false"; \
+    echo "com.bigdata.rdf.store.AbstractTripleStore.textIndex=true"; \
+    echo "com.bigdata.journal.AbstractJournal.bufferMode=DiskRW"; \
+    echo "com.bigdata.journal.AbstractJournal.file=${BLAZEGRAPH_DATA}/blazegraph.jnl"; \
+    echo "com.bigdata.rdf.store.DataLoader.bufferCapacity=100000"; \
+    echo "com.bigdata.rdf.store.DataLoader.closure=None"; \
+    echo "com.bigdata.rdf.store.DataLoader.ignoreInvalidFiles=true"; \
+} > ${BLAZEGRAPH_HOME}/RWStore.properties
+RUN {\
+      echo "#!/bin/bash"; \
+      echo "java -server \${JAVA_OPTS} -Djetty.start.timeout=${JETTY_START_TIMEOUT} -Dbigdata.propertyFile=${BLAZEGRAPH_HOME}/RWStore.properties -jar ${BLAZEGRAPH_HOME}/blazegraph.jar"; \
+    } > ${BLAZEGRAPH_HOME}/start.sh
+RUN groupadd -r blazegraph  && useradd -r -g blazegraph blazegraph
+RUN chown -R blazegraph:0 /var/lib/blazegraph
+RUN chmod -R ug+rw /var/lib/blazegraph && chmod +x /var/lib/blazegraph/start.sh
+RUN apt-get -qq update
+RUN apt-get -yq install dnsutils procps
+RUN apt-get clean
+USER blazegraph
+WORKDIR ${BLAZEGRAPH_HOME}
+EXPOSE 9999
+ENV NO_PROXY="*" HTTP_PROXY="" HTTPS_PROXY="" no_proxy="*" http_proxy="" https_proxy=""
+ENTRYPOINT "${BLAZEGRAPH_HOME}/start.sh"

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphDocker.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphDocker.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 
 trait BlazegraphDocker extends DockerKitWithFactory {
 
-  val blazegraphContainer: DockerContainer = DockerContainer("bluebrain/blazegraph-nexus:2.1.5")
+  val blazegraphContainer: DockerContainer = DockerContainer("bogdanromanx/blazegraph:2.1.6-RC")
     .withPorts(DefaultPort -> Some(DefaultPort))
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(DefaultPort).looped(30, 1.second)

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/client/BlazegraphClientSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/client/BlazegraphClientSpec.scala
@@ -119,7 +119,7 @@ class BlazegraphClientSpec
   "A Blazegraph Client" should {
 
     "fetch the service description" in {
-      client.serviceDescription.accepted shouldEqual ServiceDescription(Name.unsafe("blazegraph"), "2.1.5")
+      client.serviceDescription.accepted shouldEqual ServiceDescription(Name.unsafe("blazegraph"), "2.1.6-SNAPSHOT")
     }
 
     "verify a namespace does not exist" in {

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/database/PostgresServiceDependencySpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/database/PostgresServiceDependencySpec.scala
@@ -31,7 +31,7 @@ class PostgresServiceDependencySpec
 
     "fetch its service name and version" in {
       new PostgresServiceDependency(config).serviceDescription.accepted shouldEqual
-        ServiceDescription(Name.unsafe("postgres"), "12.2")
+        ServiceDescription(Name.unsafe("postgres"), "12.7")
     }
   }
 

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/postgres/PostgresDocker.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/postgres/PostgresDocker.scala
@@ -25,7 +25,7 @@ trait PostgresDocker extends DockerKitWithFactory {
       PostgresExposedPort
     )
 
-  val postgresContainer: DockerContainer = DockerContainer("library/postgres:12.2")
+  val postgresContainer: DockerContainer = DockerContainer("library/postgres:12.7")
     .withPorts((PostgresAdvertisedPort, Some(PostgresExposedPort)))
     .withEnv(s"POSTGRES_USER=$PostgresUser", s"POSTGRES_PASSWORD=$PostgresPassword")
     .withReadyChecker(

--- a/tests/docker/docker-compose-cassandra.yml
+++ b/tests/docker/docker-compose-cassandra.yml
@@ -89,7 +89,7 @@ services:
 #      - "8080"
 
   keycloak:
-    image: jboss/keycloak:11.0.1<skipPull>
+    image: bogdanromanx/keycloak:11.0.1<skipPull>
     environment:
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
@@ -112,14 +112,14 @@ services:
       - "9200"
 
   blazegraph:
-    image: bluebrain/blazegraph-nexus:2.1.5<skipPull>
+    image: bogdanromanx/blazegraph:2.1.6-RC<skipPull>
     environment:
-      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=300m -Xms1g -Xmx1g -XX:+UseG1GC"
+      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=300m -Xms1g -Xmx1g"
     ports:
       - "9999"
 
   cassandra:
-    image: cassandra:3.11.8<skipPull>
+    image: library/cassandra:3.11.10<skipPull>
     environment:
       JVM_OPTS: "-Xms1g -Xmx1g -Dcassandra.initial_token=0 -Dcassandra.skip_wait_for_gossip_to_settle=0"
       MAX_HEAP_SIZE: "1G"
@@ -132,7 +132,7 @@ services:
       retries: 3
 
   storage-service:
-    image: bluebrain/nexus-storage:latest
+    image: bluebrain/nexus-storage:latest<localBuild>
     entrypoint: [ "./bin/storage",
                   "-Dapp.instance.interface=0.0.0.0",
                   "-Dapp.http.interface=0.0.0.0",
@@ -153,7 +153,7 @@ services:
       - /tmp/storage:/data
 
   minio:
-    image: minio/minio:RELEASE.2020-09-21T22-31-59Z<skipPull>
+    image: minio/minio:RELEASE.2021-05-26T00-22-46Z<skipPull>
     command: server /data
     environment:
       MINIO_ACCESS_KEY: "MY_ACCESS_KEY"

--- a/tests/docker/docker-compose-postgres.yml
+++ b/tests/docker/docker-compose-postgres.yml
@@ -85,7 +85,7 @@ services:
   #      - "8080"
 
   keycloak:
-    image: jboss/keycloak:11.0.1<skipPull>
+    image: bogdanromanx/keycloak:11.0.1<skipPull>
     environment:
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
@@ -109,20 +109,20 @@ services:
       - "9200"
 
   blazegraph:
-    image: bluebrain/blazegraph-nexus:2.1.5<skipPull>
+    image: bogdanromanx/blazegraph:2.1.6-RC<skipPull>
     environment:
-      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=300m -Xms1g -Xmx1g -XX:+UseG1GC"
+      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=300m -Xms1g -Xmx1g"
     ports:
       - "9999"
 
   postgres:
-    image: library/postgres:12.2<skipPull>
+    image: library/postgres:12.7<skipPull>
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"
 
   storage-service:
-    image: bluebrain/nexus-storage:latest
+    image: bluebrain/nexus-storage:latest<localBuild>
     entrypoint: [ "./bin/storage",
                   "-Dapp.instance.interface=0.0.0.0",
                   "-Dapp.http.interface=0.0.0.0",
@@ -143,7 +143,7 @@ services:
       - /tmp/storage:/data
 
   minio:
-    image: minio/minio:RELEASE.2020-09-21T22-31-59Z<skipPull>
+    image: minio/minio:RELEASE.2021-05-26T00-22-46Z<skipPull>
     command: server /data
     environment:
       MINIO_ACCESS_KEY: "MY_ACCESS_KEY"


### PR DESCRIPTION
Most things work out of the box, but there are a few dependencies that don't have docker images published for arm64 (currently: blazegraph and keycloak).
The durable distributed-data config needs to be removed because the library used attempts but cannot load a native binary. A related issue: https://github.com/lmdbjava/native/issues/10

Info on building multi-arch images: https://docs.docker.com/desktop/multi-arch/

The PR includes a Dockerfile for building a blazegraph image for arm64. It requires a version bump to 2.1.6-RC because 2.1.5 does not support a jvm > 1.8.

Keycloak needs to also be built because when running emulated it has issues resolving the loopback address. The image source is https://github.com/keycloak/keycloak-containers at tag `11.0.1`.
The `Dockerfile` requires changing the base image to `redhat/ubi8-minimal:8.4`.

The cargo is commented in build.sbt to be able to produce the storage service image.

This blog post explains how to produce multi arch images starting from sbt-native-packager: https://www.acervera.com/blog/2020/04/sbt-docker-buildx-multi-arch/