### PR TITLE
Updated reference search config for optional and multi-format values

### DIFF
--- a/tests/docker/config/construct-query.sparql
+++ b/tests/docker/config/construct-query.sparql
@@ -9,57 +9,57 @@ prefix field: <https://bluebrain.github.io/nexus/field/>
 
 
 CONSTRUCT {
-  {resource_id} 	a                       ?type ;
-  					schema:name             ?name ;
+  {resource_id}     a                       ?type ;
+                    schema:name             ?name ;
                     field:description       ?description ;
-  					field:brainRegion       ?brainRegionBN ;
-  					field:project           ?projectBN ;
-  					field:subjectSpecies    ?speciesBN ;
-  					field:contributors      ?personBN ;
-  					field:organizations     ?orgBN ;
+                    field:brainRegion       ?brainRegionBN ;
+                    field:project           ?projectBN ;
+                    field:subjectSpecies    ?speciesBN ;
+                    field:contributors      ?personBN ;
+                    field:organizations     ?orgBN ;
                     field:license           ?licenseBN ;
                     field:createdBy         ?createdBy ;
                     nxv:self                ?self .
 
   ?projectBN        field:identifier        ?projectId ;
-                    rdfs:label			    ?projectLabel .
+                    rdfs:label              ?projectLabel .
 
   ?licenseBN        field:identifier        ?licenseId ;
-                    rdfs:label			    ?licenseLabel .
+                    rdfs:label              ?licenseLabel .
 
-  ?brainRegionBN	field:identifier        ?brainRegionId ;
-                    rdfs:label			    ?brainRegionLabel .
+  ?brainRegionBN    field:identifier        ?brainRegionId ;
+                    rdfs:label              ?brainRegionLabel .
 
-  ?speciesBN		field:identifier        ?speciesId ;
-                    rdfs:label			    ?speciesLabel .
+  ?speciesBN        field:identifier        ?speciesId ;
+                    rdfs:label              ?speciesLabel .
 
-  ?personBN		    field:identifier        ?personId ;
-                    rdfs:label	            ?personName .
+  ?personBN         field:identifier        ?personId ;
+                    rdfs:label              ?personName .
 
-  ?orgBN			field:identifier        ?orgId ;
-                    rdfs:label	            ?organizationName .
+  ?orgBN            field:identifier        ?orgId ;
+                    rdfs:label              ?organizationName .
 
-  ?mTypeBN			field:identifier        ?mTypeId ;
-                    rdfs:label	            ?mTypeLabel
+  ?mTypeBN          field:identifier        ?mTypeId ;
+                    rdfs:label              ?mTypeLabel
 } WHERE {
-  {resource_id} nxv:createdAt			    ?createdAt;
-                nxv:createdBy			    ?createdBy;
-                nxv:self			        ?self;
-                a 					        ?type ;
-                nxv:project 			    ?projectId .
+  {resource_id} nxv:createdAt               ?createdAt;
+                nxv:createdBy               ?createdBy;
+                nxv:self                    ?self;
+                a                           ?type ;
+                nxv:project                 ?projectId .
   ?projectId    nxv:organizationLabel       ?orgLabel;
                 nxv:label                   ?projLabel.
   BIND (CONCAT(STR(?orgLabel),STR("/"),STR(?projLabel)) as ?projectLabel) .
   BIND(BNODE() AS ?projectBN) .
 
-  OPTIONAL {  {resource_id} schema:description	?description } .
-  OPTIONAL {  {resource_id} schema:name  		?name } .
-  OPTIONAL {  {resource_id} rdfs:label  		?name } .
-  OPTIONAL {  {resource_id} skos:prefLabel  	?name } .
+  OPTIONAL {  {resource_id} schema:description   ?description } .
+  OPTIONAL {  {resource_id} schema:name          ?name } .
+  OPTIONAL {  {resource_id} rdfs:label           ?name } .
+  OPTIONAL {  {resource_id} skos:prefLabel       ?name } .
   OPTIONAL {
-    {resource_id} schema:license		?licenseId .
+    {resource_id} schema:license        ?licenseId .
     BIND(BNODE() AS ?licenseBN) .
-    OPTIONAL { ?licenseId rdfs:label		?licenseLabel . }
+    OPTIONAL { ?licenseId rdfs:label    ?licenseLabel . }
   } .
 
   OPTIONAL {
@@ -75,8 +75,8 @@ CONSTRUCT {
   }  .
 
   OPTIONAL {
-    {resource_id}   nsg:contribution / prov:agent 	?personId .
-	?personId       a 								schema:Person .
+    {resource_id}   nsg:contribution / prov:agent     ?personId .
+    ?personId       a                                 schema:Person .
     BIND(BNODE() AS ?personBN) .
     OPTIONAL { ?personId schema:givenName   ?givenName } .
     OPTIONAL { ?personId schema:familyName  ?familyName } .
@@ -84,15 +84,15 @@ CONSTRUCT {
   } .
 
   OPTIONAL {
-    {resource_id}   nsg:contribution / prov:agent 	?orgId .
-	?orgId          a 								schema:Organization .
+    {resource_id}   nsg:contribution / prov:agent     ?orgId .
+    ?orgId          a                                 schema:Organization .
     BIND(BNODE() AS ?orgBN) .
     OPTIONAL { ?orgId schema:name ?organizationName }
   } .
 
   OPTIONAL {
-    {resource_id}   nsg:annotation / nsg:hasBody 	?mTypeId .
-    ?mTypeId	    a								nsg:MType .
+    {resource_id}   nsg:annotation / nsg:hasBody     ?mTypeId .
+    ?mTypeId        a                                nsg:MType .
     BIND(BNODE() AS ?mTypeBN) .
     OPTIONAL { ?mTypeId rdfs:label ?mTypeLabel }
   }

--- a/tests/docker/config/fields.json
+++ b/tests/docker/config/fields.json
@@ -1,127 +1,193 @@
 {
   "fields": [
     {
-      "name":  "project",
+      "array": false,
+      "fields": [
+        {
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
+        },
+        {
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": false
+        }
+      ],
       "label": "Project",
-      "array": false,
-      "fields": [
-        {
-          "name": "identifier",
-          "format": "uri"
-        },
-        {
-          "name": "label",
-          "format": "text"
-        }
-      ]
+      "name": "project",
+      "optional": false
     },
     {
-      "name":  "@type",
+      "array": true,
+      "format": [
+        "uri"
+      ],
       "label": "Types",
-      "format": "uri",
-      "array": true
+      "name": "@type",
+      "optional": false
     },
     {
-      "name":  "name",
+      "array": false,
+      "format": [
+        "keyword",
+        "text"
+      ],
       "label": "Name",
-      "array": false,
-      "format": "text"
+      "name": "name",
+      "optional": true
     },
     {
-      "name":  "description",
+      "array": false,
+      "format": [
+        "text"
+      ],
       "label": "Description",
-      "array": false,
-      "format": "text"
+      "name": "description",
+      "optional": true
     },
     {
-      "name":  "brainRegion",
+      "array": false,
+      "fields": [
+        {
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
+        },
+        {
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
+        }
+      ],
       "label": "Brain Region",
+      "name": "brainRegion",
+      "optional": true
+    },
+    {
       "array": false,
       "fields": [
         {
           "name": "identifier",
-          "format": "uri"
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
           "name": "label",
-          "format": "text"
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
-      ]
-    },
-    {
-      "name":  "subjectSpecies",
+      ],
       "label": "Subject Species",
-      "array": false,
+      "name": "subjectSpecies",
+      "optional": true
+    },
+    {
+      "array": true,
       "fields": [
         {
+          "format": [
+            "uri"
+          ],
           "name": "identifier",
-          "format": "uri"
+          "optional": false
         },
         {
           "name": "label",
-          "format": "text"
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
-      ]
-    },
-    {
-      "name":  "contributors",
+      ],
       "label": "Contributors",
+      "name": "contributors",
+      "optional": true
+    },
+    {
       "array": true,
       "fields": [
         {
           "name": "identifier",
-          "format": "uri"
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
           "name": "label",
-          "format": "text"
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
-      ]
-    },
-    {
-      "name":  "organisations",
+      ],
       "label": "Organisations",
-      "array": true,
-      "fields": [
-        {
-          "name": "identifier",
-          "format": "uri"
-        },
-        {
-          "name": "label",
-          "format": "text"
-        }
-      ]
+      "name": "organisations",
+      "optional": true
     },
     {
-      "name":  "license",
-      "label": "License",
       "array": false,
       "fields": [
         {
           "name": "identifier",
-          "format": "uri"
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
           "name": "label",
-          "format": "text"
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
-      ]
+      ],
+      "label": "License",
+      "name": "license",
+      "optional": true
     },
     {
-      "name":  "mType",
-      "label": "M-Type",
       "array": true,
       "fields": [
         {
           "name": "identifier",
-          "format": "uri"
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
           "name": "label",
-          "format": "text"
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
-      ]
+      ],
+      "label": "M-Type",
+      "name": "mType",
+      "optional": true
     }
   ]
 }

--- a/tests/src/test/resources/kg/search/config.json
+++ b/tests/src/test/resources/kg/search/config.json
@@ -4,124 +4,190 @@
       "array": false,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": false
         }
       ],
       "label": "Project",
-      "name": "project"
+      "name": "project",
+      "optional": false
     },
     {
       "array": true,
-      "format": "uri",
+      "format": [
+        "uri"
+      ],
       "label": "Types",
-      "name": "@type"
+      "name": "@type",
+      "optional": false
     },
     {
       "array": false,
-      "format": "text",
+      "format": [
+        "keyword",
+        "text"
+      ],
       "label": "Name",
-      "name": "name"
+      "name": "name",
+      "optional": true
     },
     {
       "array": false,
-      "format": "text",
+      "format": [
+        "text"
+      ],
       "label": "Description",
-      "name": "description"
+      "name": "description",
+      "optional": true
     },
     {
       "array": false,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
       ],
       "label": "Brain Region",
-      "name": "brainRegion"
+      "name": "brainRegion",
+      "optional": true
     },
     {
       "array": false,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
       ],
       "label": "Subject Species",
-      "name": "subjectSpecies"
+      "name": "subjectSpecies",
+      "optional": true
     },
     {
       "array": true,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "format": [
+            "uri"
+          ],
+          "name": "identifier",
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
       ],
       "label": "Contributors",
-      "name": "contributors"
+      "name": "contributors",
+      "optional": true
     },
     {
       "array": true,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
       ],
       "label": "Organisations",
-      "name": "organisations"
+      "name": "organisations",
+      "optional": true
     },
     {
       "array": false,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
       ],
       "label": "License",
-      "name": "license"
+      "name": "license",
+      "optional": true
     },
     {
       "array": true,
       "fields": [
         {
-          "format": "uri",
-          "name": "identifier"
+          "name": "identifier",
+          "format": [
+            "uri"
+          ],
+          "optional": false
         },
         {
-          "format": "text",
-          "name": "label"
+          "name": "label",
+          "format": [
+            "keyword",
+            "text"
+          ],
+          "optional": true
         }
       ],
       "label": "M-Type",
-      "name": "mType"
+      "name": "mType",
+      "optional": true
     }
   ]
 }


### PR DESCRIPTION
The change just modifies the search reference config in the integration tests, changing the configuration structure as follows:

- the `format` field is now an array that supports multiple values to handle cases where a field should be handles as both a `keyword` and `text`
- all field objects (including nested ones) now include a boolean `optional` value to specify the expectations for clients (whether they can expect a missing value - depends on the construct query)

Added additional formatting of the reference construct query to replace tabs with spaces and sorted the config json files alphabetically.

Related to #2641, #2740