### PR TITLE
Update one_cell_minds.ipynb

### DIFF
--- a/docs/src/main/paradox/docs/getting-started/notebooks/one_cell_minds.ipynb
+++ b/docs/src/main/paradox/docs/getting-started/notebooks/one_cell_minds.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nexusforge==0.6.2"
+    "!pip install nexusforge==0.7.0"
    ]
   },
   {


### PR DESCRIPTION
Set Nexus Forge version to 0.7.0 to prevent rdflib error.

Fiixes https://github.com/BlueBrain/MOOC-neurons-and-synapses-2017/issues/91