### PR TITLE
Add default invalid route

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutes.scala
@@ -1,0 +1,33 @@
+package ch.epfl.bluebrain.nexus.delta.routes
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
+import ch.epfl.bluebrain.nexus.delta.sdk.directives.DeltaDirectives.{baseUriPrefix, emit}
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
+import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
+import monix.bio.IO
+import monix.execution.Scheduler
+
+/**
+  * Route to show errors
+  */
+final class ErrorRoutes()(implicit
+    baseUri: BaseUri,
+    s: Scheduler,
+    cr: RemoteContextResolution,
+    ordering: JsonKeyOrdering
+) {
+
+  def routes: Route =
+    baseUriPrefix(baseUri.prefix) {
+      pathPrefix("errors") {
+        pathPrefix("invalid") {
+          (get & pathEndOrSingleSlash) {
+            emit(IO.pure(AuthorizationFailed))
+          }
+        }
+      }
+    }
+}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutesSpec.scala
@@ -1,0 +1,20 @@
+package ch.epfl.bluebrain.nexus.delta.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import ch.epfl.bluebrain.nexus.delta.sdk.utils.BaseRouteSpec
+
+class ErrorRoutesSpec extends BaseRouteSpec {
+
+  private lazy val routes = Route.seal(new ErrorRoutes().routes)
+
+  "The error route" should {
+    "return the expected error when fetching the invalid error" in {
+      Get("/v1/errors/invalid") ~> routes ~> check {
+        response.status shouldEqual StatusCodes.Forbidden
+        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+      }
+    }
+  }
+
+}

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ErrorsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ErrorsSpec.scala
@@ -1,0 +1,20 @@
+package ch.epfl.bluebrain.nexus.tests.kg
+
+import akka.http.scaladsl.model.StatusCodes
+import ch.epfl.bluebrain.nexus.testkit.EitherValuable
+import ch.epfl.bluebrain.nexus.tests.{BaseSpec, Identity}
+import io.circe.Json
+import monix.execution.Scheduler.Implicits.global
+
+class ErrorsSpec extends BaseSpec with EitherValuable {
+
+  "The /errors/invalid endpoint" should {
+    s"return the proper error code" in {
+      deltaClient.get[Json]("/errors/invalid", Identity.Anonymous) { (json, response) =>
+        response.status shouldEqual StatusCodes.Forbidden
+        json shouldEqual jsonContentOf("/iam/errors/unauthorized-access.json")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #3536

`/errors/invalid` now returns a static answer with the invalid resource message