### PR TITLE
Improve integration tests

### DIFF
--- a/tests/docker/docker-compose-cassandra.yml
+++ b/tests/docker/docker-compose-cassandra.yml
@@ -52,23 +52,30 @@ services:
 #      KAMON_ENABLED: "false"
 #    image: bluebrain/nexus-delta:latest<localBuild>
 #    entrypoint: [ "bin/wait-for-it.sh", "-s", "-t", "0", "delta:8080", "--", "./bin/delta-app",
-#                  "-Xmx2G",
+#                  "-Xmx512m",
 #                  "-Dapp.http.interface=0.0.0.0",
 #                  "-Dapp.http.base-uri=http://delta:8080/v1",
 #                  "-Dapp.cluster.remote-interface=delta2",
 #                  "-Dapp.cluster.seeds=delta:25520",
 #                  "-Dapp.database.cassandra.contact-points.1=cassandra:9042",
 #                  "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+#                  "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
 #                  "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-#                  "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+#                  "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+#                  "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+#                  "-Dplugins.composite-views.indexing.max-time-window=50ms",
 #                  "-Dplugins.storage.storages.remote-disk.enabled=true",
 #                  "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
 #                  "-Dplugins.storage.storages.amazon.enabled=true",
 #                  "-Dakka.persistence.cassandra.events-by-tag.first-time-bucket=20210503T00:00",
-#                  "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=4s",
-#                  "-Dakka.persistence.cassandra.query.refresh-interval=1s"]
+#                  "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=2s",
+#                  "-Dakka.persistence.cassandra.query.refresh-interval=500ms"]
 #    ports:
 #      - "8080"
+#    deploy:
+#      resources:
+#        limits:
+#          memory: 768M
 #
 #  delta3:
 #    depends_on:
@@ -78,23 +85,30 @@ services:
 #      KAMON_ENABLED: "false"
 #    image: bluebrain/nexus-delta:latest<localBuild>
 #    entrypoint: [ "bin/wait-for-it.sh", "-s", "-t", "0", "delta2:8080", "--", "./bin/delta-app",
-#                  "-Xmx2G",
+#                  "-Xmx512m",
 #                  "-Dapp.http.interface=0.0.0.0",
 #                  "-Dapp.http.base-uri=http://delta:8080/v1",
 #                  "-Dapp.cluster.remote-interface=delta3",
 #                  "-Dapp.cluster.seeds=delta:25520",
 #                  "-Dapp.database.cassandra.contact-points.1=cassandra:9042",
 #                  "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+#                  "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
 #                  "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-#                  "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+#                  "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+#                  "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+#                  "-Dplugins.composite-views.indexing.max-time-window=50ms",
 #                  "-Dplugins.storage.storages.remote-disk.enabled=true",
 #                  "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
 #                  "-Dplugins.storage.storages.amazon.enabled=true",
 #                  "-Dakka.persistence.cassandra.events-by-tag.first-time-bucket=20210503T00:00",
-#                  "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=4s",
-#                  "-Dakka.persistence.cassandra.query.refresh-interval=1s"]
+#                  "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=2s",
+#                  "-Dakka.persistence.cassandra.query.refresh-interval=500ms"]
 #    ports:
 #      - "8080"
+#    deploy:
+#      resources:
+#        limits:
+#          memory: 768M
 
   keycloak:
     image: jboss/keycloak:11.0.1<skipPull>

--- a/tests/docker/docker-compose-cassandra.yml
+++ b/tests/docker/docker-compose-cassandra.yml
@@ -4,6 +4,7 @@ services:
     depends_on:
       - keycloak
       - elasticsearch
+      - blazegraph
       - cassandra
       - storage-service
       - minio
@@ -12,7 +13,7 @@ services:
       KAMON_ENABLED: "false"
     image: bluebrain/nexus-delta:latest<localBuild>
     entrypoint: ["bin/wait-for-it.sh", "-s", "-t", "0", "cassandra:9042", "--", "./bin/delta-app",
-                 "-Xmx2G",
+                 "-Xmx512m",
                  "-Dapp.http.interface=0.0.0.0",
                  "-Dapp.http.base-uri=http://delta:8080/v1",
                  "-Dapp.cluster.remote-interface=delta",
@@ -21,16 +22,23 @@ services:
                  "-Dapp.database.cassandra.keyspace-autocreate=true",
                  "-Dapp.database.cassandra.tables-autocreate=true",
                  "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+                 "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
                  "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-                 "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+                 "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+                 "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+                 "-Dplugins.composite-views.indexing.max-time-window=50ms",
                  "-Dplugins.storage.storages.remote-disk.enabled=true",
                  "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
                  "-Dplugins.storage.storages.amazon.enabled=true",
                  "-Dakka.persistence.cassandra.events-by-tag.first-time-bucket=20210503T00:00",
-                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=4s",
-                 "-Dakka.persistence.cassandra.query.refresh-interval=1s"]
+                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=2s",
+                 "-Dakka.persistence.cassandra.query.refresh-interval=500ms"]
     ports:
       - "8080"
+    deploy:
+      resources:
+        limits:
+          memory: 768M
 
 #########################################################
 #  Uncomment the following lines to run a local cluster #
@@ -91,16 +99,22 @@ services:
   keycloak:
     image: jboss/keycloak:11.0.1<skipPull>
     environment:
+      JAVA_OPTS: "-Xms64m -Xmx256m"
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
       KEYCLOAK_FRONTEND_URL: "http://keycloak:8080/auth"
+      DB_VENDOR: H2
     ports:
       - "8080"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0<skipPull>
     environment:
-      ES_JAVA_OPTS: "-Xmx1G"
+      ES_JAVA_OPTS: "-Xmx256m"
       discovery.type: "single-node"
       bootstrap.memory_lock: "true"
     healthcheck:
@@ -110,30 +124,41 @@ services:
       retries: 3
     ports:
       - "9200"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
 
   blazegraph:
     image: bluebrain/blazegraph-nexus:2.1.5<skipPull>
     environment:
-      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=300m -Xms1g -Xmx1g -XX:+UseG1GC"
+      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=64m -Xmx256m -XX:+UseG1GC"
     ports:
       - "9999"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
 
   cassandra:
     image: cassandra:3.11.8<skipPull>
     environment:
-      JVM_OPTS: "-Xms1g -Xmx1g -Dcassandra.initial_token=0 -Dcassandra.skip_wait_for_gossip_to_settle=0"
-      MAX_HEAP_SIZE: "1G"
+      JVM_OPTS: "-Xms300m -Xmx512m -Dcassandra.initial_token=0 -Dcassandra.skip_wait_for_gossip_to_settle=0"
+      MAX_HEAP_SIZE: "512m"
       HEAP_NEWSIZE: "100m"
       CASSANDRA_BROADCAST_ADDRESS: cassandra
+      CASSANDRA_NUM_TOKENS: 1
     healthcheck:
       test: ["CMD", "cqlsh","-e describe keyspaces"]
       interval: 30s
       timeout: 20s
       retries: 3
 
+
   storage-service:
     image: bluebrain/nexus-storage:latest
     entrypoint: [ "./bin/storage",
+                  "-Xmx192m",
                   "-Dapp.instance.interface=0.0.0.0",
                   "-Dapp.http.interface=0.0.0.0",
                   "-Dapp.http.public-uri=http://storage.tests.nexus.ocp.bbp.epfl.ch",
@@ -151,6 +176,10 @@ services:
       - "8080"
     volumes:
       - /tmp/storage:/data
+    deploy:
+      resources:
+        limits:
+          memory: 256M
 
   minio:
     image: minio/minio:RELEASE.2020-09-21T22-31-59Z<skipPull>

--- a/tests/docker/docker-compose-ci.yml
+++ b/tests/docker/docker-compose-ci.yml
@@ -16,21 +16,23 @@ services:
                  "-Xmx4G",
                  "-Dapp.http.interface=0.0.0.0",
                  "-Dapp.http.base-uri=http://delta:8080/v1",
+                 "-Dapp.cluster.remote-interface=delta",
+                 "-Dapp.cluster.seeds=delta:25520",
                  "-Dapp.database.cassandra.contact-points.1=cassandra:9042",
                  "-Dapp.database.cassandra.keyspace-autocreate=true",
                  "-Dapp.database.cassandra.tables-autocreate=true",
-                 "-Dapp.cluster.remote-interface=delta",
-                 "-Dapp.cluster.seeds=delta:25520",
-#                 "-Dakka.cluster.min-nr-of-members=3",
                  "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+                 "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
                  "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-                 "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+                 "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+                 "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+                 "-Dplugins.composite-views.indexing.max-time-window=50ms",
                  "-Dplugins.storage.storages.remote-disk.enabled=true",
                  "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
                  "-Dplugins.storage.storages.amazon.enabled=true",
                  "-Dakka.persistence.cassandra.events-by-tag.first-time-bucket=20210503T00:00",
-                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=4s",
-                 "-Dakka.persistence.cassandra.query.refresh-interval=1s"]
+                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=2s",
+                 "-Dakka.persistence.cassandra.query.refresh-interval=500ms"]
     ports:
       - "8080"
 
@@ -94,6 +96,7 @@ services:
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
       KEYCLOAK_FRONTEND_URL: "http://keycloak:8080/auth"
+      DB_VENDOR: H2
     ports:
       - "8080"
 

--- a/tests/docker/docker-compose-ci.yml
+++ b/tests/docker/docker-compose-ci.yml
@@ -52,14 +52,17 @@ services:
 #                 "-Dakka.cluster.min-nr-of-members=3",
 #                 "-Dapp.database.cassandra.contact-points.1=cassandra:9042",
 #                 "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+#                 "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
 #                 "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-#                 "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+#                 "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+#                 "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+#                 "-Dplugins.composite-views.indexing.max-time-window=50ms",
 #                 "-Dplugins.storage.storages.remote-disk.enabled=true",
 #                 "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
 #                 "-Dplugins.storage.storages.amazon.enabled=true",
 #                 "-Dakka.persistence.cassandra.events-by-tag.first-time-bucket=20210503T00:00",
-#                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=4s",
-#                 "-Dakka.persistence.cassandra.query.refresh-interval=1s"]
+#                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=2s",
+#                 "-Dakka.persistence.cassandra.query.refresh-interval=500ms"]
 #    ports:
 #      - "8080"
 #
@@ -79,14 +82,17 @@ services:
 #                 "-Dakka.cluster.min-nr-of-members=3",
 #                 "-Dapp.database.cassandra.contact-points.1=cassandra:9042",
 #                 "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+#                 "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
 #                 "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-#                 "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+#                 "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+#                 "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+#                 "-Dplugins.composite-views.indexing.max-time-window=50ms",
 #                 "-Dplugins.storage.storages.remote-disk.enabled=true",
 #                 "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
 #                 "-Dplugins.storage.storages.amazon.enabled=true",
 #                 "-Dakka.persistence.cassandra.events-by-tag.first-time-bucket=20210503T00:00",
-#                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=4s",
-#                 "-Dakka.persistence.cassandra.query.refresh-interval=1s"]
+#                 "-Dakka.persistence.cassandra.events-by-tag.eventual-consistency-delay=2s",
+#                 "-Dakka.persistence.cassandra.query.refresh-interval=500ms"]
 #    ports:
 #      - "8080"
 

--- a/tests/docker/docker-compose-postgres.yml
+++ b/tests/docker/docker-compose-postgres.yml
@@ -12,7 +12,7 @@ services:
       KAMON_ENABLED: "false"
     image: bluebrain/nexus-delta:latest<localBuild>
     entrypoint: [ "bin/wait-for-it.sh", "-s", "-t", "0", "postgres:5432", "--", "./bin/delta-app",
-                  "-Xmx2G",
+                  "-Xmx512m",
                   "-Dapp.http.interface=0.0.0.0",
                   "-Dapp.http.base-uri=http://delta:8080/v1",
                   "-Dapp.cluster.remote-interface=delta",
@@ -21,14 +21,21 @@ services:
                   "-Dapp.database.postgres.host=postgres",
                   "-Dapp.database.postgres.tables-autocreate=true",
                   "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+                  "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
                   "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-                  "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+                  "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+                  "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+                  "-Dplugins.composite-views.indexing.max-time-window=50ms",
                   "-Dplugins.storage.storages.remote-disk.enabled=true",
                   "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
                   "-Dplugins.storage.storages.amazon.enabled=true",
-                  "-Djdbc-read-journal.refresh-interval=1s"]
+                  "-Djdbc-read-journal.refresh-interval=500ms"]
     ports:
       - "8080"
+    deploy:
+      resources:
+        limits:
+          memory: 768M
 
   #########################################################
   #  Uncomment the following lines to run a local cluster #
@@ -87,17 +94,22 @@ services:
   keycloak:
     image: jboss/keycloak:11.0.1<skipPull>
     environment:
+      JAVA_OPTS: "-Xms64m -Xmx256m"
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
       KEYCLOAK_FRONTEND_URL: "http://keycloak:8080/auth"
       DB_VENDOR: H2
     ports:
       - "8080"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0<skipPull>
     environment:
-      ES_JAVA_OPTS: "-Xmx1G"
+      ES_JAVA_OPTS: "-Xmx256m"
       discovery.type: "single-node"
       bootstrap.memory_lock: "true"
     healthcheck:
@@ -107,13 +119,21 @@ services:
       retries: 3
     ports:
       - "9200"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
 
   blazegraph:
     image: bluebrain/blazegraph-nexus:2.1.5<skipPull>
     environment:
-      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=300m -Xms1g -Xmx1g -XX:+UseG1GC"
+      JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxDirectMemorySize=64m -Xmx256m -XX:+UseG1GC"
     ports:
       - "9999"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
 
   postgres:
     image: library/postgres:12.2<skipPull>
@@ -124,6 +144,7 @@ services:
   storage-service:
     image: bluebrain/nexus-storage:latest
     entrypoint: [ "./bin/storage",
+                  "-Xmx192m",
                   "-Dapp.instance.interface=0.0.0.0",
                   "-Dapp.http.interface=0.0.0.0",
                   "-Dapp.http.public-uri=http://storage.tests.nexus.ocp.bbp.epfl.ch",
@@ -141,6 +162,10 @@ services:
       - "8080"
     volumes:
       - /tmp/storage:/data
+    deploy:
+      resources:
+        limits:
+          memory: 256M
 
   minio:
     image: minio/minio:RELEASE.2020-09-21T22-31-59Z<skipPull>

--- a/tests/docker/docker-compose-postgres.yml
+++ b/tests/docker/docker-compose-postgres.yml
@@ -49,7 +49,7 @@ services:
   #      KAMON_ENABLED: "false"
   #    image: bluebrain/nexus-delta:latest<localBuild>
   #    entrypoint: [ "bin/wait-for-it.sh", "-s", "-t", "0", "delta:8080", "--", "./bin/delta-app",
-  #                  "-Xmx2G",
+  #                  "-Xmx512m",
   #                  "-Dapp.http.interface=0.0.0.0",
   #                  "-Dapp.http.base-uri=http://delta:8080/v1",
   #                  "-Dapp.cluster.remote-interface=delta2",
@@ -57,14 +57,21 @@ services:
   #                  "-Dapp.database.flavour=postgres",
   #                  "-Dapp.database.postgres.host=postgres",
   #                  "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+  #                  "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
   #                  "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-  #                  "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+  #                  "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+  #                  "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+  #                  "-Dplugins.composite-views.indexing.max-time-window=50ms",
   #                  "-Dplugins.storage.storages.remote-disk.enabled=true",
   #                  "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
   #                  "-Dplugins.storage.storages.amazon.enabled=true",
-  #                  "-Djdbc-read-journal.refresh-interval=1s"]
+  #                  "-Djdbc-read-journal.refresh-interval=500ms"]
   #    ports:
   #      - "8080"
+  #    deploy:
+  #     resources:
+  #       limits:
+  #         memory: 768M
   #
   #  delta3:
   #    depends_on:
@@ -74,7 +81,7 @@ services:
   #      KAMON_ENABLED: "false"
   #    image: bluebrain/nexus-delta:latest<localBuild>
   #    entrypoint: [ "bin/wait-for-it.sh", "-s", "-t", "0", "delta2:8080", "--", "./bin/delta-app",
-  #                  "-Xmx2G",
+  #                  "-Xmx512m",
   #                  "-Dapp.http.interface=0.0.0.0",
   #                  "-Dapp.http.base-uri=http://delta:8080/v1",
   #                  "-Dapp.cluster.remote-interface=delta3",
@@ -82,14 +89,21 @@ services:
   #                  "-Dapp.database.flavour=postgres",
   #                  "-Dapp.database.postgres.host=postgres",
   #                  "-Dplugins.elasticsearch.base=http://elasticsearch:9200",
+  #                  "-Dplugins.elasticsearch.indexing.max-time-window=50ms",
   #                  "-Dplugins.blazegraph.base=http://blazegraph:9999/blazegraph",
-  #                  "-Dplugins.composite-views.min-interval-rebuild=15seconds",
+  #                  "-Dplugins.blazegraph.indexing.max-time-window=50ms",
+  #                  "-Dplugins.composite-views.min-interval-rebuild=5seconds",
+  #                  "-Dplugins.composite-views.indexing.max-time-window=50ms",
   #                  "-Dplugins.storage.storages.remote-disk.enabled=true",
   #                  "-Dplugins.storage.storages.remote-disk.default-endpoint=http://storage-service:8080/v1",
   #                  "-Dplugins.storage.storages.amazon.enabled=true",
-  #                  "-Djdbc-read-journal.refresh-interval=1s"]
+  #                  "-Djdbc-read-journal.refresh-interval=500ms"
   #    ports:
   #      - "8080"
+  #    deploy:
+  #      resources:
+  #        limits:
+  #          memory: 768M
 
   keycloak:
     image: jboss/keycloak:11.0.1<skipPull>

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -2,6 +2,7 @@ tests {
   delta-uri = "http://delta:8080/v1"
   realm-uri = "http://keycloak:8080/auth/realms"
   patience = 20 seconds
+  clean-up = true
 }
 
 storage {

--- a/tests/src/test/resources/elasticsearch/template.json
+++ b/tests/src/test/resources/elasticsearch/template.json
@@ -5,7 +5,7 @@
     "settings" : {
       "number_of_shards": 1,
       "number_of_replicas": 0,
-      "refresh_interval": "1s"
+      "refresh_interval": "200ms"
     }
   }
 }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/ElasticsearchDsl.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/ElasticsearchDsl.scala
@@ -1,7 +1,7 @@
 package ch.epfl.bluebrain.nexus.tests
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.HttpMethods.PUT
+import akka.http.scaladsl.model.HttpMethods.{DELETE, PUT}
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, StatusCode}
 import akka.stream.Materializer
 import ch.epfl.bluebrain.nexus.testkit.TestHelpers
@@ -45,5 +45,18 @@ class ElasticsearchDsl(implicit as: ActorSystem, materializer: Materializer) ext
       res.status
     }
   }
+
+  def deleteAllIndices(): Task[StatusCode] =
+    elasticClient(
+      HttpRequest(
+        method = DELETE,
+        uri = s"$elasticUrl/delta_*"
+      )
+    ).tapError { t =>
+      Task { logger.error(s"Error while deleting elasticsearch indices", t) }
+    }.map { res =>
+      logger.info(s"Deleting elasticsearch indices returned ${res.status}")
+      res.status
+    }
 
 }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/Identity.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/Identity.scala
@@ -1,8 +1,10 @@
 package ch.epfl.bluebrain.nexus.tests
 
+import ch.epfl.bluebrain.nexus.testkit.TestHelpers
+
 sealed trait Identity extends Product with Serializable
 
-object Identity {
+object Identity extends TestHelpers {
 
   case object Anonymous extends Identity
 
@@ -27,5 +29,49 @@ object Identity {
   val ServiceAccount: ClientCredentials = ClientCredentials("delta", "shhh", internal)
 
   val Delta: UserCredentials = UserCredentials("delta", "shhh", internal)
+
+  val testRealm  = Realm("test-" + genString())
+  val testClient = Identity.ClientCredentials(genString(), genString(), testRealm)
+
+  object acls {
+    val Marge = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object archives {
+    val Tweety = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object compositeviews {
+    val Jerry = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object events {
+    val BugsBunny = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object orgs {
+    val Fry   = UserCredentials(genString(), genString(), testRealm)
+    val Leela = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object projects {
+    val Bojack          = UserCredentials(genString(), genString(), testRealm)
+    val PrincessCarolyn = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object resources {
+    val Rick = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object storages {
+    val Coyote = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  object views {
+    val ScoobyDoo = UserCredentials(genString(), genString(), testRealm)
+  }
+
+  lazy val allUsers =
+    acls.Marge :: archives.Tweety :: compositeviews.Jerry :: events.BugsBunny :: orgs.Fry :: orgs.Leela :: projects.Bojack :: projects.PrincessCarolyn :: resources.Rick :: storages.Coyote :: views.ScoobyDoo :: Nil
 
 }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/admin/OrgsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/admin/OrgsSpec.scala
@@ -2,31 +2,16 @@ package ch.epfl.bluebrain.nexus.tests.admin
 
 import akka.http.scaladsl.model.StatusCodes
 import ch.epfl.bluebrain.nexus.testkit.EitherValuable
-import ch.epfl.bluebrain.nexus.tests.Identity.UserCredentials
+import ch.epfl.bluebrain.nexus.tests.Identity.orgs.{Fry, Leela}
 import ch.epfl.bluebrain.nexus.tests.Optics._
 import ch.epfl.bluebrain.nexus.tests.Tags.OrgsTag
-import ch.epfl.bluebrain.nexus.tests.{BaseSpec, ExpectedResponse, Identity, Realm}
+import ch.epfl.bluebrain.nexus.tests.{BaseSpec, ExpectedResponse}
 import io.circe.Json
 import monix.execution.Scheduler.Implicits.global
 
 class OrgsSpec extends BaseSpec with EitherValuable {
 
-  private val testRealm  = Realm("orgs" + genString())
-  private val testClient = Identity.ClientCredentials(genString(), genString(), testRealm)
-  private val Fry        = UserCredentials(genString(), genString(), testRealm)
-  private val Leela      = UserCredentials(genString(), genString(), testRealm)
-
   import ch.epfl.bluebrain.nexus.tests.iam.types.Permission._
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    initRealm(
-      testRealm,
-      Identity.ServiceAccount,
-      testClient,
-      Fry :: Leela :: Nil
-    ).runSyncUnsafe()
-  }
 
   private val UnauthorizedAccess = ExpectedResponse(
     StatusCodes.Forbidden,

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/config/TestsConfig.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/config/TestsConfig.scala
@@ -5,7 +5,7 @@ import ch.epfl.bluebrain.nexus.tests.Realm
 
 import scala.concurrent.duration.FiniteDuration
 
-case class TestsConfig(deltaUri: Uri, realmUri: Uri, patience: FiniteDuration) {
+case class TestsConfig(deltaUri: Uri, realmUri: Uri, patience: FiniteDuration, cleanUp: Boolean) {
 
   def realmSuffix(realm: Realm) = s"$realmUri/${realm.name}"
 }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/iam/AclDsl.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/iam/AclDsl.scala
@@ -93,7 +93,7 @@ class AclDsl(cl: HttpClient) extends TestHelpers with CirceUnmarshalling with Op
         .filter(_.acl.nonEmpty)
 
       permissions
-        .traverse { acl =>
+        .parTraverse { acl =>
           val payload = jsonContentOf(
             "/iam/subtract-permissions.json",
             "realm" -> target.realm.name,
@@ -123,7 +123,7 @@ class AclDsl(cl: HttpClient) extends TestHelpers with CirceUnmarshalling with Op
         .filter(_.acl.nonEmpty)
 
       permissions
-        .traverse { acl =>
+        .parTraverse { acl =>
           val payload = jsonContentOf(
             "/iam/subtract-permissions-anon.json",
             "perms" -> acl.acl.head.permissions.map(_.value).mkString("""","""")

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ArchiveSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ArchiveSpec.scala
@@ -6,11 +6,12 @@ import akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers
 import akka.util.ByteString
 import ch.epfl.bluebrain.nexus.testkit.{CirceEq, EitherValuable}
 import ch.epfl.bluebrain.nexus.tests.HttpClient._
-import ch.epfl.bluebrain.nexus.tests.Identity.UserCredentials
+import ch.epfl.bluebrain.nexus.tests.Identity.archives.Tweety
+import ch.epfl.bluebrain.nexus.tests.Identity.testRealm
 import ch.epfl.bluebrain.nexus.tests.Optics._
 import ch.epfl.bluebrain.nexus.tests.Tags.ArchivesTag
 import ch.epfl.bluebrain.nexus.tests.iam.types.Permission.{Projects, Resources}
-import ch.epfl.bluebrain.nexus.tests.{BaseSpec, Identity, Realm}
+import ch.epfl.bluebrain.nexus.tests.{BaseSpec, Identity}
 import io.circe.Json
 import io.circe.parser._
 import monix.execution.Scheduler.Implicits.global
@@ -22,10 +23,6 @@ import java.security.MessageDigest
 import scala.annotation.tailrec
 
 class ArchiveSpec extends BaseSpec with CirceEq with EitherValuable {
-
-  private val testRealm  = Realm("resources" + genString())
-  private val testClient = Identity.ClientCredentials(genString(), genString(), testRealm)
-  private val Tweety     = UserCredentials(genString(), genString(), testRealm)
 
   private val orgId   = genId()
   private val projId  = genId()
@@ -75,16 +72,6 @@ class ArchiveSpec extends BaseSpec with CirceEq with EitherValuable {
     "edd70eff895cde1e36eaedd22ed8e9c870bb04155d05d275f970f4f255488e993a32a7c914ee195f6893d43b8be4e0b00db0a6d545a8462491eae788f664ea6b"
 
   private type PathAndContent = (Path, ByteString)
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    initRealm(
-      testRealm,
-      Identity.ServiceAccount,
-      testClient,
-      Tweety :: Nil
-    ).runSyncUnsafe()
-  }
 
   @tailrec
   private def readEntries(tar: TarArchiveInputStream, entries: List[PathAndContent] = Nil): List[PathAndContent] = {

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/DiskStorageSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/DiskStorageSpec.scala
@@ -1,6 +1,7 @@
 package ch.epfl.bluebrain.nexus.tests.kg
 
 import akka.http.scaladsl.model.StatusCodes
+import ch.epfl.bluebrain.nexus.tests.Identity.storages.Coyote
 import ch.epfl.bluebrain.nexus.tests.Optics.filterMetadataKeys
 import ch.epfl.bluebrain.nexus.tests.Tags.StorageTag
 import ch.epfl.bluebrain.nexus.tests.iam.types.Permission

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/RemoteStorageSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/RemoteStorageSpec.scala
@@ -1,11 +1,9 @@
 package ch.epfl.bluebrain.nexus.tests.kg
 
-import java.io.File
-import java.nio.file.{Files, Paths}
-
 import akka.http.scaladsl.model.StatusCodes
 import ch.epfl.bluebrain.nexus.tests.HttpClient._
 import ch.epfl.bluebrain.nexus.tests.Identity
+import ch.epfl.bluebrain.nexus.tests.Identity.storages.Coyote
 import ch.epfl.bluebrain.nexus.tests.Optics.{filterKey, filterMetadataKeys}
 import ch.epfl.bluebrain.nexus.tests.Tags.StorageTag
 import ch.epfl.bluebrain.nexus.tests.iam.types.Permission
@@ -13,6 +11,8 @@ import io.circe.Json
 import monix.bio.Task
 import org.scalatest.Assertion
 
+import java.io.File
+import java.nio.file.{Files, Paths}
 import scala.reflect.io.Directory
 
 class RemoteStorageSpec extends StorageSpec {

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/S3StorageSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/S3StorageSpec.scala
@@ -1,9 +1,7 @@
 package ch.epfl.bluebrain.nexus.tests.kg
 
-import java.net.URI
-import java.nio.file.Paths
-
 import akka.http.scaladsl.model.StatusCodes
+import ch.epfl.bluebrain.nexus.tests.Identity.storages.Coyote
 import ch.epfl.bluebrain.nexus.tests.Optics.filterMetadataKeys
 import ch.epfl.bluebrain.nexus.tests.Tags.StorageTag
 import ch.epfl.bluebrain.nexus.tests.config.S3Config
@@ -16,6 +14,8 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
 
+import java.net.URI
+import java.nio.file.Paths
 import scala.jdk.CollectionConverters._
 
 class S3StorageSpec extends StorageSpec {

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/StorageSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/StorageSpec.scala
@@ -4,15 +4,15 @@ import akka.http.scaladsl.model.headers.{ContentDispositionTypes, HttpEncodings}
 import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpResponse, StatusCodes}
 import akka.util.ByteString
 import ch.epfl.bluebrain.nexus.testkit.CirceEq
+import ch.epfl.bluebrain.nexus.tests.BaseSpec
 import ch.epfl.bluebrain.nexus.tests.HttpClient._
-import ch.epfl.bluebrain.nexus.tests.Identity.UserCredentials
+import ch.epfl.bluebrain.nexus.tests.Identity.storages.Coyote
 import ch.epfl.bluebrain.nexus.tests.Optics._
 import ch.epfl.bluebrain.nexus.tests.Tags.StorageTag
 import ch.epfl.bluebrain.nexus.tests.config.ConfigLoader._
 import ch.epfl.bluebrain.nexus.tests.config.StorageConfig
 import ch.epfl.bluebrain.nexus.tests.iam.types.Permission
 import ch.epfl.bluebrain.nexus.tests.iam.types.Permission.Organizations
-import ch.epfl.bluebrain.nexus.tests.{BaseSpec, Identity, Realm}
 import com.google.common.io.BaseEncoding
 import com.typesafe.config.ConfigFactory
 import io.circe.Json
@@ -32,21 +32,6 @@ abstract class StorageSpec extends BaseSpec with CirceEq {
   private[tests] val orgId  = genId()
   private[tests] val projId = genId()
   private[tests] val fullId = s"$orgId/$projId"
-
-  private[tests] val testRealm  = Realm("storage" + genString())
-  private[tests] val testClient = Identity.ClientCredentials(genString(), genString(), testRealm)
-  private[tests] val Coyote     = UserCredentials(genString(), genString(), testRealm)
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    initRealm(
-      testRealm,
-      Identity.ServiceAccount,
-      testClient,
-      Coyote :: Nil
-    ).runSyncUnsafe()
-    ()
-  }
 
   def storageName: String
 

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/VersionSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/VersionSpec.scala
@@ -38,7 +38,8 @@ object VersionSpec {
 
   final case class DependenciesBundle(
       blazegraph: String,
-      cassandra: String,
+      cassandra: Option[String],
+      postgres: Option[String],
       elasticsearch: String,
       remoteStorage: String
   )


### PR DESCRIPTION
Fixes #2491 

* Limit memory for the different components
* Refresh more aggressively
* Make integration tests work with PostgreSQL
* Do Keycloak related stuff at bootstrap
* Improve error message with context
* Make parallel calls where it is possible