### PR TITLE
Added community_louvain import

### DIFF
--- a/docs/src/main/paradox/docs/getting-started/notebooks/MOOC_Content_based_Recommender_System_using_Blue_Brain_Nexus.ipynb
+++ b/docs/src/main/paradox/docs/getting-started/notebooks/MOOC_Content_based_Recommender_System_using_Blue_Brain_Nexus.ipynb
@@ -59,6 +59,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
+    "from community import community_louvain\n",
+    "\n",
     "from pathlib import Path\n",
     "\n",
     "from kgforge.core import KnowledgeGraphForge\n",


### PR DESCRIPTION
Added  `from community import community_louvain` to avoid import error for `from pyrdf2vec import RDF2VecTransformer` on Google Colaboratory.

![Screenshot 2021-08-16 at 15 07 57](https://user-images.githubusercontent.com/27771434/129576585-d1bb9362-8d59-4439-ae39-e1ba5df70f68.png)
