### PR TITLE
Command `jupyter-notebook` not found

### DIFF
--- a/docs/src/main/paradox/docs/getting-started/try-nexus.md
+++ b/docs/src/main/paradox/docs/getting-started/try-nexus.md
@@ -79,7 +79,7 @@ pip install git+https://github.com/BlueBrain/nexus-forge.git@<branch-name>
 To avoid any issues, install @link:[Jupyter](https://jupyter.org/){ open=new } in your environment.
 
 ```bash
-pip install jupyterlab
+pip install jupyter
 ```
 
 You will need the @link:[Allen SDK](https://allensdk.readthedocs.io/en/latest/index.html){ open=new } to get data from their database.


### PR DESCRIPTION
Solve
```Jupyter command `jupyter-notebook` not found```
by replacing ```pip install jupyterlab``` with ```pip install jupyterlab```.