### PR TITLE
Fix MOOC notebooks: new NeuroM version

### DIFF
--- a/docs/src/main/paradox/docs/getting-started/notebooks/dataset_from_different_sources.ipynb
+++ b/docs/src/main/paradox/docs/getting-started/notebooks/dataset_from_different_sources.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install neurom[plotly]"
+    "!pip install neurom[plotly]==3.0.1"
    ]
   },
   {
@@ -726,8 +726,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neurom import load_neuron\n",
-    "from neurom.view.plotly import draw\n",
+    "from neurom import load_morphology\n",
+    "from neurom.view.plotly_impl import plot_morph3d\n",
     "import IPython"
    ]
   },
@@ -737,8 +737,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "neuron = load_neuron(f\"{dirpath}/{data[0].distribution.name}\")\n",
-    "draw(neuron, inline=False)\n",
+    "neuron = load_morphology(f\"{dirpath}/{data[0].distribution.name}\")\n",
+    "plot_morph3d(neuron, inline=False)\n",
     "IPython.display.HTML(filename='./neuron-3D.html')"
    ]
   },
@@ -817,6 +817,13 @@
    "source": [
     "forge.as_dataframe(non_tagged_data)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -827,9 +834,9 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "Python (kgo)",
+   "display_name": "Python (mooc)",
    "language": "python",
-   "name": "kgo"
+   "name": "mooc"
   },
   "language_info": {
    "codemirror_mode": {
@@ -841,7 +848,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/docs/src/main/paradox/docs/getting-started/notebooks/one_cell_minds.ipynb
+++ b/docs/src/main/paradox/docs/getting-started/notebooks/one_cell_minds.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install neurom[plotly]"
+    "!pip install neurom[plotly]==3.0.1"
    ]
   },
   {
@@ -507,8 +507,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neurom import load_neuron\n",
-    "from neurom.view.plotly import draw\n",
+    "from neurom import load_morphology\n",
+    "from neurom.view.plotly_impl import plot_morph3d\n",
     "import IPython"
    ]
   },
@@ -518,8 +518,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "neuron = load_neuron(f\"{dirpath}/{data[0].distribution.name}\")\n",
-    "draw(neuron, inline=False)\n",
+    "neuron = load_morphology(f\"{dirpath}/{data[0].distribution.name}\")\n",
+    "plot_morph3d(neuron, inline=False)\n",
     "IPython.display.HTML(filename='./neuron-3D.html')"
    ]
   },
@@ -605,9 +605,9 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "Python (20210819)",
+   "display_name": "Python (mooc)",
    "language": "python",
-   "name": "20210819"
+   "name": "mooc"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Due to breaking changes in the latest NeuroM release (https://github.com/BlueBrain/NeuroM/blob/59eae76e7290b0828af3ada633471ea1e4e434ea/CHANGELOG.rst), the notebooks were updated to be compatible and the NeuroM version installed is now fixed