### PR TITLE
Bumped dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,50 +12,50 @@ scalafmt: {
 }
  */
 
-val scalacScapegoatVersion = "1.4.8"
-val scalaCompilerVersion   = "2.13.5"
+val scalacScapegoatVersion = "1.4.10"
+val scalaCompilerVersion   = "2.13.6"
 
-val akkaHttpVersion                 = "10.2.4"
-val akkaHttpCirceVersion            = "1.36.0"
-val akkaCorsVersion                 = "1.1.1"
+val akkaHttpVersion                 = "10.2.6"
+val akkaHttpCirceVersion            = "1.38.2"
+val akkaCorsVersion                 = "1.1.2"
 val akkaPersistenceCassandraVersion = "1.0.5"
-val akkaPersistenceJdbcVersion      = "5.0.0"
-val akkaVersion                     = "2.6.14"
-val alpakkaVersion                  = "2.0.2"
-val apacheCompressVersion           = "1.20"
-val awsSdkVersion                   = "2.16.44"
+val akkaPersistenceJdbcVersion      = "5.0.4"
+val akkaVersion                     = "2.6.17"
+val alpakkaVersion                  = "3.0.3"
+val apacheCompressVersion           = "1.21"
+val awsSdkVersion                   = "2.17.71"
 val byteBuddyAgentVersion           = "1.10.17"
 val betterMonadicForVersion         = "0.3.1"
-val caffeineVersion                 = "3.0.1"
-val catsEffectVersion               = "2.5.0"
-val catsRetryVersion                = "2.1.0"
-val catsVersion                     = "2.6.0"
-val circeVersion                    = "0.13.0"
-val classgraphVersion               = "4.8.104"
-val distageVersion                  = "1.0.3"  // 1.0.5 conflicts with pureconfig 0.15.0
+val caffeineVersion                 = "3.0.4"
+val catsEffectVersion               = "2.5.4"
+val catsRetryVersion                = "2.1.1"
+val catsVersion                     = "2.6.1"
+val circeVersion                    = "0.14.1"
+val classgraphVersion               = "4.8.129"
+val distageVersion                  = "1.0.8"
 val dockerTestKitVersion            = "0.9.9"
-val doobieVersion                   = "0.10.0"
-val fs2Version                      = "2.5.4"
+val doobieVersion                   = "0.13.4"
+val fs2Version                      = "2.5.10"
 val h2Version                       = "1.4.200"
-val jenaVersion                     = "3.17.0"
+val jenaVersion                     = "4.2.0"
 val jsonldjavaVersion               = "0.13.3"
-val kamonVersion                    = "2.1.16"
-val kanelaAgentVersion              = "1.0.9"
-val kindProjectorVersion            = "0.11.3"
-val kryoVersion                     = "2.1.0"
-val logbackVersion                  = "1.2.3"
+val kamonVersion                    = "2.3.1"
+val kanelaAgentVersion              = "1.0.13"
+val kindProjectorVersion            = "0.13.2"
+val kryoVersion                     = "2.3.0"
+val logbackVersion                  = "1.2.6"
 val magnoliaVersion                 = "0.17.0"
-val mockitoVersion                  = "1.16.37"
-val monixVersion                    = "3.3.0"
-val monixBioVersion                 = "1.1.0"
-val nimbusJoseJwtVersion            = "9.8.1"
-val pureconfigVersion               = "0.14.0" // 0.15.0 conflicts with distage 1.0.5
-val scalaLoggingVersion             = "3.9.3"
-val scalateVersion                  = "1.9.6"
-val scalaTestVersion                = "3.2.9"
+val mockitoVersion                  = "1.16.46"
+val monixVersion                    = "3.4.0"
+val monixBioVersion                 = "1.2.0"
+val nimbusJoseJwtVersion            = "9.15.2"
+val pureconfigVersion               = "0.17.0"
+val scalaLoggingVersion             = "3.9.4"
+val scalateVersion                  = "1.9.6" // scala-parser-combinators_2.13:2.0.0 ... is selected over 1.1.2
+val scalaTestVersion                = "3.2.10"
 val slickVersion                    = "3.3.3"
 val streamzVersion                  = "0.12"
-val topBraidVersion                 = "1.3.2"
+val topBraidVersion                 = "1.3.2" // 1.4.1 fails to validate some test schemas
 val uuidGeneratorVersion            = "4.0.1"
 
 lazy val akkaActorTyped           = "com.typesafe.akka" %% "akka-actor-typed"            % akkaVersion
@@ -925,7 +925,7 @@ lazy val kamonSettings = Seq(
   libraryDependencies ++= Seq(
     kamonAkkaHttp,
     "io.kamon" %% "kamon-akka"           % kamonVersion,
-    // "io.kamon" %% "kamon-cassandra"      % kamonVersion, // does not support v4.x of the cassandra driver
+    "io.kamon" %% "kamon-cassandra"      % kamonVersion,
     "io.kamon" %% "kamon-core"           % kamonVersion,
     "io.kamon" %% "kamon-executors"      % kamonVersion,
     "io.kamon" %% "kamon-jaeger"         % kamonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -947,6 +947,7 @@ lazy val storageAssemblySettings = Seq(
     case PathList("org", "apache", "commons", "codec", xs @ _*)          => MergeStrategy.last
     case PathList("akka", "remote", "kamon", xs @ _*)                    => MergeStrategy.last
     case PathList("kamon", "instrumentation", "akka", "remote", xs @ _*) => MergeStrategy.last
+    case PathList("javax", "annotation", xs @ _*)                        => MergeStrategy.first
     case x if x.endsWith("module-info.class")                            => MergeStrategy.discard
     case x                                                               =>
       val oldStrategy = (assembly / assemblyMergeStrategy).value

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeView.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeView.scala
@@ -74,7 +74,7 @@ object CompositeView {
     */
   final case class Interval private[model] (value: FiniteDuration) extends RebuildStrategy
   object Interval {
-    def apply(value: FiniteDuration)(implicit config: CompositeViewsConfig): Option[Interval] =
+    def apply(value: FiniteDuration, config: CompositeViewsConfig): Option[Interval] =
       Option.when(value gteq config.minIntervalRebuild)(new Interval(value))
   }
 
@@ -82,7 +82,7 @@ object CompositeView {
 
   object RebuildStrategy {
     @nowarn("cat=unused")
-    implicit final val rebuildStrategyEncoder: Encoder[RebuildStrategy] = {
+    implicit final val rebuildStrategyEncoder: Encoder.AsObject[RebuildStrategy] = {
       implicit val config: Configuration                          = Configuration.default.withDiscriminator(keywords.tpe)
       implicit val finiteDurationEncoder: Encoder[FiniteDuration] = Encoder.encodeString.contramap(_.toString())
       deriveConfiguredEncoder[RebuildStrategy]

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectsConfig.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/projects/ProjectsConfig.scala
@@ -15,8 +15,6 @@ import pureconfig.configurable._
 import pureconfig.error.CannotConvert
 import pureconfig.generic.semiauto._
 
-import scala.annotation.nowarn
-
 /**
   * Configuration for the Projects module.
   *
@@ -47,7 +45,7 @@ final case class ProjectsConfig(
     quotas: QuotasConfig,
     denyProjectPruning: Boolean
 ) {
-  def allowProjectPruning = !denyProjectPruning
+  def allowProjectPruning: Boolean = !denyProjectPruning
 }
 
 object ProjectsConfig {
@@ -83,26 +81,21 @@ object ProjectsConfig {
 
   }
 
-  @nowarn("cat=unused")
   implicit private val permissionConfigReader: ConfigReader[Permission] =
     ConfigReader.fromString(str =>
       Permission(str).leftMap(err => CannotConvert(str, classOf[Permission].getSimpleName, err.getMessage))
     )
 
-  @nowarn("cat=unused")
   implicit private val iriConfigReader: ConfigReader[Iri] =
     ConfigReader.fromString(str => Iri(str).leftMap(err => CannotConvert(str, classOf[Iri].getSimpleName, err)))
 
-  @nowarn("cat=unused")
   implicit private val labelConfigReader: ConfigReader[Label] = ConfigReader.fromString(str =>
     Label(str).leftMap(e => CannotConvert(str, classOf[Label].getSimpleName, e.getMessage))
   )
 
-  @nowarn("cat=unused")
   implicit private val mapReader: ConfigReader[Map[Label, Label]] =
     genericMapReader(str => Label(str).leftMap(e => CannotConvert(str, classOf[Label].getSimpleName, e.getMessage)))
 
-  @nowarn("cat=unused")
   implicit private val prefixIriReader: ConfigReader[PrefixIri] = ConfigReader.fromString { str =>
     (for {
       iri       <- Iri(str)
@@ -110,7 +103,6 @@ object ProjectsConfig {
     } yield prefixIri).leftMap(e => CannotConvert(str, classOf[PrefixIri].getSimpleName, e))
   }
 
-  @nowarn("cat=unused")
   implicit private val apiMappingsReader: ConfigReader[ApiMappings] = ConfigReader[Map[String, Iri]].map(ApiMappings(_))
 
   implicit val provisioningConfigReader: ConfigReader[AutomaticProvisioningConfig] = ConfigReader.fromCursor { cursor =>

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/DockerSupport.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/DockerSupport.scala
@@ -1,6 +1,9 @@
 package ch.epfl.bluebrain.nexus.testkit
 
-import com.whisk.docker.impl.dockerjava.DockerKitDockerJava
+import com.github.dockerjava.core.DefaultDockerClientConfig
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory
+import com.whisk.docker.DockerFactory
+import com.whisk.docker.impl.dockerjava.{Docker => JDocker, DockerJavaExecutorFactory, DockerKitDockerJava}
 
 import scala.concurrent.duration._
 
@@ -10,6 +13,13 @@ object DockerSupport {
     override val PullImagesTimeout: FiniteDuration      = 20.minutes
     override val StartContainersTimeout: FiniteDuration = 2.minutes
     override val StopContainersTimeout: FiniteDuration  = 1.minute
+
+    implicit override val dockerFactory: DockerFactory = new DockerJavaExecutorFactory(
+      new JDocker(
+        DefaultDockerClientConfig.createDefaultConfigBuilder().build(),
+        new NettyDockerCmdExecFactory()
+      )
+    )
   }
 
 }

--- a/tests/src/main/scala/ch/epfl/bluebrain/nexus/tests/config/ConfigLoader.scala
+++ b/tests/src/main/scala/ch/epfl/bluebrain/nexus/tests/config/ConfigLoader.scala
@@ -3,8 +3,8 @@ package ch.epfl.bluebrain.nexus.tests.config
 import akka.http.scaladsl.model.Uri
 import com.typesafe.config.Config
 import pureconfig.ConvertHelpers.catchReadError
-import pureconfig.{ConfigConvert, ConfigReader, ConfigSource, Derivation, Exported}
 import pureconfig.generic.ExportMacros
+import pureconfig.{ConfigConvert, ConfigReader, ConfigSource, Exported}
 
 import scala.reflect.ClassTag
 
@@ -15,7 +15,7 @@ trait ConfigLoader {
   implicit val uriConverter: ConfigConvert[Uri] =
     ConfigConvert.viaString[Uri](catchReadError(s => Uri(s)), _.toString)
 
-  def load[A: ClassTag](config: Config, namespace: String)(implicit reader: Derivation[ConfigReader[A]]): A =
+  def load[A: ClassTag](config: Config, namespace: String)(implicit reader: ConfigReader[A]): A =
     ConfigSource.fromConfig(config).at(namespace).loadOrThrow[A]
 
 }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/HttpClient.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/HttpClient.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.Multipart.FormData
 import akka.http.scaladsl.model.Multipart.FormData.BodyPart
 import akka.http.scaladsl.model.headers.{`Accept-Encoding`, Accept, Authorization, HttpEncodings}
-import akka.http.scaladsl.model.{HttpResponse, _}
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.stream.Materializer
@@ -29,7 +29,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class HttpClient private (baseUrl: Uri, httpExt: HttpExt)(implicit materializer: Materializer)
+class HttpClient private (baseUrl: Uri, httpExt: HttpExt)(implicit as: ActorSystem, materializer: Materializer)
     extends Matchers
     with AppendedClues {
 
@@ -318,5 +318,5 @@ object HttpClient {
   val gzipHeaders: Seq[HttpHeader] = Seq(Accept(MediaRanges.`*/*`), `Accept-Encoding`(HttpEncodings.gzip))
 
   def apply(baseUrl: Uri)(implicit as: ActorSystem, materializer: Materializer) =
-    new HttpClient(baseUrl, Http())(materializer)
+    new HttpClient(baseUrl, Http())
 }


### PR DESCRIPTION
Notable changes:

- Bump scala to 2.13.6
- Add kamon-cassandra which now supports 4.x driver version
- Revert docker-java to make use of netty for transport