### PR TITLE
Handle invalid state occurences during migration

### DIFF
--- a/delta/migration/src/main/scala/ch/epfl/bluebrain/nexus/migration/Migration.scala
+++ b/delta/migration/src/main/scala/ch/epfl/bluebrain/nexus/migration/Migration.scala
@@ -8,12 +8,13 @@ import ch.epfl.bluebrain.nexus.delta.kernel.database.Transactors
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.Acls
 import ch.epfl.bluebrain.nexus.delta.sdk.migration.{MigrationLog, ToMigrateEvent}
+import ch.epfl.bluebrain.nexus.delta.sourcing.EvaluationError.InvalidState
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.BatchConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.SuccessElem
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream._
 import ch.epfl.bluebrain.nexus.delta.sourcing.implicits._
-import ch.epfl.bluebrain.nexus.migration.Migration.{logger, MigrationProgress}
+import ch.epfl.bluebrain.nexus.migration.Migration.{processEvent, MigrationProgress}
 import ch.epfl.bluebrain.nexus.migration.config.ReplayConfig
 import ch.epfl.bluebrain.nexus.migration.replay.ReplayEvents
 import com.typesafe.config.{ConfigFactory, ConfigParseOptions}
@@ -38,20 +39,6 @@ final class Migration private (
     batch: BatchConfig,
     xas: Transactors
 ) {
-
-  private val logMap = logs.map { log => log.entityType -> log }.toMap
-
-  private val processEvent: ToMigrateEvent => Task[Unit] = event =>
-    logMap.get(event.entityType) match {
-      case Some(migrationLog) =>
-        migrationLog(event).tapError { e =>
-          Task.delay { logger.error(s"[${event.persistenceId}] $e") }
-        }
-      case None               =>
-        val message = s"The logMap has no entry for ${event.entityType}"
-        Task.delay { logger.error(message) } >>
-          Task.raiseError(new NoSuchElementException(message))
-    }
 
   private def saveProgress(progress: MigrationProgress) =
     sql"""INSERT INTO migration_offset (name, akka_offset, processed, discarded, failed, instant)
@@ -87,7 +74,7 @@ final class Migration private (
             val (toIgnore, toProcess) = chunk.partitionEither { e =>
               Either.cond(!Migration.toIgnore(e, blacklisted), e, e)
             }
-            val migrated              = toProcess.traverse(processEvent)
+            val migrated              = toProcess.traverse(processEvent(logs))
             val ignored               = saveIgnored(toIgnore).transact(xas.write)
             val migrationProgress     =
               MigrationProgress(last.offset, last.instant, toProcess.size.toLong, toIgnore.size.toLong, 0L)
@@ -129,6 +116,31 @@ object Migration {
           failed
         )
       }
+    }
+  }
+
+  def processEvent(logs: Set[MigrationLog]): ToMigrateEvent => Task[Unit] = { event =>
+    val logMap = logs.map { log => log.entityType -> log }.toMap
+
+    logMap.get(event.entityType) match {
+      case Some(migrationLog) =>
+        migrationLog(event)
+          .tapError { e =>
+            Task.delay {
+              logger.error(s"[${event.persistenceId}] $e")
+            }
+          }
+          .onErrorRecoverWith { case _: InvalidState[_, _] =>
+            Task.delay {
+              logger.warn(s"Invalid state encountered")
+            }
+          }
+      case None               =>
+        val message = s"The logMap has no entry for ${event.entityType}"
+        Task.delay {
+          logger.error(message)
+        } >>
+          Task.raiseError(new NoSuchElementException(message))
     }
   }
 

--- a/delta/migration/src/main/scala/ch/epfl/bluebrain/nexus/migration/Migration.scala
+++ b/delta/migration/src/main/scala/ch/epfl/bluebrain/nexus/migration/Migration.scala
@@ -130,9 +130,9 @@ object Migration {
               logger.error(s"[${event.persistenceId}] $e")
             }
           }
-          .onErrorRecoverWith { case _: InvalidState[_, _] =>
+          .onErrorRecoverWith { case e: InvalidState[_, _] =>
             Task.delay {
-              logger.warn(s"Invalid state encountered")
+              logger.warn(s"Invalid state encountered. Proceeding with migration. Original message: ${e.getMessage}")
             }
           }
       case None               =>

--- a/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationSuite.scala
+++ b/delta/migration/src/test/scala/ch/epfl/bluebrain/nexus/migration/MigrationSuite.scala
@@ -1,16 +1,19 @@
 package ch.epfl.bluebrain.nexus.migration
 
-import ch.epfl.bluebrain.nexus.delta.sdk.acls.Acls
-import ch.epfl.bluebrain.nexus.delta.sdk.migration.ToMigrateEvent
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.{AclFixtures, Acls}
+import ch.epfl.bluebrain.nexus.delta.sdk.migration.{MigrationLog, ToMigrateEvent}
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.Projects
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.Resolvers
-import ch.epfl.bluebrain.nexus.testkit.TestHelpers
+import ch.epfl.bluebrain.nexus.delta.sourcing.EvaluationError.InvalidState
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.EntityType
 import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
+import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
+import monix.bio.Task
 
 import java.time.Instant
 import java.util.UUID
 
-class MigrationSuite extends BioSuite with TestHelpers {
+class MigrationSuite extends BioSuite with TestHelpers with AclFixtures with IOValues {
 
   private val projectsToIgnore = Set("dummy", "myorg/test")
   private val uuid             = UUID.randomUUID()
@@ -41,14 +44,27 @@ class MigrationSuite extends BioSuite with TestHelpers {
 
   test("A project event that is not in a blacklisted project should not be ignored") {
     val payload = jsonContentOf("events/project-created.json")
-    val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
+    val event   = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
     assert(!Migration.toIgnore(event, projectsToIgnore))
   }
 
   test("A ProjectEvent that is in a blacklisted project should be ignored") {
     val payload = jsonContentOf("events/project-created-blacklist.json")
-    val event = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
+    val event   = ToMigrateEvent(Projects.entityType, "id", 1L, payload, Instant.EPOCH, uuid)
     assert(Migration.toIgnore(event, projectsToIgnore))
+  }
+
+  private val projectPayload = jsonContentOf("events/project-created.json")
+  private val projectEvent   = ToMigrateEvent(Projects.entityType, "id", 1L, projectPayload, Instant.EPOCH, uuid)
+
+  test("An invalid state should not be rejected") {
+    val ml = new MigrationLog {
+      override def entityType: EntityType = Projects.entityType
+
+      override def apply(event: ToMigrateEvent): Task[Unit] =
+        Task.raiseError(InvalidState(None, event))
+    }
+    Migration.processEvent(Set(ml))(projectEvent).accepted
   }
 
 }


### PR DESCRIPTION
An invalid state occurrence will be logged as a warning, and the migration will proceed.