### PR TITLE
Granular control of indexing deactivation

### DIFF
--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
@@ -107,7 +107,7 @@ class BlazegraphPluginModule(priority: Int) extends ModuleDef {
         )(api, clock, uuidF)
     }
 
-  if (!MigrationState.isIndexingDisabled) {
+  if (!MigrationState.isBgIndexingDisabled) {
     make[BlazegraphCoordinator].fromEffect {
       (
           views: BlazegraphViews,

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -149,24 +149,26 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
     CompositeGraphStream(local, remote)
   }
 
-  make[CompositeViewsCoordinator].fromEffect {
-    (
-        compositeViews: CompositeViews,
-        supervisor: Supervisor,
-        registry: ReferenceRegistry,
-        graphStream: CompositeGraphStream,
-        buildSpaces: CompositeSpaces.Builder,
-        compositeProjections: CompositeProjections,
-        cr: RemoteContextResolution @Id("aggregate")
-    ) =>
-      CompositeViewsCoordinator(
-        compositeViews,
-        supervisor,
-        PipeChain.compile(_, registry),
-        graphStream,
-        buildSpaces.apply,
-        compositeProjections
-      )(cr)
+  if (!MigrationState.isCompositeIndexingDisabled) {
+    make[CompositeViewsCoordinator].fromEffect {
+      (
+          compositeViews: CompositeViews,
+          supervisor: Supervisor,
+          registry: ReferenceRegistry,
+          graphStream: CompositeGraphStream,
+          buildSpaces: CompositeSpaces.Builder,
+          compositeProjections: CompositeProjections,
+          cr: RemoteContextResolution @Id("aggregate")
+      ) =>
+        CompositeViewsCoordinator(
+          compositeViews,
+          supervisor,
+          PipeChain.compile(_, registry),
+          graphStream,
+          buildSpaces.apply,
+          compositeProjections
+        )(cr)
+    }
   }
 
   many[MetadataContextValue].addEffect(MetadataContextValue.fromFile("contexts/composite-views-metadata.json"))

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
@@ -101,7 +101,7 @@ class ElasticSearchPluginModule(priority: Int) extends ModuleDef {
       )(api, clock, uuidF)
   }
 
-  if (!MigrationState.isIndexingDisabled) {
+  if (!MigrationState.isEsIndexingDisabled) {
     make[ElasticSearchCoordinator].fromEffect {
       (
           views: ElasticSearchViews,

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/migration/MigrationState.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/migration/MigrationState.scala
@@ -5,7 +5,16 @@ object MigrationState {
   def isRunning: Boolean =
     sys.env.getOrElse("MIGRATE_DATA", "false").toBooleanOption.getOrElse(false)
 
-  def isIndexingDisabled: Boolean =
+  private def isIndexingDisabled: Boolean =
     sys.env.getOrElse("DISABLE_INDEXING", "false").toBooleanOption.getOrElse(false)
+
+  def isEsIndexingDisabled: Boolean =
+    sys.env.getOrElse("DISABLE_ES_INDEXING", "false").toBooleanOption.getOrElse(false) || isIndexingDisabled
+
+  def isBgIndexingDisabled: Boolean =
+    sys.env.getOrElse("DISABLE_BG_INDEXING", "false").toBooleanOption.getOrElse(false) || isIndexingDisabled
+
+  def isCompositeIndexingDisabled: Boolean =
+    sys.env.getOrElse("DISABLE_COMPOSITE_INDEXING", "false").toBooleanOption.getOrElse(false) || isIndexingDisabled
 
 }


### PR DESCRIPTION
* By default, indexing is enabled
* `DISABLE_INDEXING` deactivates indexing for all views (ES, BG, composite)
* Each coordinator can be disabled on its own using `DISABLE_ES_INDEXING`, `DISABLE_BG_INDEXING`, and `DISABLE_COMPOSITE_INDEXING`

Closes #3661 

