### PR TITLE
Add lz4 dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -336,7 +336,8 @@ lazy val migration = project
   .settings(
     libraryDependencies ++= Seq(
       circeOptics,
-      "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % "4.0.0"
+      "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % "4.0.0",
+      "org.lz4" % "lz4-java" % "1.4.1"
     )
   )
 


### PR DESCRIPTION
The lz4 library is used in the migration by setting
```
-Ddatastax-java-driver.advanced.protocol.compression=lz4
```