### PR TITLE
Added missing ProjectReferenceFinder annotation to project-deletion

### DIFF
--- a/delta/plugins/project-deletion/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/projectdeletion/ProjectDeletionModule.scala
+++ b/delta/plugins/project-deletion/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/projectdeletion/ProjectDeletionModule.scala
@@ -33,8 +33,9 @@ class ProjectDeletionModule(priority: Int) extends ModuleDef {
 
   many[PriorityRoute].add { (route: ProjectDeletionRoutes) => PriorityRoute(priority, route.routes) }
 
-  make[DeleteProject].from { (projects: Projects, serviceAccount: ServiceAccount, prf: ProjectReferenceFinder) =>
-    DeleteProject(projects)(serviceAccount.subject, prf)
+  make[DeleteProject].from {
+    (projects: Projects, serviceAccount: ServiceAccount, prf: ProjectReferenceFinder @Id("aggregate")) =>
+      DeleteProject(projects)(serviceAccount.subject, prf)
   }
 
   make[ProjectDeletion].fromEffect {


### PR DESCRIPTION
The missing annotation is causing Delta to fail booting when the project-deletion plugin is enabled.