### PR TITLE
Externalize ignore paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import scala.io.Source
+
 /*
 scalafmt: {
   maxColumn = 150
@@ -158,23 +160,12 @@ lazy val docs = project
     name                             := "docs",
     moduleName                       := "docs",
     // paradox settings
-    paradoxValidationIgnorePaths    ++= List(
-      "https://bluebrain.github.io/nexus/contexts/metadata.json".r,
-      "https://dl.acm.org/.*".r,
-      "http://example.com/.*".r,
-      "https://github.com/BlueBrain/nexus-web/blob/main/README.md.*".r,
-      "https://www.janelia.org".r,
-      "http://mouselight.janelia.org/".r,
-      "http://ml-neuronbrowser.janelia.org".r,
-      "https://movies.com/movieId/1".r,
-      "https://link.springer.com/.*".r,
-      "https://sandbox.bluebrainnexus.io.*".r,
-      "https://www.sciencedirect.com/.*".r,
-      "https://shacl.org/.*".r,
-      "http://www.w3.org/2001/XMLSchema.*".r,
-      "https://www.youtube.com/.*".r,
-      "https://web.stanford.edu/.*".r
-    ),
+    paradoxValidationIgnorePaths    ++= {
+      val source      = Source.fromFile(file("docs/ignore-paths.txt"))
+      val ignorePaths = source.getLines().map(_.r).toList
+      source.close()
+      ignorePaths
+    },
     Compile / paradoxMaterialTheme   := {
       ParadoxMaterialTheme()
         .withColor("light-blue", "cyan")

--- a/docs/ignore-paths.txt
+++ b/docs/ignore-paths.txt
@@ -1,0 +1,15 @@
+https://bluebrain.github.io/nexus/contexts/metadata.json
+https://dl.acm.org/.*
+http://example.com/.*
+https://github.com/BlueBrain/nexus-web/blob/main/README.md.*
+https://www.janelia.org
+http://mouselight.janelia.org/
+http://ml-neuronbrowser.janelia.org
+https://movies.com/movieId/1
+https://link.springer.com/.*
+https://sandbox.bluebrainnexus.io.*
+https://www.sciencedirect.com/.*
+https://shacl.org/.*
+http://www.w3.org/2001/XMLSchema.*
+https://www.youtube.com/.*
+https://web.stanford.edu/.*


### PR DESCRIPTION
This list has been growing a bit lately and several people have been updating it.

- It is easier for people to modify this dedicated file than `build.sbt`
- Less errors will result of that
- Less noise in `build.sbt`
- Adding a link will now only trigger the doc workflow