### PR TITLE
Build transactors from a `HikariDataSource`

### DIFF
--- a/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/database/Transactors.scala
+++ b/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/database/Transactors.scala
@@ -70,7 +70,7 @@ object Transactors {
           ds.setUsername(config.username)
           ds.setPassword(config.password.value)
           ds.setDriverClassName("org.postgresql.Driver")
-          ds.setMaximumPoolSize(15)
+          ds.setMaximumPoolSize(access.poolSize)
           ds.setAutoCommit(false)
           ds.setReadOnly(readOnly)
           ds

--- a/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/database/Transactors.scala
+++ b/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/database/Transactors.scala
@@ -76,7 +76,7 @@ object Transactors {
 
     def transactor(access: DatabaseAccess, readOnly: Boolean) = {
       for {
-        ce      <- ExecutionContexts.fixedThreadPool[Task](access.poolSize) // our connect EC
+        ce      <- ExecutionContexts.fixedThreadPool[Task](access.poolSize)
         blocker <- Blocker[Task]
         cfg     <- hikariConfig(access, readOnly)
         xa      <- HikariTransactor.fromHikariConfig[Task](

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/ProjectionStore.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/ProjectionStore.scala
@@ -134,7 +134,7 @@ object ProjectionStore {
                |  failed = EXCLUDED.failed,
                |  updated_at = EXCLUDED.updated_at;
                |""".stripMargin.update.run
-            .transact(xas.streaming)
+            .transact(xas.write)
             .void
             .hideErrors
         }
@@ -146,14 +146,14 @@ object ProjectionStore {
           .query[ProjectionProgressRow]
           .map(_.progress)
           .option
-          .transact(xas.streaming)
+          .transact(xas.read)
           .hideErrors
 
       override def delete(name: String): UIO[Unit] =
         sql"""DELETE FROM projection_offsets
              |WHERE name = $name;
              |""".stripMargin.update.run
-          .transact(xas.streaming)
+          .transact(xas.write)
           .void
           .hideErrors
 
@@ -161,7 +161,7 @@ object ProjectionStore {
         sql"""SELECT * from projection_offsets;"""
           .query[ProjectionProgressRow]
           .streamWithChunkSize(config.batchSize)
-          .transact(xas.streaming)
+          .transact(xas.read)
 
       override def failedElemEntries(
           projectionProject: ProjectRef,
@@ -175,7 +175,7 @@ object ProjectionStore {
              |ORDER BY ordering ASC""".stripMargin
           .query[FailedElemLogRow]
           .streamWithChunkSize(config.batchSize)
-          .transact(xas.streaming)
+          .transact(xas.read)
 
       override def failedElemEntries(
           projectionName: String,
@@ -187,7 +187,7 @@ object ProjectionStore {
              |ORDER BY ordering ASC""".stripMargin
           .query[FailedElemLogRow]
           .streamWithChunkSize(config.batchSize)
-          .transact(xas.streaming)
+          .transact(xas.read)
 
       override def saveFailedElems(
           metadata: ProjectionMetadata,


### PR DESCRIPTION
* Set `autoCommit` to false (cf. https://github.com/tpolecat/doobie/issues/1244) (not configurable from `app.conf`)
* Set `readOnly` to true for read and streaming pools (not configurable from `app.conf`)
* Set `maximumPoolSize` from app config
* Update the pools used by the ProjectionStore