### PR TITLE
Update paradox plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"       % "0.11.0")
 
 addSbtPlugin("com.typesafe.sbt"      % "sbt-site"                   % "1.4.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"                % "0.10.3")
-addSbtPlugin("io.github.jonas"       % "sbt-paradox-material-theme" % "0.5.1")
+addSbtPlugin("io.github.jonas"       % "sbt-paradox-material-theme" % "0.6.0")
 
 addSbtPlugin("com.dwijnand"   % "sbt-dynver"          % "4.1.1")
 addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"        % "1.2.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"       % "0.11.0")
 
 addSbtPlugin("com.typesafe.sbt"      % "sbt-site"                   % "1.4.1")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"                % "0.9.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"                % "0.10.3")
 addSbtPlugin("io.github.jonas"       % "sbt-paradox-material-theme" % "0.5.1")
 
 addSbtPlugin("com.dwijnand"   % "sbt-dynver"          % "4.1.1")


### PR DESCRIPTION
* Updating `sbt-paradox` to 0.10.3 allows to run paradox using JDK version >17. (tested with both 17 and 19).
* Updating `sbt-paradox-material-theme` to 0.6.0.