### PR TITLE
Deleting views is now synchronous + implement deleting progress

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ProjectsModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ProjectsModule.scala
@@ -113,9 +113,7 @@ object ProjectsModule extends ModuleDef {
         projectsCounts: ProjectsCounts,
         dbCleanup: DatabaseCleanup
     ) =>
-      val list = deletions.toList :+ ProjectDeletion(cache, agg, projectsCounts, dbCleanup)
-      ResourcesDeletion.combine(NonEmptyList(list.head, list.tail))
-
+      ResourcesDeletion.combine(deletions, ProjectDeletion(cache, agg, projectsCounts, dbCleanup))
   }
 
   make[Projection[ResourcesDeletionStatusCollection]].fromEffect {

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViews.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViews.scala
@@ -33,7 +33,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectFetchOptions._
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, Project, ProjectFetchOptions, ProjectRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, Project, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.Pagination.{FromPagination, OnePage}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.ResultEntry.UnscoredResultEntry
@@ -222,29 +222,9 @@ final class BlazegraphViews(
       id: IdSegment,
       project: ProjectRef,
       rev: Long
-  )(implicit subject: Subject): IO[BlazegraphViewRejection, ViewResource] =
-    deprecate(id, project, notDeprecatedOrDeletedWithEventQuotas, rev)
-
-  /**
-    * Deprecate a view without any extra checks on the projects API.
-    * @see
-    *   [[deprecate(id, project, rev)]]
-    */
-  private[blazegraph] def deprecateWithoutProjectChecks(
-      id: IdSegment,
-      project: ProjectRef,
-      rev: Long
-  )(implicit subject: Subject): IO[BlazegraphViewRejection, ViewResource] =
-    deprecate(id, project, Set.empty, rev)
-
-  private def deprecate(
-      id: IdSegment,
-      project: ProjectRef,
-      projectFetchOptions: Set[ProjectFetchOptions],
-      rev: Long
   )(implicit subject: Subject): IO[BlazegraphViewRejection, ViewResource] = {
     for {
-      p   <- projects.fetchProject(project, projectFetchOptions)
+      p   <- projects.fetchProject(project, notDeprecatedOrDeletedWithEventQuotas)
       iri <- expandIri(id, p)
       res <- eval(DeprecateBlazegraphView(iri, project, rev, subject), p)
     } yield res

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/indexing/BlazegraphIndexingCoordinator.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/indexing/BlazegraphIndexingCoordinator.scala
@@ -10,7 +10,6 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewsCon
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.{IndexingStreamController, IndexingStreamCoordinator}
-import ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewIndex
 import com.typesafe.scalalogging.Logger
 import monix.bio.Task
 import monix.execution.Scheduler
@@ -26,20 +25,7 @@ object BlazegraphIndexingCoordinator {
     views
       .fetchIndexingView(id, project)
       .map { res =>
-        Some(
-          ViewIndex(
-            res.value.project,
-            res.id,
-            res.value.uuid,
-            BlazegraphViews.projectionId(res),
-            BlazegraphViews.namespace(res, config.indexing),
-            res.rev,
-            res.deprecated,
-            res.value.resourceTag,
-            res.updatedAt,
-            res.value
-          )
-        )
+        Some(IndexingBlazegraphView.resourceToViewIndex(res, config))
       }
       .onErrorHandle {
         case _: DifferentBlazegraphViewType =>

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/model/BlazegraphView.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/model/BlazegraphView.scala
@@ -1,5 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model
 
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.BlazegraphViews
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphView.Metadata
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
@@ -9,7 +10,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{NonEmptySet, TagLabel}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
-import ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.model.{ViewIndex, ViewRef}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
 import io.circe.syntax._
@@ -105,6 +106,28 @@ object BlazegraphView {
     override def metadata: Metadata = Metadata(Some(uuid))
 
     override def tpe: BlazegraphViewType = BlazegraphViewType.IndexingBlazegraphView
+  }
+
+  object IndexingBlazegraphView {
+
+    /**
+      * Create the view index from the [[IndexingBlazegraphView]]
+      */
+    def resourceToViewIndex(
+        res: IndexingViewResource,
+        config: BlazegraphViewsConfig
+    ): ViewIndex[IndexingBlazegraphView] = ViewIndex(
+      res.value.project,
+      res.id,
+      res.value.uuid,
+      BlazegraphViews.projectionId(res),
+      BlazegraphViews.namespace(res, config.indexing),
+      res.rev,
+      res.deprecated,
+      res.value.resourceTag,
+      res.updatedAt,
+      res.value
+    )
   }
 
   /**

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/indexing/BlazegraphIndexingSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/indexing/BlazegraphIndexingSpec.scala
@@ -177,7 +177,7 @@ class BlazegraphIndexingSpec
   private val indexingStream = new BlazegraphIndexingStream(blazegraphClient, indexingSource, cache, config, projection)
 
   private val views: BlazegraphViews = BlazegraphViewsSetup.init(orgs, projs, permissions.query)
-  private val indexingCleanup        = new BlazegraphIndexingCleanup(blazegraphClient, cache)
+  private val indexingCleanup        = new BlazegraphIndexingCleanup(blazegraphClient, cache, projection)
   private val controller             = new IndexingStreamController[IndexingBlazegraphView](BlazegraphViews.moduleType)
   BlazegraphIndexingCoordinator(views, controller, indexingStream, indexingCleanup, config).accepted
 

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViews.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViews.scala
@@ -38,7 +38,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectFetchOptions._
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{Project, ProjectBase, ProjectFetchOptions, ProjectRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{Project, ProjectBase, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.Pagination.{FromPagination, OnePage}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.ResultEntry.UnscoredResultEntry
@@ -252,29 +252,9 @@ final class CompositeViews private (
       id: IdSegment,
       project: ProjectRef,
       rev: Long
-  )(implicit subject: Subject): IO[CompositeViewRejection, ViewResource] =
-    deprecate(id, project, notDeprecatedOrDeletedWithEventQuotas, rev)
-
-  /**
-    * Deprecate a view without any extra checks on the projects API.
-    * @see
-    *   [[deprecate(id, project, rev)]]
-    */
-  private[compositeviews] def deprecateWithoutProjectChecks(
-      id: IdSegment,
-      project: ProjectRef,
-      rev: Long
-  )(implicit subject: Subject): IO[CompositeViewRejection, ViewResource] =
-    deprecate(id, project, Set.empty, rev)
-
-  private def deprecate(
-      id: IdSegment,
-      project: ProjectRef,
-      projectFetchOptions: Set[ProjectFetchOptions],
-      rev: Long
   )(implicit subject: Subject): IO[CompositeViewRejection, ViewResource] = {
     for {
-      p   <- projects.fetchProject(project, projectFetchOptions)
+      p   <- projects.fetchProject(project, notDeprecatedOrDeletedWithEventQuotas)
       iri <- expandIri(id, p)
       res <- eval(DeprecateCompositeView(iri, project, rev, subject), p)
     } yield res

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -23,9 +23,8 @@ import ch.epfl.bluebrain.nexus.delta.sdk.cache.KeyValueStore
 import ch.epfl.bluebrain.nexus.delta.sdk.crypto.Crypto
 import ch.epfl.bluebrain.nexus.delta.sdk.eventlog.EventLogUtils.databaseEventLog
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClient
-import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.ServiceAccount
-import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.IndexingStreamBehaviour.Restart
 import ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.{IndexingSource, IndexingStreamController}
 import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{Projection, ProjectionId, ProjectionProgress}
@@ -111,8 +110,8 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
         agg: CompositeViewsAggregate,
         views: CompositeViews,
         dbCleanup: DatabaseCleanup,
-        sa: ServiceAccount
-    ) => CompositeViewsDeletion(cache, agg, views, dbCleanup, sa)
+        coordinator: CompositeIndexingCoordinator
+    ) => CompositeViewsDeletion(cache, agg, views, dbCleanup, coordinator)
   }
 
   many[ProjectReferenceFinder].add { (views: CompositeViews) =>
@@ -208,6 +207,7 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
         esClient: ElasticSearchClient,
         blazeClient: BlazegraphClient @Id("blazegraph-indexing-client"),
         cache: ProgressesCache @Id("composite-progresses"),
+        projection: Projection[Unit],
         config: CompositeViewsConfig
     ) =>
       new CompositeIndexingCleanup(
@@ -215,7 +215,8 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
         esClient,
         config.blazegraphIndexing,
         blazeClient,
-        cache
+        cache,
+        projection
       )
   }
 

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/indexing/CompositeIndexingSpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/indexing/CompositeIndexingSpec.scala
@@ -262,7 +262,14 @@ class CompositeIndexingSpec
     RemoteIndexingSource.apply(remoteProjectStream, remoteResourceNQuads, config.remoteSourceClient, metadataPredicates)
 
   private val indexingCleanup =
-    new CompositeIndexingCleanup(config.elasticSearchIndexing, esClient, config.blazegraphIndexing, blazeClient, cache)
+    new CompositeIndexingCleanup(
+      config.elasticSearchIndexing,
+      esClient,
+      config.blazegraphIndexing,
+      blazeClient,
+      cache,
+      projection
+    )
   private val indexingStream  = new CompositeIndexingStream(
     config.elasticSearchIndexing,
     esClient,

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViews.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViews.scala
@@ -34,7 +34,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectFetchOptions._
-import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, Project, ProjectFetchOptions, ProjectRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.{ApiMappings, Project, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.Pagination.{FromPagination, OnePage}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.ResultEntry.UnscoredResultEntry
@@ -254,29 +254,9 @@ final class ElasticSearchViews private (
       id: IdSegment,
       project: ProjectRef,
       rev: Long
-  )(implicit subject: Subject): IO[ElasticSearchViewRejection, ViewResource] =
-    deprecate(id, project, notDeprecatedOrDeletedWithEventQuotas, rev)
-
-  /**
-    * Deprecate a view without any extra checks on the projects API.
-    * @see
-    *   [[deprecate(id, project, rev)]]
-    */
-  private[elasticsearch] def deprecateWithoutProjectChecks(
-      id: IdSegment,
-      project: ProjectRef,
-      rev: Long
-  )(implicit subject: Subject): IO[ElasticSearchViewRejection, ViewResource] =
-    deprecate(id, project, Set.empty, rev)
-
-  private def deprecate(
-      id: IdSegment,
-      project: ProjectRef,
-      projectFetchOptions: Set[ProjectFetchOptions],
-      rev: Long
   )(implicit subject: Subject): IO[ElasticSearchViewRejection, ViewResource] = {
     for {
-      p   <- projects.fetchProject(project, projectFetchOptions)
+      p   <- projects.fetchProject(project, notDeprecatedOrDeletedWithEventQuotas)
       iri <- expandIri(id, p)
       res <- eval(DeprecateElasticSearchView(iri, project, rev, subject), p)
     } yield res

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingCleanup.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingCleanup.scala
@@ -5,16 +5,20 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.sdk.ProgressesStatistics.ProgressesCache
 import ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.IndexingCleanup
 import ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewIndex
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.Projection
 import monix.bio.UIO
 
 class ElasticSearchIndexingCleanup(
     client: ElasticSearchClient,
-    cache: ProgressesCache
+    cache: ProgressesCache,
+    projection: Projection[Unit]
 ) extends IndexingCleanup[IndexingElasticSearchView] {
 
-  // TODO: We might want to delete the projection row too, but deletion is not implemented in Projection
   override def apply(view: ViewIndex[IndexingElasticSearchView]): UIO[Unit] =
-    cache.remove(view.projectionId) >> client.deleteIndex(idx(view)).attempt.void
+    client
+      .deleteIndex(idx(view))
+      .attempt
+      .void >> cache.remove(view.projectionId) >> projection.delete(view.projectionId).attempt.void
 
   private def idx(view: ViewIndex[_]): IndexLabel =
     IndexLabel.unsafe(view.index)

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingCoordinator.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingCoordinator.scala
@@ -10,7 +10,6 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sdk.views.indexing.{IndexingStreamController, IndexingStreamCoordinator}
-import ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewIndex
 import com.typesafe.scalalogging.Logger
 import monix.bio.Task
 import monix.execution.Scheduler
@@ -27,18 +26,7 @@ object ElasticSearchIndexingCoordinator {
       .fetchIndexingView(id, project)
       .map { res =>
         Some(
-          ViewIndex(
-            res.value.project,
-            res.id,
-            res.value.uuid,
-            ElasticSearchViews.projectionId(res),
-            ElasticSearchViews.index(res, config.indexing),
-            res.rev,
-            res.deprecated,
-            res.value.resourceTag,
-            res.updatedAt,
-            res.value
-          )
+          IndexingElasticSearchView.resourceToViewIndex(res, config)
         )
       }
       .onErrorHandle {

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchView.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchView.scala
@@ -1,5 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model
 
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViews
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.config.ElasticSearchViewsConfig
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchView.Metadata
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
@@ -12,7 +14,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.permissions.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{NonEmptySet, TagLabel}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
-import ch.epfl.bluebrain.nexus.delta.sdk.views.model.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.model.{ViewIndex, ViewRef}
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
 import io.circe.parser.parse
@@ -119,6 +121,29 @@ object ElasticSearchView {
     override def metadata: Metadata = Metadata(Some(uuid))
 
     override def tpe: ElasticSearchViewType = ElasticSearchViewType.ElasticSearch
+  }
+
+  object IndexingElasticSearchView {
+
+    /**
+      * Create the view index from the [[IndexingElasticSearchView]]
+      */
+    def resourceToViewIndex(
+        res: IndexingViewResource,
+        config: ElasticSearchViewsConfig
+    ): ViewIndex[IndexingElasticSearchView] =
+      ViewIndex(
+        res.value.project,
+        res.id,
+        res.value.uuid,
+        ElasticSearchViews.projectionId(res),
+        ElasticSearchViews.index(res, config.indexing),
+        res.rev,
+        res.deprecated,
+        res.value.resourceTag,
+        res.updatedAt,
+        res.value
+      )
   }
 
   /**

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchIndexingSpec.scala
@@ -186,7 +186,7 @@ class ElasticSearchIndexingSpec
   private val indexingStream = new ElasticSearchIndexingStream(esClient, indexingSource, cache, config, projection)
 
   private val (orgs, projs)             = ProjectSetup.init(org :: Nil, project1 :: project2 :: Nil).accepted
-  private val indexingCleanup           = new ElasticSearchIndexingCleanup(esClient, cache)
+  private val indexingCleanup           = new ElasticSearchIndexingCleanup(esClient, cache, projection)
   private val views: ElasticSearchViews = ElasticSearchViewsSetup.init(orgs, projs, permissions.query)
   private val controller                = new IndexingStreamController[IndexingElasticSearchView](ElasticSearchViews.moduleType)
   ElasticSearchIndexingCoordinator(views, controller, indexingStream, indexingCleanup, config).accepted

--- a/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsPluginModule.scala
+++ b/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsPluginModule.scala
@@ -69,8 +69,12 @@ class GraphAnalyticsPluginModule(priority: Int) extends ModuleDef {
   }
 
   make[GraphAnalyticsIndexingCleanup].from {
-    (client: ElasticSearchClient, cache: ProgressesCache @Id("graph-analytics-progresses")) =>
-      new GraphAnalyticsIndexingCleanup(client, cache)
+    (
+        client: ElasticSearchClient,
+        cache: ProgressesCache @Id("graph-analytics-progresses"),
+        projection: Projection[Unit]
+    ) =>
+      new GraphAnalyticsIndexingCleanup(client, cache, projection)
   }
 
   make[GraphAnalyticsIndexingCoordinator].fromEffect {

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginModule.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginModule.scala
@@ -120,10 +120,9 @@ class StoragePluginModule(priority: Int) extends ModuleDef {
   many[ResourcesDeletion].add {
     (
         agg: FilesAggregate,
-        storages: Storages,
         files: Files,
         dbCleanup: DatabaseCleanup
-    ) => FilesDeletion(agg, storages, files, dbCleanup)
+    ) => FilesDeletion(agg, files, dbCleanup)
   }
 
   make[StoragesRoutes].from {

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FilesDeletion.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FilesDeletion.scala
@@ -1,64 +1,21 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage.files
 
-import akka.persistence.query.NoOffset
-import ch.epfl.bluebrain.nexus.delta.kernel.Mapper
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.Files.FilesAggregate
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.FilesDeletion.logger
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.FileEvent
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.FileEvent._
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.Storages
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageRejection.StorageFetchRejection
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.{Storage, StorageType}
 import ch.epfl.bluebrain.nexus.delta.sdk.ResourcesDeletion.{CurrentEvents, ProjectScopedResourcesDeletion, StopActor}
-import ch.epfl.bluebrain.nexus.delta.sdk.model.Envelope
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourcesDeletionProgress.{CachesDeleted, ResourcesDataDeleted}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sourcing.DatabaseCleanup
-import com.typesafe.scalalogging.Logger
 import monix.bio.Task
 
-import java.io.File
-import scala.reflect.io.Directory
-
 final class FilesDeletion(
-    storages: Storages,
     stopActor: StopActor,
     currentEvents: CurrentEvents[FileEvent],
     dbCleanup: DatabaseCleanup
 ) extends ProjectScopedResourcesDeletion[FileEvent](stopActor, currentEvents, dbCleanup, Files.moduleType)(_.id) {
 
-  implicit private val mapper: Mapper[StorageFetchRejection, Throwable] =
-    rej => new IllegalArgumentException(rej.reason)
-
-  // TODO: So far we only delete files from ''DiskStorage''. To be implemented for S3Storages and RemoteDiskStorages
   override def freeResources(projectRef: ProjectRef): Task[ResourcesDataDeleted] =
-    currentEvents(projectRef, NoOffset).flatMap { stream =>
-      stream
-        .collect {
-          case Envelope(file: FileCreated, _, _, _, _, _) if file.storageType == StorageType.DiskStorage => file.storage
-          case Envelope(file: FileUpdated, _, _, _, _, _) if file.storageType == StorageType.DiskStorage => file.storage
-        }
-        .evalMap { ref =>
-          storages.fetch(ref, projectRef).map(_.value)
-        }
-        .collect { case Storage.DiskStorage(_, _, value, _, _) => value.volume }
-        .changes
-        .evalMap { volume =>
-          val directory = new Directory(new File(volume.value.toFile, projectRef.toString))
-          if (directory.exists) directory.deleteRecursively() else true
-
-          Task.when(directory.exists) {
-            Task.delay {
-              if (!directory.deleteRecursively()) {
-                logger.warn(s"Directory ${directory.path} could not be deleted")
-              }
-            }
-          }
-        }
-        .compile
-        .drain
-        .as(ResourcesDataDeleted)
-    }
+    Task.pure(ResourcesDataDeleted)
 
   override def deleteCaches(projectRef: ProjectRef): Task[CachesDeleted] =
     Task.pure(CachesDeleted)
@@ -67,16 +24,12 @@ final class FilesDeletion(
 
 object FilesDeletion {
 
-  private val logger: Logger = Logger[FilesDeletion.type]
-
   final def apply(
       agg: FilesAggregate,
-      storages: Storages,
       files: Files,
       dbCleanup: DatabaseCleanup
   ): FilesDeletion =
     new FilesDeletion(
-      storages,
       agg.stop,
       (project, offset) =>
         files.currentEvents(project, offset).mapError(rej => new IllegalArgumentException(rej.reason)),

--- a/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsDummy.scala
+++ b/delta/sdk-testkit/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsDummy.scala
@@ -23,7 +23,6 @@ import ch.epfl.bluebrain.nexus.testkit.{IORef, IOSemaphore}
 import monix.bio.{IO, Task, UIO}
 
 import java.util.UUID
-import scala.concurrent.duration.FiniteDuration
 
 final class ProjectsDummy private (
     journal: ProjectsJournal,
@@ -34,7 +33,7 @@ final class ProjectsDummy private (
     quotas: Quotas,
     scopeInitializations: Set[ScopeInitialization],
     override val defaultApiMappings: ApiMappings,
-    creationCooldown: ProjectRef => IO[FiniteDuration, Unit]
+    creationCooldown: ProjectRef => IO[ProjectCreationCooldown, Unit]
 )(implicit base: BaseUri, clock: Clock[UIO], uuidf: UUIDF)
     extends Projects {
 
@@ -202,14 +201,14 @@ object ProjectsDummy {
     * @param defaultApiMappings
     *   the default api mappings
     * @param creationCooldown
-    *   define if a cooldown must be observed before being able to (re)create a projecgt
+    *   define if a cooldown must be observed before being able to (re)create a project
     */
   def apply(
       organizations: Organizations,
       quotas: Quotas,
       scopeInitializations: Set[ScopeInitialization],
       defaultApiMappings: ApiMappings,
-      creationCooldown: ProjectRef => IO[FiniteDuration, Unit]
+      creationCooldown: ProjectRef => IO[ProjectCreationCooldown, Unit]
   )(implicit base: BaseUri, clock: Clock[UIO], uuidf: UUIDF): UIO[ProjectsDummy] =
     for {
       journal       <- Journal(moduleType, 1L, EventTags.forProjectScopedEvent[ProjectEvent](moduleType))

--- a/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsBehaviors.scala
+++ b/delta/sdk-testkit/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/testkit/ProjectsBehaviors.scala
@@ -35,7 +35,6 @@ import org.scalatest.{CancelAfterFailure, Inspectors, OptionValues}
 
 import java.time.Instant
 import java.util.UUID
-import scala.concurrent.duration._
 
 trait ProjectsBehaviors {
   this: AnyWordSpecLike
@@ -96,10 +95,10 @@ trait ProjectsBehaviors {
   // this project must observe a cooldown before being created
   val projCoolDown = Label.unsafe("projCoolDown")
 
-  val cooldown = 42.minutes
+  val cooldown = epoch.plusSeconds(42 * 60L)
 
-  def creationCooldown(proj: ProjectRef): IO[FiniteDuration, Unit] =
-    IO.raiseWhen(proj == ProjectRef(org1, projCoolDown))(cooldown)
+  def creationCooldown(proj: ProjectRef): IO[ProjectCreationCooldown, Unit] =
+    IO.raiseWhen(proj == ProjectRef(org1, projCoolDown))(ProjectCreationCooldown(proj, cooldown))
 
   private val order = ResourceF.defaultSort[Project]
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejection.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectRejection.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.model.projects
 
-import cats.Show
 import ch.epfl.bluebrain.nexus.delta.kernel.Mapper
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClassUtils
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClassUtils.simpleName
@@ -18,8 +17,8 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.processor.AggregateResponse.{Evalu
 import io.circe.syntax._
 import io.circe.{Encoder, JsonObject}
 
+import java.time.Instant
 import java.util.UUID
-import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
 /**
@@ -77,9 +76,9 @@ object ProjectRejection {
   /**
     * Signals that the current project is expected to be deleted but it isn't
     */
-  final case class ProjectCreationCooldown(projectRef: ProjectRef, end: FiniteDuration)
+  final case class ProjectCreationCooldown(projectRef: ProjectRef, end: Instant)
       extends ProjectRejection(
-        s"Project '$projectRef' has been deleted recently and can't be created again before ${Show[FiniteDuration].show(end)}."
+        s"Project '$projectRef' has been deleted recently and can't be created again before '$end'."
       )
 
   /**

--- a/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectsImpl.scala
+++ b/delta/service/src/main/scala/ch/epfl/bluebrain/nexus/delta/service/projects/ProjectsImpl.scala
@@ -30,7 +30,6 @@ import monix.bio.{IO, Task, UIO}
 import monix.execution.Scheduler
 
 import java.util.UUID
-import scala.concurrent.duration.FiniteDuration
 
 final class ProjectsImpl private (
     agg: ProjectsAggregate,
@@ -250,7 +249,7 @@ object ProjectsImpl {
       config: ProjectsConfig,
       organizations: Organizations,
       defaultApiMappings: ApiMappings,
-      creationCooldown: ProjectRef => IO[FiniteDuration, Unit]
+      creationCooldown: ProjectRef => IO[ProjectCreationCooldown, Unit]
   )(implicit as: ActorSystem[Nothing], clock: Clock[UIO], uuidF: UUIDF): UIO[ProjectsAggregate] = {
     val definition = PersistentEventDefinition(
       entityType = moduleType,

--- a/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/projects/CreationCooldownSpec.scala
+++ b/delta/service/src/test/scala/ch/epfl/bluebrain/nexus/delta/service/projects/CreationCooldownSpec.scala
@@ -7,6 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourcesDeletionProgress.Resourc
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourcesDeletionStatus
 import ch.epfl.bluebrain.nexus.delta.sdk.model.identities.Identity.Anonymous
 import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRef
+import ch.epfl.bluebrain.nexus.delta.sdk.model.projects.ProjectRejection.ProjectCreationCooldown
 import ch.epfl.bluebrain.nexus.delta.sourcing.EventLogConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.DatabaseFlavour
 import ch.epfl.bluebrain.nexus.testkit.IOValues
@@ -54,7 +55,7 @@ class CreationCooldownSpec extends AnyWordSpecLike with IOValues with Matchers {
     }
 
     "detect any problem if the ttl has not been observed" in {
-      CreationCooldown.validate(cache, eventLogConfigWithTtl)(ref1).rejected shouldEqual 150.seconds
+      CreationCooldown.validate(cache, eventLogConfigWithTtl)(ref1).rejectedWith[ProjectCreationCooldown]
     }
 
     "not detect any problem if the ttl has been observed" in {

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/InMemoryProjection.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/InMemoryProjection.scala
@@ -19,6 +19,9 @@ class InMemoryProjection[A](
 )(implicit clock: Clock[UIO])
     extends Projection[A] {
 
+  override def delete(id: ProjectionId): Task[Unit] =
+    Task.delay(success.remove(id)) >> Task.delay(errors.remove(id)).void
+
   override def recordProgress(id: ProjectionId, progress: ProjectionProgress[A]): Task[Unit] =
     Task.delay(success.update(id, progress))
 

--- a/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/Projection.scala
+++ b/delta/sourcing/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/Projection.scala
@@ -23,6 +23,13 @@ import scala.collection.concurrent.TrieMap
 trait Projection[A] {
 
   /**
+    * Delete the progress and the errors for the given projection
+    * @param id
+    *   the projection identifier
+    */
+  def delete(id: ProjectionId): Task[Unit]
+
+  /**
     * Records progress against a projection identifier.
     *
     * @param id

--- a/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/CassandraProjectionSpec.scala
+++ b/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/CassandraProjectionSpec.scala
@@ -9,11 +9,10 @@ import org.scalatest.DoNotDiscover
 @DoNotDiscover
 class CassandraProjectionSpec extends ProjectionSpec {
 
-  import monix.execution.Scheduler.Implicits.global
   implicit val actorSystem: ActorSystem[Nothing] = AkkaPersistenceCassandraSpec.actorSystem
 
   override lazy val projections: Projection[SomeEvent] =
-    Projection.cassandra(cassandraConfig, SomeEvent.empty, throwableToString).runSyncUnsafe()
+    Projection.cassandra(cassandraConfig, SomeEvent.empty, throwableToString).accepted
 
   override def generateOffset: Offset = TimeBasedUUID(Uuids.timeBased())
 }

--- a/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/InMemoryProjectionSpec.scala
+++ b/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/InMemoryProjectionSpec.scala
@@ -6,10 +6,8 @@ import scala.util.Random
 
 class InMemoryProjectionSpec extends ProjectionSpec {
 
-  import monix.execution.Scheduler.Implicits.global
-
   override val projections: Projection[SomeEvent] =
-    Projection.inMemory(SomeEvent.empty, throwableToString).runSyncUnsafe()
+    Projection.inMemory(SomeEvent.empty, throwableToString).accepted
 
   override def generateOffset: Offset = Sequence(Random.nextLong())
 }

--- a/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/PostgresProjectionSpec.scala
+++ b/delta/sourcing/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/PostgresProjectionSpec.scala
@@ -9,10 +9,8 @@ import scala.util.Random
 @DoNotDiscover
 class PostgresProjectionSpec extends ProjectionSpec {
 
-  import monix.execution.Scheduler.Implicits.global
-
   override lazy val projections: Projection[SomeEvent] =
-    Projection.postgres(PostgresSpecs.postgresConfig, SomeEvent.empty, throwableToString).runSyncUnsafe()
+    Projection.postgres(PostgresSpecs.postgresConfig, SomeEvent.empty, throwableToString).accepted
 
   override def generateOffset: Offset = Sequence(Random.nextLong())
 }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ListingsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ListingsSpec.scala
@@ -113,7 +113,7 @@ final class ListingsSpec extends BaseSpec with Inspectors with EitherValuable wi
       }
     }
 
-    "get responses using after" in {
+    "get responses using after" in eventually {
       // Building the next results, replace the public url by the one used by the tests
       def next(json: Json) = {
         listing._next.getOption(json).map { url =>


### PR DESCRIPTION
Fixes #2840 

* Deleting views is now synchronous as project could be deleted before them and it resulted in an error
* Implement projection deletion and add it to clean up so when a view is created again, it starts from the beginning
* Physical file deletion is now handled in `StorageDeletion`
* ProjectCreationCooldown now return an `Instant` and not a `Duration`
