### PR TITLE
Update `delete-old-packages` action

### DIFF
--- a/.github/workflows/ci-snapshot-cleanup.yml
+++ b/.github/workflows/ci-snapshot-cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Cleanup
-        uses: smartsquaregmbh/delete-old-packages@v0.4.0
+        uses: smartsquaregmbh/delete-old-packages@v0.6.0
         with:
           owner: BlueBrain
           repo: nexus


### PR DESCRIPTION
Version 0.4.0 uses a node version that is to be deprecated for GitHub Actions.