### PR TITLE
Changed neuron-3D.html to morphology-3D.html

### DIFF
--- a/docs/src/main/paradox/docs/getting-started/notebooks/dataset_from_different_sources.ipynb
+++ b/docs/src/main/paradox/docs/getting-started/notebooks/dataset_from_different_sources.ipynb
@@ -739,7 +739,7 @@
    "source": [
     "neuron = load_morphology(f\"{dirpath}/{data[0].distribution.name}\")\n",
     "plot_morph3d(neuron, inline=False)\n",
-    "IPython.display.HTML(filename='./neuron-3D.html')"
+    "IPython.display.HTML(filename='./morphology-3D.html')"
    ]
   },
   {

--- a/docs/src/main/paradox/docs/getting-started/notebooks/one_cell_minds.ipynb
+++ b/docs/src/main/paradox/docs/getting-started/notebooks/one_cell_minds.ipynb
@@ -520,7 +520,7 @@
    "source": [
     "neuron = load_morphology(f\"{dirpath}/{data[0].distribution.name}\")\n",
     "plot_morph3d(neuron, inline=False)\n",
-    "IPython.display.HTML(filename='./neuron-3D.html')"
+    "IPython.display.HTML(filename='./morphology-3D.html')"
    ]
   },
   {


### PR DESCRIPTION
The `neuron-3D.html` file generated by the plotly implementation in `NeuroM` was renamed to `morphology-3D.html`. This change is now reflected in the two MOOC notebooks concerned.