### PR TITLE
Allow rdf parser to be configurable

### DIFF
--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -77,6 +77,23 @@ app {
     }
   }
 
+  # Json-LD Api configuration
+  json-ld-api {
+    # Set the Jena parser to perform extra checks:
+    # * URIs - whether IRs confirm to all the rules of the URI scheme
+    # * Literals: whether the lexical form conforms to the rules for the datatype.
+    # * Triples and quads: check slots have a valid kind of RDF term (parsers usually make this a syntax error anyway).
+    extra-checks: true
+    # Set the Jena parser to strict mode
+    # This mode do the extra-checks described above and reject relative iris/uris
+    strict: false
+    # Define the error handler for the Jena parser
+    # * strict: Both errors and warnings will raise exceptions
+    # * default: Errors will raise exceptions and warning will result in logs
+    # * no-warning: Erros will raise exceptions and warning will result in logs
+    error-handling: "strict"
+  }
+
   # Identities configuration
   identities {
     # configuration on how group information is cached

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/AppConfig.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/config/AppConfig.scala
@@ -1,5 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.config
 
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApiConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.crypto.EncryptionConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ServiceAccountConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectsConfig
@@ -29,6 +30,8 @@ import java.nio.charset.StandardCharsets.UTF_8
   *   the cluster config
   * @param database
   *   the database config
+  * @param jsonLdApi
+  *   the json-ld api config
   * @param identities
   *   the identities config
   * @param permissions
@@ -57,6 +60,7 @@ final case class AppConfig(
     http: HttpConfig,
     cluster: ClusterConfig,
     database: DatabaseConfig,
+    jsonLdApi: JsonLdApiConfig,
     identities: IdentitiesConfig,
     permissions: PermissionsConfig,
     realms: RealmsConfig,

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/DeltaModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/DeltaModule.scala
@@ -11,6 +11,7 @@ import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.config.AppConfig
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk.IndexingAction.AggregateIndexingAction
@@ -65,6 +66,7 @@ class DeltaModule(appCfg: AppConfig, config: Config)(implicit classLoader: Class
   make[IndexingAction].named("aggregate").from { (internal: Set[IndexingAction]) =>
     AggregateIndexingAction(internal.toSeq)
   }
+
   make[RemoteContextResolution].named("aggregate").fromEffect { (otherCtxResolutions: Set[RemoteContextResolution]) =>
     for {
       errorCtx    <- ContextValue.fromFile("contexts/error.json")
@@ -82,6 +84,8 @@ class DeltaModule(appCfg: AppConfig, config: Config)(implicit classLoader: Class
       )
       .merge(otherCtxResolutions.toSeq: _*)
   }
+
+  make[JsonLdApi].fromValue(new JsonLdJavaApi(appCfg.jsonLdApi))
 
   make[Clock[UIO]].from(Clock[UIO])
   make[UUIDF].from(UUIDF.random)

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResolversModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResolversModule.scala
@@ -6,6 +6,7 @@ import ch.epfl.bluebrain.nexus.delta.Main.pluginsMaxPriority
 import ch.epfl.bluebrain.nexus.delta.config.AppConfig
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.routes.ResolversRoutes
@@ -53,6 +54,7 @@ object ResolversModule extends ModuleDef {
         projects: Projects,
         cache: ResolversCache,
         agg: ResolversAggregate,
+        api: JsonLdApi,
         resolverContextResolution: ResolverContextResolution,
         as: ActorSystem[Nothing],
         uuidF: UUIDF,
@@ -66,7 +68,7 @@ object ResolversModule extends ModuleDef {
         resolverContextResolution,
         cache,
         agg
-      )(uuidF, scheduler, as)
+      )(api, uuidF, scheduler, as)
   }
 
   many[ResourcesDeletion].add {

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResourcesModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ResourcesModule.scala
@@ -5,6 +5,7 @@ import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.Main.pluginsMinPriority
 import ch.epfl.bluebrain.nexus.delta.config.AppConfig
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.routes.ResourcesRoutes
@@ -35,6 +36,7 @@ object ResourcesModule extends ModuleDef {
         resolvers: Resolvers,
         schemas: Schemas,
         resourceIdCheck: ResourceIdCheck,
+        api: JsonLdApi,
         as: ActorSystem[Nothing],
         clock: Clock[UIO]
     ) =>
@@ -42,7 +44,7 @@ object ResourcesModule extends ModuleDef {
         config.resources.aggregate,
         ResourceResolution.schemaResource(acls, resolvers, schemas),
         resourceIdCheck
-      )(as, clock)
+      )(api, as, clock)
   }
 
   many[ResourcesDeletion].add { (agg: ResourcesAggregate, resources: Resources, dbCleanup: DatabaseCleanup) =>
@@ -55,10 +57,11 @@ object ResourcesModule extends ModuleDef {
         agg: ResourcesAggregate,
         organizations: Organizations,
         projects: Projects,
+        api: JsonLdApi,
         resolverContextResolution: ResolverContextResolution,
         uuidF: UUIDF
     ) =>
-      ResourcesImpl(organizations, projects, agg, resolverContextResolution, eventLog)(uuidF)
+      ResourcesImpl(organizations, projects, agg, resolverContextResolution, eventLog)(api, uuidF)
   }
 
   make[ResolverContextResolution].from {

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/utils/RouteFixtures.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/utils/RouteFixtures.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.utils
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, schemas}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.{RdfExceptionHandler, RdfRejectionHandler}
@@ -20,6 +21,8 @@ import java.util.UUID
 
 trait RouteFixtures extends TestHelpers with IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit def rcr: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveDownload.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveDownload.scala
@@ -13,6 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.Files
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.FileRejection
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -76,6 +77,7 @@ object ArchiveDownload {
   ) extends ArchiveDownload {
 
     implicit private val logger: Logger = Logger[ArchiveDownload]
+    implicit private val api: JsonLdApi = JsonLdJavaApi.lenient
 
     override def apply(
         value: ArchiveValue,

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginModule.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginModule.scala
@@ -7,6 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.archive.ArchiveDownload.ArchiveDown
 import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.contexts
 import ch.epfl.bluebrain.nexus.delta.plugins.archive.routes.ArchiveRoutes
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.Files
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ApiMappings
@@ -43,12 +44,13 @@ object ArchivePluginModule extends ModuleDef {
         archiveDownload: ArchiveDownload,
         cfg: ArchivePluginConfig,
         resourceIdCheck: ResourceIdCheck,
+        api: JsonLdApi,
         as: ActorSystem[Nothing],
         uuidF: UUIDF,
         rcr: RemoteContextResolution @Id("aggregate"),
         clock: Clock[UIO]
     ) =>
-      Archives(projects, archiveDownload, cfg, resourceIdCheck)(as, uuidF, rcr, clock)
+      Archives(projects, archiveDownload, cfg, resourceIdCheck)(api, as, uuidF, rcr, clock)
   }
 
   make[ArchiveRoutes].from {

--- a/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/RemoteContextResolutionFixture.scala
+++ b/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/RemoteContextResolutionFixture.scala
@@ -4,11 +4,14 @@ import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.contexts
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.{contexts => fileContexts}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.{contexts => storageContexts}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 
 trait RemoteContextResolutionFixture extends IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(
     storageContexts.storages         -> ContextValue.fromFile("contexts/storages.json").accepted,

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
@@ -11,6 +11,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.indexing.{BlazegraphInde
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphView.IndexingBlazegraphView
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.{contexts, schema => viewsSchemaId, BlazegraphViewEvent, BlazegraphViewsConfig}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.routes.BlazegraphViewsRoutes
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk.ProgressesStatistics.ProgressesCache
@@ -155,6 +156,7 @@ class BlazegraphPluginModule(priority: Int) extends ModuleDef {
           agg: BlazegraphViewsAggregate,
           orgs: Organizations,
           projects: Projects,
+          api: JsonLdApi,
           uuidF: UUIDF,
           as: ActorSystem[Nothing],
           scheduler: Scheduler
@@ -170,6 +172,7 @@ class BlazegraphPluginModule(priority: Int) extends ModuleDef {
           projects,
           client
         )(
+          api,
           uuidF,
           scheduler,
           as

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViews.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViews.scala
@@ -18,6 +18,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewType
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewValue._
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.ProjectReferenceFinder.ProjectReferenceMap
@@ -622,6 +623,7 @@ object BlazegraphViews {
       projects: Projects,
       client: BlazegraphClient
   )(implicit
+      api: JsonLdApi,
       uuidF: UUIDF,
       scheduler: Scheduler,
       as: ActorSystem[Nothing]
@@ -649,6 +651,7 @@ object BlazegraphViews {
       projects: Projects,
       createNamespace: ViewResource => IO[BlazegraphViewRejection, Unit]
   )(implicit
+      api: JsonLdApi,
       uuidF: UUIDF,
       scheduler: Scheduler,
       as: ActorSystem[Nothing]

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphScopeInitializationSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphScopeInitializationSpec.scala
@@ -26,7 +26,7 @@ class BlazegraphScopeInitializationSpec
     with IOValues
     with TestHelpers
     with ConfigFixtures
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   private val uuid                   = UUID.randomUUID()
   implicit private val uuidF: UUIDF  = UUIDF.fixed(uuid)

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewDecodingSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewDecodingSpec.scala
@@ -25,7 +25,7 @@ class BlazegraphViewDecodingSpec
     with Inspectors
     with IOValues
     with TestHelpers
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   private val project = ProjectGen.project("org", "project")
 

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewEventExchangeSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewEventExchangeSpec.scala
@@ -23,11 +23,7 @@ import org.scalatest.Inspectors
 import java.time.Instant
 import java.util.UUID
 
-class BlazegraphViewEventExchangeSpec
-    extends AbstractDBSpec
-    with Inspectors
-    with ConfigFixtures
-    with RemoteContextResolutionFixture {
+class BlazegraphViewEventExchangeSpec extends AbstractDBSpec with Inspectors with ConfigFixtures with Fixtures {
 
   implicit private val scheduler: Scheduler = Scheduler.global
 

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewReferenceExchangeSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewReferenceExchangeSpec.scala
@@ -16,11 +16,7 @@ import org.scalatest.Inspectors
 
 import java.util.UUID
 
-class BlazegraphViewReferenceExchangeSpec
-    extends AbstractDBSpec
-    with Inspectors
-    with ConfigFixtures
-    with RemoteContextResolutionFixture {
+class BlazegraphViewReferenceExchangeSpec extends AbstractDBSpec with Inspectors with ConfigFixtures with Fixtures {
 
   implicit private val scheduler: Scheduler = Scheduler.global
 

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewsSetup.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewsSetup.scala
@@ -19,7 +19,7 @@ import monix.execution.Scheduler
 
 import scala.concurrent.duration._
 
-trait BlazegraphViewsSetup extends IOValues with ConfigFixtures with IOFixedClock with RemoteContextResolutionFixture {
+trait BlazegraphViewsSetup extends IOValues with ConfigFixtures with IOFixedClock with Fixtures {
 
   def config(implicit baseUri: BaseUri) = BlazegraphViewsConfig(
     baseUri.toString,

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewsSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewsSpec.scala
@@ -36,7 +36,7 @@ class BlazegraphViewsSpec
     with IOValues
     with TestHelpers
     with ConfigFixtures
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   "BlazegraphViews" when {
     val uuid                      = UUID.randomUUID()

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/Fixtures.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/Fixtures.scala
@@ -2,11 +2,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.blazegraph
 
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.contexts.{blazegraph, blazegraphMetadata}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 
-trait RemoteContextResolutionFixture extends IOValues {
+trait Fixtures extends IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(
     blazegraph                     -> ContextValue.fromFile("contexts/sparql.json").accepted,

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/client/BlazegraphClientSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/client/BlazegraphClientSpec.scala
@@ -13,6 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.SparqlResults.Bin
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.SparqlWriteQuery.replace
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.NTriples
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError.{HttpClientStatusError, HttpServerStatusError}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.{HttpClient, HttpClientConfig}
@@ -48,6 +49,7 @@ class BlazegraphClientSpec
 
   implicit private val sc: Scheduler                = Scheduler.global
   implicit private val httpCfg: HttpClientConfig    = httpClientConfig
+  implicit private val api: JsonLdApi               = JsonLdJavaApi.strict
   implicit private val rcr: RemoteContextResolution = RemoteContextResolution.never
 
   private val endpoint = blazegraphHostConfig.endpoint

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/indexing/BlazegraphIndexingSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/indexing/BlazegraphIndexingSpec.scala
@@ -10,7 +10,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.indexing.BlazegraphIndex
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphView.IndexingBlazegraphView
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewValue.IndexingBlazegraphViewValue
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.{permissions, _}
-import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.{BlazegraphViews, BlazegraphViewsSetup, RemoteContextResolutionFixture}
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.{BlazegraphViews, BlazegraphViewsSetup, Fixtures}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{nxv, rdf, xsd}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.NTriples
@@ -61,7 +61,7 @@ class BlazegraphIndexingSpec
     with TestMatchers
     with ConfigFixtures
     with Eventually
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   implicit private val uuidF: UUIDF     = UUIDF.random
   implicit private val sc: Scheduler    = Scheduler.global

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutesSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutesSpec.scala
@@ -10,7 +10,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.utils.{UUIDF, UrlUtils}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.SparqlQuery.SparqlConstructQuery
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.{SparqlQuery, SparqlQueryClientDummy, SparqlResults}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model._
-import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.{BlazegraphViewsSetup, RemoteContextResolutionFixture}
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.{BlazegraphViewsSetup, Fixtures}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfMediaTypes._
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
@@ -59,7 +59,7 @@ class BlazegraphViewsRoutesSpec
     with ConfigFixtures
     with BeforeAndAfterAll
     with TestHelpers
-    with RemoteContextResolutionFixture
+    with Fixtures
     with BlazegraphViewRoutesFixtures {
 
   import akka.actor.typed.scaladsl.adapter._

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViews.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViews.scala
@@ -23,6 +23,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.serialization.Compos
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViews
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.{ElasticSearchClient, IndexLabel}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.Permissions.events
 import ch.epfl.bluebrain.nexus.delta.sdk.ProjectReferenceFinder.ProjectReferenceMap
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
@@ -706,9 +707,9 @@ object CompositeViews {
       cache: CompositeViewsCache,
       agg: CompositeViewsAggregate,
       contextResolution: ResolverContextResolution
-  )(implicit uuidF: UUIDF, as: ActorSystem[Nothing], sc: Scheduler): Task[CompositeViews] =
+  )(implicit api: JsonLdApi, uuidF: UUIDF, as: ActorSystem[Nothing], sc: Scheduler): Task[CompositeViews] =
     for {
-      sourceDecoder <- Task.delay(CompositeViewFieldsJsonLdSourceDecoder(uuidF, contextResolution)(config))
+      sourceDecoder <- Task.delay(CompositeViewFieldsJsonLdSourceDecoder(uuidF, contextResolution)(api, config))
       views          = new CompositeViews(agg, eventLog, cache, orgs, projects, sourceDecoder)
       _             <- CompositeViewsIndexing.populateCache(config.cacheIndexing.retry, views, cache)
     } yield views

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -14,6 +14,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.{contexts, Com
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.routes.CompositeViewsRoutes
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, JsonLdContext, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk.ProgressesStatistics.ProgressesCache
@@ -83,6 +84,7 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
         cache: CompositeViewsCache,
         agg: CompositeViewsAggregate,
         contextResolution: ResolverContextResolution,
+        api: JsonLdApi,
         uuidF: UUIDF,
         as: ActorSystem[Nothing],
         sc: Scheduler
@@ -96,6 +98,7 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
         agg,
         contextResolution
       )(
+        api,
         uuidF,
         as,
         sc
@@ -152,10 +155,10 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
   make[MetadataPredicates].fromEffect {
     (
         listingsMetadataCtx: MetadataContextValue @Id("search-metadata"),
+        api: JsonLdApi,
         cr: RemoteContextResolution @Id("aggregate")
     ) =>
-      implicit val res = cr
-      JsonLdContext(listingsMetadataCtx.value)
+      JsonLdContext(listingsMetadataCtx.value)(api, cr, JsonLdOptions.defaults)
         .map(_.aliasesInv.keySet.map(Triple.predicate))
         .map(MetadataPredicates)
   }

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/serialization/CompositeViewFieldsJsonLdSourceDecoder.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/serialization/CompositeViewFieldsJsonLdSourceDecoder.scala
@@ -4,6 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.{contexts, CompositeViewFields, CompositeViewRejection}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax.jsonOpsSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdSourceProcessor.JsonLdSourceResolvingDecoder
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
@@ -47,6 +48,7 @@ final class CompositeViewFieldsJsonLdSourceDecoder private (
 object CompositeViewFieldsJsonLdSourceDecoder {
 
   def apply(uuidF: UUIDF, contextResolution: ResolverContextResolution)(implicit
+      api: JsonLdApi,
       cfg: CompositeViewsConfig
   ): CompositeViewFieldsJsonLdSourceDecoder =
     new CompositeViewFieldsJsonLdSourceDecoder(

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/BlazegraphQuerySpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/BlazegraphQuerySpec.scala
@@ -45,7 +45,7 @@ class BlazegraphQuerySpec
     with CancelAfterFailure
     with Inspectors
     with ConfigFixtures
-    with RemoteContextResolutionFixture
+    with Fixtures
     with IOValues
     with Eventually {
   implicit override def patienceConfig: PatienceConfig = PatienceConfig(6.seconds, 100.millis)

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewDecodingSpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewDecodingSpec.scala
@@ -17,7 +17,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.{Group, User}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.{ResolverContextResolution, ResourceResolutionReport}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{Label, NonEmptySet}
-import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, EitherValuable, IOValues, TestHelpers}
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, EitherValuable, TestHelpers}
 import monix.bio.IO
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -30,10 +30,9 @@ class CompositeViewDecodingSpec
     extends AnyWordSpecLike
     with Matchers
     with Inspectors
-    with IOValues
     with TestHelpers
     with CirceLiteral
-    with RemoteContextResolutionFixture
+    with Fixtures
     with EitherValuable
     with OptionValues {
 

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsSetup.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsSetup.scala
@@ -24,7 +24,7 @@ import io.circe.Decoder
 import monix.bio.{IO, Task, UIO}
 import monix.execution.Scheduler
 
-trait CompositeViewsSetup extends RemoteContextResolutionFixture with IOFixedClock {
+trait CompositeViewsSetup extends Fixtures with IOFixedClock {
 
   private val deltaClient = new DeltaClient {
     override def projectCount(source: CompositeViewSource.RemoteProjectSource): HttpResult[ProjectCount] =

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/ElasticSearchQuerySpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/ElasticSearchQuerySpec.scala
@@ -46,7 +46,7 @@ class ElasticSearchQuerySpec
     with CancelAfterFailure
     with Inspectors
     with ConfigFixtures
-    with RemoteContextResolutionFixture
+    with Fixtures
     with IOValues
     with Eventually
     with TestMatchers {

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/Fixtures.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/Fixtures.scala
@@ -2,12 +2,15 @@ package ch.epfl.bluebrain.nexus.delta.plugins.compositeviews
 
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 
-trait RemoteContextResolutionFixture extends IOValues {
+trait Fixtures extends IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(
     iri"http://music.com/context"   -> ContextValue.fromFile("indexing/music-context.json").accepted,

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
@@ -14,6 +14,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts, schema => viewsSchemaId, ElasticSearchViewEvent}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.routes.ElasticSearchViewsRoutes
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -154,6 +155,7 @@ class ElasticSearchPluginModule(priority: Int) extends ModuleDef {
           deferred: Deferred[Task, ElasticSearchViews],
           orgs: Organizations,
           projects: Projects,
+          api: JsonLdApi,
           uuidF: UUIDF,
           as: ActorSystem[Nothing],
           scheduler: Scheduler
@@ -168,6 +170,7 @@ class ElasticSearchPluginModule(priority: Int) extends ModuleDef {
           orgs,
           projects
         )(
+          api,
           uuidF,
           scheduler,
           as

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewJsonLdSourceDecoder.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewJsonLdSourceDecoder.scala
@@ -5,6 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViewJson
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.{AggregateElasticSearchViewValue, IndexingElasticSearchViewValue}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts, permissions, ElasticSearchViewRejection, ElasticSearchViewType, ElasticSearchViewValue}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.{Configuration, JsonLdDecoder}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.configuration.semiauto._
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
@@ -111,11 +112,12 @@ object ElasticSearchViewJsonLdSourceDecoder {
       AggregateElasticSearchViewValue(a.views)
   }
 
-  def apply(uuidF: UUIDF, contextResolution: ResolverContextResolution) = new ElasticSearchViewJsonLdSourceDecoder(
-    new JsonLdSourceResolvingDecoder[ElasticSearchViewRejection, ElasticSearchViewFields](
-      contexts.elasticsearch,
-      contextResolution,
-      uuidF
+  def apply(uuidF: UUIDF, contextResolution: ResolverContextResolution)(implicit api: JsonLdApi) =
+    new ElasticSearchViewJsonLdSourceDecoder(
+      new JsonLdSourceResolvingDecoder[ElasticSearchViewRejection, ElasticSearchViewFields](
+        contexts.elasticsearch,
+        contextResolution,
+        uuidF
+      )
     )
-  )
 }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViews.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViews.scala
@@ -19,6 +19,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue._
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
 import ch.epfl.bluebrain.nexus.delta.sdk.ProjectReferenceFinder.ProjectReferenceMap
@@ -537,6 +538,7 @@ object ElasticSearchViews {
       orgs: Organizations,
       projects: Projects
   )(implicit
+      api: JsonLdApi,
       uuidF: UUIDF,
       scheduler: Scheduler,
       as: ActorSystem[Nothing]

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingStreamEntry.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingStreamEntry.scala
@@ -7,6 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.predicate
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{nxv, rdf, rdfs, skos}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
@@ -17,6 +18,7 @@ import io.circe.Json
 import io.circe.syntax._
 import monix.bio.Task
 import org.apache.jena.graph.Node
+import ElasticSearchIndexingStreamEntry._
 
 final case class ElasticSearchIndexingStreamEntry(
     resource: IndexingData
@@ -124,6 +126,8 @@ final case class ElasticSearchIndexingStreamEntry(
 }
 
 object ElasticSearchIndexingStreamEntry {
+
+  implicit private[indexing] val api: JsonLdApi = JsonLdJavaApi.lenient
 
   private val graphPredicates: Set[Node] =
     Set(skos.prefLabel, rdf.tpe, rdfs.label, Vocabulary.schema.name).map(predicate)

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchScopeInitializationSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchScopeInitializationSpec.scala
@@ -29,7 +29,7 @@ class ElasticSearchScopeInitializationSpec
     with OptionValues
     with TestHelpers
     with ConfigFixtures
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   private val uuid                   = UUID.randomUUID()
   implicit private val uuidF: UUIDF  = UUIDF.fixed(uuid)

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewDecodingSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewDecodingSpec.scala
@@ -28,7 +28,7 @@ class ElasticSearchViewDecodingSpec
     with IOValues
     with TestHelpers
     with OptionValues
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   private val project = Project(
     label = Label.unsafe("proj"),

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewEventExchangeSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewEventExchangeSpec.scala
@@ -24,11 +24,7 @@ import org.scalatest.Inspectors
 import java.time.Instant
 import java.util.UUID
 
-class ElasticSearchViewEventExchangeSpec
-    extends AbstractDBSpec
-    with Inspectors
-    with ConfigFixtures
-    with RemoteContextResolutionFixture {
+class ElasticSearchViewEventExchangeSpec extends AbstractDBSpec with Inspectors with ConfigFixtures with Fixtures {
 
   implicit private val scheduler: Scheduler = Scheduler.global
 

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewReferenceExchangeSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewReferenceExchangeSpec.scala
@@ -17,11 +17,7 @@ import org.scalatest.Inspectors
 
 import java.util.UUID
 
-class ElasticSearchViewReferenceExchangeSpec
-    extends AbstractDBSpec
-    with Inspectors
-    with ConfigFixtures
-    with RemoteContextResolutionFixture {
+class ElasticSearchViewReferenceExchangeSpec extends AbstractDBSpec with Inspectors with ConfigFixtures with Fixtures {
 
   implicit private val scheduler: Scheduler = Scheduler.global
 

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsQuerySpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsQuerySpec.scala
@@ -66,7 +66,7 @@ class ElasticSearchViewsQuerySpec
     with ConfigFixtures
     with IOValues
     with Eventually
-    with RemoteContextResolutionFixture {
+    with Fixtures {
   implicit override def patienceConfig: PatienceConfig = PatienceConfig(6.seconds, 100.millis)
 
   implicit private val sc: Scheduler                = Scheduler.global

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSetup.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSetup.scala
@@ -3,10 +3,11 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 import akka.actor.typed.ActorSystem
 import cats.effect.concurrent.Deferred
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.RemoteContextResolutionFixture.rcr
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.Fixtures.rcr
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.Refresh
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.config.ElasticSearchViewsConfig
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewEvent
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
@@ -42,7 +43,14 @@ trait ElasticSearchViewsSetup extends IOValues with ConfigFixtures with IOFixedC
       org: Label,
       project: Project,
       perms: Permission*
-  )(implicit base: BaseUri, as: ActorSystem[Nothing], uuid: UUIDF, s: Subject, sc: Scheduler): ElasticSearchViews = {
+  )(implicit
+      api: JsonLdApi,
+      base: BaseUri,
+      as: ActorSystem[Nothing],
+      uuid: UUIDF,
+      s: Subject,
+      sc: Scheduler
+  ): ElasticSearchViews = {
     for {
       (orgs, projs) <- ProjectSetup.init(orgsToCreate = org :: Nil, projectsToCreate = project :: Nil)
     } yield init(orgs, projs, perms: _*)
@@ -52,14 +60,20 @@ trait ElasticSearchViewsSetup extends IOValues with ConfigFixtures with IOFixedC
       orgs: Organizations,
       projects: Projects,
       perms: Permission*
-  )(implicit base: BaseUri, as: ActorSystem[Nothing], uuid: UUIDF, sc: Scheduler): ElasticSearchViews =
+  )(implicit api: JsonLdApi, base: BaseUri, as: ActorSystem[Nothing], uuid: UUIDF, sc: Scheduler): ElasticSearchViews =
     init(orgs, projects, PermissionsDummy(perms.toSet).accepted)
 
   def init(
       orgs: Organizations,
       projects: Projects,
       perms: Permissions
-  )(implicit base: BaseUri, as: ActorSystem[Nothing], uuid: UUIDF, sc: Scheduler): ElasticSearchViews = {
+  )(implicit
+      api: JsonLdApi,
+      base: BaseUri,
+      as: ActorSystem[Nothing],
+      uuid: UUIDF,
+      sc: Scheduler
+  ): ElasticSearchViews = {
     for {
       eventLog   <- EventLog.postgresEventLog[Envelope[ElasticSearchViewEvent]](EventLogUtils.toEnvelope).hideErrors
       deferred   <- Deferred[Task, ElasticSearchViews]

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSpec.scala
@@ -40,7 +40,7 @@ class ElasticSearchViewsSpec
     with OptionValues
     with TestHelpers
     with ConfigFixtures
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   private val realm                  = Label.unsafe("myrealm")
   implicit private val alice: Caller = Caller(User("Alice", realm), Set(User("Alice", realm), Group("users", realm)))

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/Fixtures.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/Fixtures.scala
@@ -3,11 +3,12 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.contexts
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.contexts.{elasticsearch, elasticsearchMetadata}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 
-trait RemoteContextResolutionFixture extends IOValues {
+trait Fixtures extends IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
 
   private val listingsMetadataCtx =
@@ -25,6 +26,8 @@ trait RemoteContextResolutionFixture extends IOValues {
   private val indexingMetadataCtx = listingsMetadataCtx.visit(obj = { case ContextObject(obj) =>
     ContextObject(obj.filterKeys(_.startsWith("_")))
   })
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(
     elasticsearch                  -> ContextValue.fromFile("contexts/elasticsearch.json").accepted,
@@ -44,4 +47,4 @@ trait RemoteContextResolutionFixture extends IOValues {
   )
 }
 
-object RemoteContextResolutionFixture extends RemoteContextResolutionFixture
+object Fixtures extends Fixtures

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingSpec.scala
@@ -13,7 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.ElasticSearc
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchView.IndexingElasticSearchView
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.IndexingElasticSearchViewValue
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{permissions, IndexingViewResource}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViews, ElasticSearchViewsSetup, RemoteContextResolutionFixture}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViews, ElasticSearchViewsSetup, Fixtures}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
@@ -61,7 +61,7 @@ class ElasticSearchIndexingSpec
     with CancelAfterFailure
     with ConfigFixtures
     with Eventually
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   implicit private val uuidF: UUIDF     = UUIDF.random
   implicit private val sc: Scheduler    = Scheduler.global

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewSpec.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model
 
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.RemoteContextResolutionFixture
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.Fixtures
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchView.{AggregateElasticSearchView, IndexingElasticSearchView}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
@@ -21,7 +21,7 @@ class ElasticSearchViewSpec
     with TestHelpers
     with IOValues
     with CirceEq
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   private val id      = nxv + "myview"
   private val project = ProjectRef.unsafe("org", "project")

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -11,7 +11,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewType.{ElasticSearch => ElasticSearchType}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.contexts.searchMetadata
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultElasticsearchSettings, permissions => esPermissions, schema => elasticSearchSchema, ElasticSearchViewEvent}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViewsSetup, RemoteContextResolutionFixture}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViewsSetup, Fixtures}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
@@ -63,7 +63,7 @@ class ElasticSearchViewsRoutesSpec
     with ConfigFixtures
     with TestHelpers
     with CirceMarshalling
-    with RemoteContextResolutionFixture {
+    with Fixtures {
 
   import akka.actor.typed.scaladsl.adapter._
   implicit val typedSystem = system.toTyped

--- a/delta/plugins/search/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/search/SearchSparqlQuerySpec.scala
+++ b/delta/plugins/search/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/search/SearchSparqlQuerySpec.scala
@@ -11,6 +11,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.{Graph, NTriples}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.{HttpClient, HttpClientConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
@@ -49,6 +50,7 @@ class SearchSparqlQuerySpec
 
   implicit private val sc: Scheduler                = Scheduler.global
   implicit private val httpCfg: HttpClientConfig    = httpClientConfig
+  implicit private val api: JsonLdApi               = JsonLdJavaApi.strict
   implicit private val rcr: RemoteContextResolution = RemoteContextResolution.fixed(
     searchDocument -> jsonContentOf("contexts/search-document.json").topContextValueOrEmpty
   )

--- a/delta/plugins/search/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/search/SearchSpec.scala
+++ b/delta/plugins/search/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/search/SearchSpec.scala
@@ -14,7 +14,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchDocker.e
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.Refresh
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.{ElasticSearchBulk, ElasticSearchClient}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.permissions
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchDocker, RemoteContextResolutionFixture}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchDocker, Fixtures}
 import ch.epfl.bluebrain.nexus.delta.plugins.search.Search.{ListProjections, TargetProjection}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
@@ -54,7 +54,7 @@ class SearchSpec
     with ConfigFixtures
     with IOValues
     with Eventually
-    with RemoteContextResolutionFixture
+    with Fixtures
     with ElasticSearchDocker
     with DockerTestKit {
   implicit override def patienceConfig: PatienceConfig = PatienceConfig(6.seconds, 100.millis)

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginModule.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginModule.scala
@@ -19,6 +19,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.remote.
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.routes.StoragesRoutes
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.schemas.{storage => storagesSchemaId}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.{StorageEventExchange, Storages, StoragesDeletion, StoragesStatistics}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk._
@@ -83,6 +84,7 @@ class StoragePluginModule(priority: Int) extends ModuleDef {
           projects: Projects,
           cache: StoragesCache,
           agg: StoragesAggregate,
+          api: JsonLdApi,
           uuidF: UUIDF,
           contextResolution: ResolverContextResolution,
           as: ActorSystem[Nothing],
@@ -99,6 +101,7 @@ class StoragePluginModule(priority: Int) extends ModuleDef {
           agg,
           serviceAccount
         )(
+          api,
           uuidF,
           scheduler,
           as

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/Storages.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/Storages.scala
@@ -18,6 +18,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model._
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.StorageAccess
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.schemas.{storage => storageSchema}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
@@ -509,6 +510,7 @@ object Storages {
       agg: StoragesAggregate,
       serviceAccount: ServiceAccount
   )(implicit
+      api: JsonLdApi,
       uuidF: UUIDF,
       scheduler: Scheduler,
       as: ActorSystem[Nothing]

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/RemoteContextResolutionFixture.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/RemoteContextResolutionFixture.scala
@@ -3,11 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.storage
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.{contexts => fileContexts}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.{contexts => storageContexts}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 
 trait RemoteContextResolutionFixture extends IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit val rcr: RemoteContextResolution = RemoteContextResolution.fixed(
     storageContexts.storages         -> ContextValue.fromFile("/contexts/storages.json").accepted,

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApi.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApi.scala
@@ -35,7 +35,3 @@ trait JsonLdApi {
   )(implicit opts: JsonLdOptions, rcr: RemoteContextResolution): IO[RdfError, JsonLdContext]
 
 }
-
-object JsonLdApi {
-  implicit val jsonLdJavaAPI: JsonLdApi = JsonLdJavaApi
-}

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApiConfig.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/api/JsonLdApiConfig.scala
@@ -1,0 +1,47 @@
+package ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api
+
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApiConfig.ErrorHandling
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.{deriveEnumerationReader, deriveReader}
+
+/**
+  * Configuration for the json
+  * @param strict
+  *   set the Jena parser to strict mode
+  * @param extraChecks
+  *   set the Jena parser to perform additional checks
+  * @param errorHandling
+  *   set the error handler fpr the jena parser
+  */
+final case class JsonLdApiConfig(strict: Boolean, extraChecks: Boolean, errorHandling: ErrorHandling)
+
+object JsonLdApiConfig {
+
+  sealed trait ErrorHandling
+
+  object ErrorHandling {
+
+    /**
+      * Keep the default error handler, errors will throw exception but only log warnings
+      */
+    case object Default extends ErrorHandling
+
+    /**
+      * Error handler that will throw exceptions for both errors and warnings
+      */
+    case object Strict extends ErrorHandling
+
+    /**
+      * Error handler that will throw exceptions for errors but do nothing about warnings
+      */
+    case object NoWarning extends ErrorHandling
+
+    implicit final val flavourReader: ConfigReader[ErrorHandling] =
+      deriveEnumerationReader
+
+  }
+
+  implicit final val jsonLdApiConfigReader: ConfigReader[JsonLdApiConfig] =
+    deriveReader[JsonLdApiConfig]
+
+}

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngine.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngine.scala
@@ -4,6 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioStrea
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxsh
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import monix.bio.IO
 import org.apache.jena.graph.Factory.createDefaultGraph
 import org.apache.jena.query.{Dataset, DatasetFactory}
@@ -77,7 +78,7 @@ object ShaclEngine {
   def apply(
       shapesGraph: Graph,
       reportDetails: Boolean
-  ): IO[String, ValidationReport] =
+  )(implicit api: JsonLdApi): IO[String, ValidationReport] =
     for {
       shaclGraph <- shaclGraphIO
       shapes      = ShaclShapesGraph(shaclGraph)
@@ -100,7 +101,7 @@ object ShaclEngine {
       dataGraph: Graph,
       shapesGraph: Graph,
       reportDetails: Boolean
-  ): IO[String, ValidationReport] =
+  )(implicit api: JsonLdApi): IO[String, ValidationReport] =
     apply(dataGraph, ShaclShapesGraph(shapesGraph), validateShapes = false, reportDetails)
 
   /**
@@ -122,7 +123,7 @@ object ShaclEngine {
       shapesGraph: ShaclShapesGraph,
       validateShapes: Boolean,
       reportDetails: Boolean
-  ): IO[String, ValidationReport] =
+  )(implicit api: JsonLdApi): IO[String, ValidationReport] =
     apply(DatasetFactory.wrap(graph.value), shapesGraph, validateShapes, reportDetails)
 
   private def apply(
@@ -130,7 +131,7 @@ object ShaclEngine {
       shapesGraph: ShaclShapesGraph,
       validateShapes: Boolean,
       reportDetails: Boolean
-  ): IO[String, ValidationReport] = {
+  )(implicit api: JsonLdApi): IO[String, ValidationReport] = {
     // Create Dataset that contains both the data model and the shapes model
     // (here, using a temporary URI for the shapes graph)
     dataset.addNamedModel(shapesGraph.uri.toString, shapesGraph.model)

--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReport.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReport.scala
@@ -4,6 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.predicate
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, sh}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
 import io.circe.{Encoder, Json}
@@ -43,7 +44,7 @@ object ValidationReport {
       contexts.shacl -> ContextValue.fromFile("contexts/shacl.json").memoizeOnSuccess
     )
 
-  final def apply(report: Resource): IO[String, ValidationReport] = {
+  final def apply(report: Resource)(implicit api: JsonLdApi): IO[String, ValidationReport] = {
     val tmpGraph = Graph.unsafe(DatasetFactory.create(report.getModel).asDatasetGraph())
     for {
       rootNode      <- IO.fromEither(

--- a/delta/rdf/src/test/resources/expanded-invalid-iri.json
+++ b/delta/rdf/src/test/resources/expanded-invalid-iri.json
@@ -1,0 +1,27 @@
+[
+  {
+    "@id": "http://nexus.example.com/john-doé",
+    "@type": [
+      "http://schema.org/Person"
+    ],
+    "http://example.com/address": [
+      {
+        "http://example.com/customid": [
+          {
+            "@id": " http://nexus.example.com/myid"
+          }
+        ],
+        "http://example.com/number": [
+          {
+            "@value": 2
+          }
+        ],
+        "http://example.com/street": [
+          {
+            "@value": "my street"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/Fixtures.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/Fixtures.scala
@@ -4,6 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.{BNode, Iri}
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.{predicate, subject}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.testkit._
 import monix.execution.schedulers.CanBlock
@@ -16,6 +17,8 @@ trait Fixtures
     with IOValues
     with EitherValuable
     with TestMatchers {
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   val iri = iri"http://nexus.example.com/john-doé"
 

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/context/JsonLdContextSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/context/JsonLdContextSpec.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context
 import ch.epfl.bluebrain.nexus.delta.rdf.Fixtures
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{rdf, schema, xsd}
 import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -12,7 +11,6 @@ class JsonLdContextSpec extends AnyWordSpecLike with Matchers with Fixtures with
 
   "A Json-LD context" should {
     val context = jsonContentOf("context.json").topContextValueOrEmpty
-    val api     = implicitly[JsonLdApi]
 
     "be constructed successfully" in {
       api.context(context).accepted shouldBe a[JsonLdContext]

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/decoder/JsonLdDecoderSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/jsonld/decoder/JsonLdDecoderSpec.scala
@@ -1,5 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder
 
+import ch.epfl.bluebrain.nexus.delta.rdf.Fixtures
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schema
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
@@ -29,6 +30,7 @@ class JsonLdDecoderSpec
     with CirceLiteral
     with EitherValuable
     with IOValues
+    with Fixtures
     with TestHelpers {
 
   implicit private val rcr: RemoteContextResolution = RemoteContextResolution.fixed()

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngineSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ShaclEngineSpec.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.rdf.shacl
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
@@ -18,6 +19,8 @@ class ShaclEngineSpec
     with IOValues
     with EitherValuable
     with Inspectors {
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.lenient
 
   "A ShaclEngine" should {
 

--- a/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReportSpec.scala
+++ b/delta/rdf/src/test/scala/ch/epfl/bluebrain/nexus/delta/rdf/shacl/ValidationReportSpec.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.rdf.shacl
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
 import ch.epfl.bluebrain.nexus.testkit.{EitherValuable, IOValues, TestHelpers}
@@ -21,6 +22,8 @@ class ValidationReportSpec
     with EitherValuable
     with OptionValues
     with IOValues {
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   private val shaclResolvedCtx = jsonContentOf("contexts/shacl.json").topContextValueOrEmpty
 

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResolversDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResolversDummy.scala
@@ -6,6 +6,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.Lens
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers._
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
 import ch.epfl.bluebrain.nexus.delta.sdk._
@@ -213,7 +214,7 @@ object ResolversDummy {
   implicit private val eventLens: Lens[ResolverEvent, ResolverIdentifier] =
     (event: ResolverEvent) => (event.project, event.id)
 
-  implicit private val lens: Lens[Resolver, ResolverIdentifier]    =
+  implicit private val lens: Lens[Resolver, ResolverIdentifier]                    =
     (resolver: Resolver) => resolver.project -> resolver.id
 
   /**
@@ -233,7 +234,7 @@ object ResolversDummy {
       projects: Projects,
       contextResolution: ResolverContextResolution,
       idAvailability: IdAvailability[ResourceAlreadyExists]
-  )(implicit clock: Clock[UIO], uuidF: UUIDF): UIO[ResolversDummy] =
+  )(implicit api: JsonLdApi, clock: Clock[UIO], uuidF: UUIDF): UIO[ResolversDummy] =
     for {
       journal      <- Journal(moduleType, 1L, EventTags.forProjectScopedEvent[ResolverEvent](moduleType))
       cache        <- ResourceCache[ResolverIdentifier, Resolver]

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesDummy.scala
@@ -5,6 +5,7 @@ import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.kernel.Lens
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.ResolverResolution.ResourceResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
 import ch.epfl.bluebrain.nexus.delta.sdk.Resources._
@@ -49,7 +50,7 @@ final class ResourcesDummy private (
     idAvailability: IdAvailability[ResourceAlreadyExists],
     semaphore: IOSemaphore,
     sourceParser: JsonLdSourceResolvingParser[ResourceRejection]
-)(implicit clock: Clock[UIO])
+)(implicit api: JsonLdApi, clock: Clock[UIO])
     extends Resources {
 
   private val eval = Resources.evaluate(resourceResolution, idAvailability)(_, _)
@@ -234,7 +235,7 @@ object ResourcesDummy {
       resourceResolution: ResourceResolution[Schema],
       idAvailability: IdAvailability[ResourceAlreadyExists],
       contextResolution: ResolverContextResolution
-  )(implicit clock: Clock[UIO], uuidF: UUIDF): UIO[ResourcesDummy] =
+  )(implicit api: JsonLdApi, clock: Clock[UIO], uuidF: UUIDF): UIO[ResourcesDummy] =
     for {
       journal <- Journal(moduleType, 1L, EventTags.forResourceEvents(moduleType))
       sem     <- IOSemaphore(1L)
@@ -272,7 +273,7 @@ object ResourcesDummy {
       idAvailability: IdAvailability[ResourceAlreadyExists],
       contextResolution: ResolverContextResolution,
       journal: ResourcesJournal
-  )(implicit clock: Clock[UIO], uuidF: UUIDF): UIO[ResourcesDummy] =
+  )(implicit api: JsonLdApi, clock: Clock[UIO], uuidF: UUIDF): UIO[ResourcesDummy] =
     for {
       sem   <- IOSemaphore(1L)
       parser = JsonLdSourceResolvingParser[ResourceRejection](contextResolution, uuidF)

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasDummy.scala
@@ -6,6 +6,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.Lens
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
 import ch.epfl.bluebrain.nexus.delta.sdk.Schemas._
 import ch.epfl.bluebrain.nexus.delta.sdk._
@@ -34,7 +35,7 @@ final class SchemasDummy private (
     semaphore: IOSemaphore,
     sourceParser: JsonLdSourceResolvingParser[SchemaRejection],
     idAvailability: IdAvailability[ResourceAlreadyExists]
-)(implicit clock: Clock[UIO])
+)(implicit api: JsonLdApi, clock: Clock[UIO])
     extends Schemas {
 
   override def create(
@@ -183,7 +184,7 @@ object SchemasDummy {
       schemaImports: SchemaImports,
       contextResolution: ResolverContextResolution,
       idAvailability: IdAvailability[ResourceAlreadyExists]
-  )(implicit clock: Clock[UIO], uuidF: UUIDF): UIO[SchemasDummy] =
+  )(implicit api: JsonLdApi, clock: Clock[UIO], uuidF: UUIDF): UIO[SchemasDummy] =
     for {
       journal <- Journal(moduleType, 1L, EventTags.forProjectScopedEvent[SchemaEvent](Schemas.moduleType))
       sem     <- IOSemaphore(1L)

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResolversBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResolversBehaviors.scala
@@ -4,6 +4,7 @@ import akka.persistence.query.{NoOffset, Sequence}
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
@@ -51,6 +52,8 @@ trait ResolversBehaviors {
 
   val uuid                  = UUID.randomUUID()
   implicit val uuidF: UUIDF = UUIDF.fixed(uuid)
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ResourcesBehaviors.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.testkit
 import akka.persistence.query.{NoOffset, Sequence}
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema, schemas}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.ResolverResolution.{FetchResource, ResourceResolution}
@@ -51,6 +52,8 @@ trait ResourcesBehaviors {
 
   val uuid                  = UUID.randomUUID()
   implicit val uuidF: UUIDF = UUIDF.fixed(uuid)
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemaSetup.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemaSetup.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.testkit
 import cats.effect.Clock
 import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.{ResolverContextResolution, ResourceResolutionReport}
@@ -29,6 +30,7 @@ object SchemaSetup {
       resolveSchema: Resolve[Schema] = (_, _, _) => IO.raiseError(ResourceResolutionReport()),
       resolveResource: Resolve[Resource] = (_, _, _) => IO.raiseError(ResourceResolutionReport())
   )(implicit
+      api: JsonLdApi,
       clock: Clock[UIO],
       uuidf: UUIDF,
       rcr: RemoteContextResolution,

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/SchemasBehaviors.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.testkit
 import akka.persistence.query.{NoOffset, Sequence}
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, SchemaGen}
@@ -48,6 +49,8 @@ trait SchemasBehaviors {
   val uuid                             = UUID.randomUUID()
   implicit val uuidF: UUIDF            = UUIDF.fixed(uuid)
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.lenient
 
   implicit def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/sdk-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/views/model/IndexingData.scala
+++ b/delta/sdk-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/views/model/IndexingData.scala
@@ -5,6 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.subject
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
@@ -46,6 +47,8 @@ final case class IndexingData(
 }
 
 object IndexingData {
+
+  implicit private val api: JsonLdApi = JsonLdJavaApi.lenient
 
   /**
     * Helper function to generate an IndexingData from the [[EventExchangeValue]]. The resource data is divided in 2

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resources.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Resources.scala
@@ -8,6 +8,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schemas}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.shacl.ShaclEngine
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
@@ -296,6 +297,7 @@ object Resources {
       resourceResolution: ResourceResolution[Schema],
       idAvailability: IdAvailability[ResourceAlreadyExists]
   )(state: ResourceState, cmd: ResourceCommand)(implicit
+      api: JsonLdApi,
       clock: Clock[UIO]
   ): IO[ResourceRejection, ResourceEvent] = {
 
@@ -311,6 +313,7 @@ object Resources {
     ): IO[ResourceRejection, (ResourceRef.Revision, ProjectRef)] =
       if (schemaRef == Latest(schemas.resources) || schemaRef == ResourceRef.Revision(schemas.resources, 1))
         IO.raiseWhen(id.startsWith(contexts.base))(ReservedResourceId(id)) >>
+          toGraph(id, expanded) >>
           IO.pure((ResourceRef.Revision(schemas.resources, 1L), projectRef))
       else
         for {

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Schemas.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/Schemas.scala
@@ -9,6 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.schemas
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.shacl.ShaclEngine
 import ch.epfl.bluebrain.nexus.delta.sdk.EventExchange.EventExchangeValue
@@ -285,7 +286,7 @@ object Schemas {
   private[delta] def evaluate(idAvailability: IdAvailability[ResourceAlreadyExists])(
       state: SchemaState,
       cmd: SchemaCommand
-  )(implicit clock: Clock[UIO] = IO.clock): IO[SchemaRejection, SchemaEvent] = {
+  )(implicit api: JsonLdApi, clock: Clock[UIO] = IO.clock): IO[SchemaRejection, SchemaEvent] = {
 
     def toGraph(id: Iri, expanded: NonEmptyList[ExpandedJsonLd]) = {
       val eitherGraph = expanded.value.foldM(Graph.empty)((acc, expandedEntry) => expandedEntry.toGraph.map(acc ++ _))

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToJsonLd.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToJsonLd.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfMediaTypes._
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -40,6 +41,10 @@ object ResponseToJsonLd extends FileBytesInstances {
       uio: UIO[RejOrFailOrComplete[E]]
   )(implicit s: Scheduler, cr: RemoteContextResolution, jo: JsonKeyOrdering): ResponseToJsonLd =
     new ResponseToJsonLd {
+
+      // Some resources may not have been created in the system with a strict configuration
+      // (and if they are, there is no need to check them again)
+      implicit val api: JsonLdApi = JsonLdJavaApi.lenient
 
       override def apply(statusOverride: Option[StatusCode]): Route = {
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToMarshaller.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToMarshaller.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.marshalling.ToEntityMarshaller
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.server.Directives.{complete, onSuccess, reject}
 import akka.http.scaladsl.server.Route
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -18,6 +19,10 @@ trait ResponseToMarshaller {
 }
 
 object ResponseToMarshaller extends RdfMarshalling {
+
+  // Some resources may not have been created in the system with a strict configuration
+  // (and if they are, there is no need to check them again)
+  implicit val api: JsonLdApi = JsonLdJavaApi.lenient
 
   private[directives] def apply[E: JsonLdEncoder, A: ToEntityMarshaller](
       uio: UIO[Either[Response[E], Complete[A]]]

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/Schema.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/schemas/Schema.scala
@@ -5,7 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
 import ch.epfl.bluebrain.nexus.delta.rdf.Triple.Triple
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, owl}
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd}
@@ -56,8 +56,9 @@ final case class Schema(
   lazy val ontologies: Graph = graph(types => types.contains(owl.Ontology) && !types.contains(nxv.Schema))
 
   private def graph(filteredTypes: Set[Iri] => Boolean): Graph = {
-    val filtered = expanded.value.filter(expanded => expanded.cursor.getTypes.exists(filteredTypes))
-    val triples  = filtered.map(_.toGraph.toOption.get).foldLeft(Set.empty[Triple])((acc, g) => acc ++ g.triples)
+    implicit val api: JsonLdApi = JsonLdJavaApi.lenient
+    val filtered                = expanded.value.filter(expanded => expanded.cursor.getTypes.exists(filteredTypes))
+    val triples                 = filtered.map(_.toGraph.toOption.get).foldLeft(Set.empty[Triple])((acc, g) => acc ++ g.triples)
     Graph.empty(id).add(triples)
   }
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/SchemasSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/SchemasSpec.scala
@@ -1,6 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.sdk
 
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schemas}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.sdk.Schemas.{evaluate, next}
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, SchemaGen}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.User
@@ -31,6 +32,8 @@ class SchemasSpec
     with CirceLiteral
     with OptionValues
     with Fixtures {
+
+  implicit override val api: JsonLdApi = JsonLdJavaApi.lenient
 
   "The Schemas state machine" when {
     implicit val sc: Scheduler = Scheduler.global

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/DeltaDirectivesSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/DeltaDirectivesSpec.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfMediaTypes._
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -55,6 +56,8 @@ class DeltaDirectivesSpec
 
   private val id       = nxv + "myresource"
   private val resource = SimpleResource(id, 1L, Instant.EPOCH, "Maria", 20)
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit private val rcr: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/ResourceGen.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.generators
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{nxv, schemas}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.DataResource
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourceRef.Latest
@@ -19,6 +20,9 @@ import org.scalatest.OptionValues
 import java.time.Instant
 
 object ResourceGen extends OptionValues with IOValues {
+
+  // We put a lenient api for schemas otherwise the api checks data types before the actual schema validation process
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   def currentState(
       id: Iri,

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/SchemaGen.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/generators/SchemaGen.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.generators
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.SchemaResource
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{NonEmptyList, TagLabel}
@@ -18,6 +19,8 @@ import org.scalatest.OptionValues
 import java.time.Instant
 
 object SchemaGen extends OptionValues with IOValues with EitherValuable {
+  // We put a lenient api for schemas otherwise the api checks data types before the actual schema validation process
+  implicit val api: JsonLdApi = JsonLdJavaApi.lenient
 
   def currentState(
       schema: Schema,

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/marshalling/RdfMarshallingSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/marshalling/RdfMarshallingSpec.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model._
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfMediaTypes._
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
 import ch.epfl.bluebrain.nexus.delta.sdk.SimpleResource
@@ -23,6 +24,7 @@ class RdfMarshallingSpec
     with IOValues
     with TestMatchers {
 
+  implicit private val api: JsonLdApi               = JsonLdJavaApi.strict
   implicit private val rcr: RemoteContextResolution = RemoteContextResolution.fixed(contextIri -> context)
   implicit private val ordering: JsonKeyOrdering    =
     JsonKeyOrdering.default(topKeys =

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/utils/Fixtures.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/utils/Fixtures.scala
@@ -1,11 +1,14 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.utils
 
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.testkit.IOValues
 
 trait Fixtures extends IOValues {
   implicit private val cl: ClassLoader = getClass.getClassLoader
+
+  implicit val api: JsonLdApi = JsonLdJavaApi.strict
 
   implicit val rcr: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolversImpl.scala
@@ -7,6 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.RetryStrategy
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers._
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
 import ch.epfl.bluebrain.nexus.delta.sdk._
@@ -291,6 +292,7 @@ object ResolversImpl {
       cache: ResolversCache,
       agg: ResolversAggregate
   )(implicit
+      api: JsonLdApi,
       uuidF: UUIDF,
       scheduler: Scheduler,
       as: ActorSystem[Nothing]

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourcesImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourcesImpl.scala
@@ -5,6 +5,7 @@ import akka.persistence.query.Offset
 import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.ResolverResolution.ResourceResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
 import ch.epfl.bluebrain.nexus.delta.sdk.Resources._
@@ -199,7 +200,7 @@ object ResourcesImpl {
       config: AggregateConfig,
       resourceResolution: ResourceResolution[Schema],
       resourceIdCheck: ResourceIdCheck
-  )(implicit as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[ResourcesAggregate] =
+  )(implicit api: JsonLdApi, as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[ResourcesAggregate] =
     aggregate(
       config,
       resourceResolution,
@@ -210,7 +211,7 @@ object ResourcesImpl {
       config: AggregateConfig,
       resourceResolution: ResourceResolution[Schema],
       idAvailability: IdAvailability[ResourceAlreadyExists]
-  )(implicit as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[ResourcesAggregate] = {
+  )(implicit api: JsonLdApi, as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[ResourcesAggregate] = {
     val definition = PersistentEventDefinition(
       entityType = moduleType,
       initialState = Initial,
@@ -245,7 +246,7 @@ object ResourcesImpl {
       agg: ResourcesAggregate,
       contextResolution: ResolverContextResolution,
       eventLog: EventLog[Envelope[ResourceEvent]]
-  )(implicit uuidF: UUIDF = UUIDF.random): Resources =
+  )(implicit api: JsonLdApi, uuidF: UUIDF = UUIDF.random): Resources =
     new ResourcesImpl(
       agg,
       orgs,

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemasImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemasImpl.scala
@@ -6,6 +6,7 @@ import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourceIdCheck.IdAvailability
 import ch.epfl.bluebrain.nexus.delta.sdk.Schemas._
 import ch.epfl.bluebrain.nexus.delta.sdk._
@@ -173,13 +174,13 @@ object SchemasImpl {
   def aggregate(
       config: AggregateConfig,
       resourceIdCheck: ResourceIdCheck
-  )(implicit as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[SchemasAggregate] =
+  )(implicit api: JsonLdApi, as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[SchemasAggregate] =
     aggregate(config, (project, id) => resourceIdCheck.isAvailableOr(project, id)(ResourceAlreadyExists(id, project)))
 
   private def aggregate(
       config: AggregateConfig,
       idAvailability: IdAvailability[ResourceAlreadyExists]
-  )(implicit as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[SchemasAggregate] = {
+  )(implicit api: JsonLdApi, as: ActorSystem[Nothing], clock: Clock[UIO]): UIO[SchemasAggregate] = {
     val definition = PersistentEventDefinition(
       entityType = moduleType,
       initialState = Initial,
@@ -210,7 +211,7 @@ object SchemasImpl {
       eventLog: EventLog[Envelope[SchemaEvent]],
       agg: SchemasAggregate,
       cache: SchemasCache
-  )(implicit uuidF: UUIDF = UUIDF.random): Schemas = {
+  )(implicit api: JsonLdApi, uuidF: UUIDF = UUIDF.random): Schemas = {
     val parser =
       new JsonLdSourceResolvingParser[SchemaRejection](
         List(contexts.shacl, contexts.schemasMetadata),

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverEventExchangeSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.resolvers
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schemas}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
@@ -42,6 +43,7 @@ class ResolverEventExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
+  implicit private val api: JsonLdApi   = JsonLdJavaApi.strict
 
   implicit private def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverReferenceExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resolvers/ResolverReferenceExchangeSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.resolvers
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
@@ -38,6 +39,7 @@ class ResolverReferenceExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
+  implicit private val api: JsonLdApi   = JsonLdJavaApi.strict
 
   implicit private def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceEventExchangeSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.resources
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schemas}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.ResolverResolution.{FetchResource, ResourceResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.Resources
@@ -45,6 +46,7 @@ class ResourceEventExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
+  implicit private val api: JsonLdApi   = JsonLdJavaApi.strict
 
   implicit private def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceReferenceExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/resources/ResourceReferenceExchangeSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.resources
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema => schemaorg}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.ResolverResolution.{FetchResource, ResourceResolution}
@@ -42,6 +43,7 @@ class ResourceReferenceExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
+  implicit private val api: JsonLdApi   = JsonLdJavaApi.strict
 
   implicit private def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaEventExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaEventExchangeSpec.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.service.schemas
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema => schemaorg}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, SchemaGen}
@@ -45,6 +46,7 @@ class SchemaEventExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
+  implicit private val api: JsonLdApi   = JsonLdJavaApi.strict
 
   implicit private def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaReferenceExchangeSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/schemas/SchemaReferenceExchangeSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.schemas
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema => schemaorg}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, SchemaGen}
@@ -39,6 +40,7 @@ class SchemaReferenceExchangeSpec
   implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
   private val uuid                      = UUID.randomUUID()
   implicit private val uuidF: UUIDF     = UUIDF.fixed(uuid)
+  implicit private val api: JsonLdApi   = JsonLdJavaApi.strict
 
   implicit private def res: RemoteContextResolution =
     RemoteContextResolution.fixed(

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/serialization/KryoSerializerInitSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/serialization/KryoSerializerInitSpec.scala
@@ -5,6 +5,7 @@ import akka.serialization.SerializationExtension
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.BNode
 import ch.epfl.bluebrain.nexus.delta.rdf.graph.Graph
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.NonEmptyList
@@ -32,6 +33,7 @@ class KryoSerializerInitSpec
     with EitherValuable {
 
   private val serialization                         = SerializationExtension(system)
+  implicit private val api: JsonLdApi               = JsonLdJavaApi.strict
   implicit private val rcr: RemoteContextResolution = RemoteContextResolution.fixed()
 
   private val expanded = ExpandedJsonLd(jsonContentOf("/kryo/expanded.json")).accepted

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/utils/ResolverScopeInitializationSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/utils/ResolverScopeInitializationSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.service.utils
 
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.{contexts, nxv, schema}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.Resolvers
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
@@ -46,12 +47,12 @@ class ResolverScopeInitializationSpec
 
   val resolvers: Resolvers = {
     implicit val baseUri: BaseUri = BaseUri.withoutPrefix("http://localhost")
-
-    val resolution = RemoteContextResolution.fixed(
+    implicit val api: JsonLdApi   = JsonLdJavaApi.strict
+    val resolution                = RemoteContextResolution.fixed(
       contexts.resolvers -> jsonContentOf("/contexts/resolvers.json").topContextValueOrEmpty
     )
-    val rcr        = new ResolverContextResolution(resolution, (_, _, _) => IO.raiseError(ResourceResolutionReport()))
-    val (o, p)     = ProjectSetup.init(List(org), List(project)).accepted
+    val rcr                       = new ResolverContextResolution(resolution, (_, _, _) => IO.raiseError(ResourceResolutionReport()))
+    val (o, p)                    = ProjectSetup.init(List(org), List(project)).accepted
     ResolversDummy(o, p, rcr, (_, _) => IO.unit).accepted
   }
   "A ResolverScopeInitialization" should {


### PR DESCRIPTION
Fixes #2760 

* The rdf parser for validating data can be configured to be more or less strict
* The rdf parser for fetching/indexing remains lenient to be able to return a resource no matter the strictness defined for validation (and also because there is no need to validate them again)