### PR TITLE
Handle `InvalidState` during migration

### DIFF
--- a/delta/migration/src/test/resources/events/org-created-2.json
+++ b/delta/migration/src/test/resources/events/org-created-2.json
@@ -1,0 +1,13 @@
+{
+  "label": "myorg",
+  "uuid": "b6bde92f-7836-4da6-8ead-2e0fd516ebe7",
+  "rev": 2,
+  "description": "some description",
+  "instant": "1970-01-01T00:00:00Z",
+  "subject": {
+    "subject": "username",
+    "realm": "myrealm",
+    "@type": "User"
+  },
+  "@type": "OrganizationCreated"
+}

--- a/delta/migration/src/test/resources/events/org-created.json
+++ b/delta/migration/src/test/resources/events/org-created.json
@@ -1,0 +1,13 @@
+{
+  "label": "myorg",
+  "uuid": "b6bde92f-7836-4da6-8ead-2e0fd516ebe7",
+  "rev": 1,
+  "description": "some description",
+  "instant": "1970-01-01T00:00:00Z",
+  "subject": {
+    "subject": "username",
+    "realm": "myrealm",
+    "@type": "User"
+  },
+  "@type": "OrganizationCreated"
+}

--- a/delta/migration/src/test/resources/events/resolver-created-2.json
+++ b/delta/migration/src/test/resources/events/resolver-created-2.json
@@ -1,0 +1,21 @@
+{
+  "@type": "ResolverCreated",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
+  "instant": "1970-01-01T00:00:00Z",
+  "project": "myorg/myproj",
+  "rev": 2,
+  "source": {
+    "resolver": "created"
+  },
+  "subject": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
+  },
+  "value": {
+    "@type": "InProjectValue",
+    "name": "resolverName",
+    "description": "resolverDescription",
+    "priority": 42
+  }
+}

--- a/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationLogSuite.scala
+++ b/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationLogSuite.scala
@@ -1,21 +1,40 @@
 package ch.epfl.bluebrain.nexus.migration
 
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.Defaults
+import ch.epfl.bluebrain.nexus.delta.sdk.migration.MigrationLog.IgnoredInvalidState
+import ch.epfl.bluebrain.nexus.delta.sdk.migration.{MigrationLog, ToMigrateEvent}
+import ch.epfl.bluebrain.nexus.delta.sdk.organizations.Organizations
+import ch.epfl.bluebrain.nexus.delta.sdk.organizations.model._
+import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.Resolvers
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.model.ResolverEvent._
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.model.ResolverValue.InProjectValue
-import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.model.{Priority, ResolverType}
+import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.model._
+import ch.epfl.bluebrain.nexus.delta.sourcing.EvaluationError.InvalidState
+import ch.epfl.bluebrain.nexus.delta.sourcing.config.{EventLogConfig, QueryConfig}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.User
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef}
+import ch.epfl.bluebrain.nexus.delta.sourcing.query.RefreshStrategy
 import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
+import ch.epfl.bluebrain.nexus.testkit.postgres.Doobie
+import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
 import io.circe.Json
+import monix.bio.IO
+import monix.bio.IO.clock
+import munit.AnyFixture
 
 import java.time.Instant
+import java.util.UUID
+import scala.concurrent.duration.DurationInt
 
-class MigrationLogSuite extends BioSuite {
+class MigrationLogSuite extends BioSuite with Doobie.Fixture with TestHelpers with IOValues {
+
+  override def munitFixtures: Seq[AnyFixture[_]] = List(doobie)
+  private lazy val xas                           = doobie()
 
   private val instant = Instant.EPOCH
   private val realm   = Label.unsafe("myrealm")
@@ -116,6 +135,63 @@ class MigrationLogSuite extends BioSuite {
       subject
     )
     assertEquals(injectedEvent, expectedCreatedEvent)
+  }
+
+  private val uuid        = UUID.randomUUID()
+  private val orgPayload  = jsonContentOf("events/org-created.json")
+  private val orgPayload2 = jsonContentOf("events/org-created-2.json")
+  private val orgEvent    = ToMigrateEvent(Organizations.entityType, "id", 1L, orgPayload, Instant.EPOCH, uuid)
+  private val orgEvent2   = orgEvent.copy(payload = orgPayload2)
+
+  private lazy val orgMigrationLog =
+    MigrationLog.global[Label, OrganizationState, OrganizationCommand, OrganizationEvent, OrganizationRejection](
+      Organizations.definition(clock, UUIDF.fixed(uuid)),
+      e => e.label,
+      identity,
+      (e, _) => e,
+      EventLogConfig(QueryConfig(5, RefreshStrategy.Stop), 10.seconds),
+      xas
+    )
+
+  test("Migrating a OrgCreated event") {
+    orgMigrationLog(orgEvent).accepted
+  }
+
+  test("Migrating the same Org event again results in IgnoredInvalidState") {
+    orgMigrationLog(orgEvent).rejectedWith[IgnoredInvalidState]
+  }
+
+  test("Trying to create an org with preexisting state fails with InvalidState") {
+    orgMigrationLog(orgEvent2).rejectedWith[InvalidState[_, _]]
+  }
+
+  private lazy val resolverMigrationLog =
+    MigrationLog.scoped[Iri, ResolverState, ResolverCommand, ResolverEvent, ResolverRejection](
+      Resolvers.definition((_, _, _) =>
+        IO.terminate(new IllegalStateException("Resolver command evaluation should not happen"))
+      )(clock),
+      e => e.id,
+      identity,
+      (e, _) => e,
+      EventLogConfig(QueryConfig(5, RefreshStrategy.Stop), 10.seconds),
+      xas
+    )
+
+  private val resolverPayload  = jsonContentOf("events/resolver-created.json")
+  private val resolverPayload2 = jsonContentOf("events/resolver-created-2.json")
+  private val resolverEvent    = ToMigrateEvent(Resolvers.entityType, "id", 1L, resolverPayload, Instant.EPOCH, uuid)
+  private val resolverEvent2   = resolverEvent.copy(payload = resolverPayload2)
+
+  test("Migrating a ResolverCreated event") {
+    resolverMigrationLog(resolverEvent).accepted
+  }
+
+  test("Migrating the same Resolver event again results in IgnoredInvalidState") {
+    resolverMigrationLog(resolverEvent).rejectedWith[IgnoredInvalidState]
+  }
+
+  test("Trying to create a resolver with preexisting state fails with InvalidState") {
+    resolverMigrationLog(resolverEvent2).rejectedWith[InvalidState[_, _]]
   }
 
 }

--- a/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationSuite.scala
+++ b/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationSuite.scala
@@ -4,13 +4,13 @@ import ch.epfl.bluebrain.nexus.delta.sdk.acls.Acls
 import ch.epfl.bluebrain.nexus.delta.sdk.migration.ToMigrateEvent
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.Projects
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.Resolvers
-import ch.epfl.bluebrain.nexus.testkit.TestHelpers
 import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
+import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
 
 import java.time.Instant
 import java.util.UUID
 
-class MigrationSuite extends BioSuite with TestHelpers {
+class MigrationSuite extends BioSuite with TestHelpers with IOValues {
 
   private val projectsToIgnore = Set("dummy", "myorg/test")
   private val uuid             = UUID.randomUUID()
@@ -49,6 +49,12 @@ class MigrationSuite extends BioSuite with TestHelpers {
     val payload = jsonContentOf("events/project-created-blacklist.json")
     val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
     assert(Migration.toIgnore(event, projectsToIgnore))
+  }
+
+  test("Reject with NoSuchElementException when a MigrationLog is missing") {
+    val payload = jsonContentOf("events/project-created-blacklist.json")
+    val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
+    Migration.processEvent(Set.empty)(event).rejectedWith[NoSuchElementException]
   }
 
 }

--- a/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationSuite.scala
+++ b/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationSuite.scala
@@ -1,16 +1,22 @@
 package ch.epfl.bluebrain.nexus.migration
 
-import ch.epfl.bluebrain.nexus.delta.sdk.acls.Acls
-import ch.epfl.bluebrain.nexus.delta.sdk.migration.ToMigrateEvent
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.{AclAddress, AclState}
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.{AclFixtures, Acls}
+import ch.epfl.bluebrain.nexus.delta.sdk.migration.MigrationLog.IgnoredInvalidState
+import ch.epfl.bluebrain.nexus.delta.sdk.migration.{MigrationLog, ToMigrateEvent}
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.Projects
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.Resolvers
+import ch.epfl.bluebrain.nexus.delta.sourcing.EvaluationError.InvalidState
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.EntityType
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Anonymous
 import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
 import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
+import monix.bio.Task
 
 import java.time.Instant
 import java.util.UUID
 
-class MigrationSuite extends BioSuite with TestHelpers with IOValues {
+class MigrationSuite extends BioSuite with TestHelpers with IOValues with AclFixtures {
 
   private val projectsToIgnore = Set("dummy", "myorg/test")
   private val uuid             = UUID.randomUUID()
@@ -41,20 +47,46 @@ class MigrationSuite extends BioSuite with TestHelpers with IOValues {
 
   test("A project event that is not in a blacklisted project should not be ignored") {
     val payload = jsonContentOf("events/project-created.json")
-    val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
+    val event   = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
     assert(!Migration.toIgnore(event, projectsToIgnore))
   }
 
   test("A ProjectEvent that is in a blacklisted project should be ignored") {
     val payload = jsonContentOf("events/project-created-blacklist.json")
-    val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
+    val event   = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
     assert(Migration.toIgnore(event, projectsToIgnore))
   }
 
   test("Reject with NoSuchElementException when a MigrationLog is missing") {
     val payload = jsonContentOf("events/project-created-blacklist.json")
-    val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
+    val event   = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
     Migration.processEvent(Set.empty)(event).rejectedWith[NoSuchElementException]
+  }
+
+  private val aclPayload             = jsonContentOf("events/acl-appended.json")
+  private val aclEvent               = ToMigrateEvent(Acls.entityType, "id", 1L, aclPayload, Instant.EPOCH, uuid)
+  private val aclAddress: AclAddress = AclAddress.Root
+  private val acl                    = anonR(aclAddress)
+  private val aclState               = AclState(acl, 1, Instant.EPOCH, Anonymous, Instant.EPOCH, Anonymous)
+
+  test("An IgnoredInvalidState should not be rejected") {
+    val ml = new MigrationLog {
+      override def entityType: EntityType = Acls.entityType
+
+      override def apply(event: ToMigrateEvent): Task[Unit] =
+        Task.raiseError(IgnoredInvalidState("error message"))
+    }
+    Migration.processEvent(Set(ml))(aclEvent).accepted
+  }
+
+  test("An invalid state should be rejected") {
+    val ml = new MigrationLog {
+      override def entityType: EntityType = Acls.entityType
+
+      override def apply(event: ToMigrateEvent): Task[Unit] =
+        Task.raiseError(InvalidState(Some(aclState), event))
+    }
+    Migration.processEvent(Set(ml))(aclEvent).rejected
   }
 
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/migration/MigrationLog.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/migration/MigrationLog.scala
@@ -54,8 +54,9 @@ object MigrationLog {
           original <- stateStore.get(extractId(event))
           enriched  = enrich(event, original)
           newState <- IO.fromOption(stateMachine.next(original, enriched), InvalidState(original, enriched))
-                        .mapErrorPartial {
+                        .mapError {
                           case err @ InvalidState(Some(s), e) if s.rev == e.rev => IgnoredInvalidState(err.getMessage)
+                          case err                                              => err
                         }
           result   <- (eventStore.save(enriched) >> stateStore.save(newState))
                         .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
@@ -147,8 +148,9 @@ object MigrationLog {
           original <- stateStore.get(event.project, extractId(event)).redeem(_ => None, Some(_))
           enriched  = enrich(event, original)
           newState <- IO.fromOption(stateMachine.next(original, enriched), InvalidState(original, enriched))
-                        .mapErrorPartial {
+                        .mapError {
                           case err @ InvalidState(Some(s), e) if s.rev == e.rev => IgnoredInvalidState(err.getMessage)
+                          case err                                              => err
                         }
           result   <- persist(enriched, original, newState)
           _        <- result.fold(


### PR DESCRIPTION
* `InvalidState` errors where the original state and event revision match are ignored.
* Other `InvalidState` cases still block the migration