### PR TITLE
Do not override compacted @id in source by its expanded version

### DIFF
--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocument.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocument.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing
 
-//import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocument.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocument.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing
 
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+//import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
@@ -9,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.state.GraphResource
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.SuccessElem
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Operation.Pipe
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{Elem, PipeRef}
-import io.circe.Json
+import io.circe.{Json, JsonObject}
 import io.circe.syntax.EncoderOps
 import monix.bio.Task
 import shapeless.Typeable
@@ -38,19 +38,23 @@ final class GraphResourceToDocument(context: ContextValue, includeContext: Boole
       graph
         .toCompactedJsonLd(context)
         .map(ld => element.map(_ => injectContext(ld.obj.asJson)))
-    else
+    else {
+      val id = getSourceId(element.value.source).getOrElse(element.value.id.toString)
       (graph -- graph.rootTypesGraph)
-        .replaceRootNode(getSourceId(element.value.source).getOrElse(element.value.id))
         .toCompactedJsonLd(context)
         .map(ld => injectContext(mergeJsonLd(element.value.source, ld.json)))
+        .map(json => injectId(json, id))
         .map(json => if (json.isEmpty()) element.dropped else element.success(json))
-
+    }
   }
 
-  private def getSourceId(json: Json): Option[Iri] =
-    json.hcursor.get[Iri]("@id").toOption
+  private def getSourceId(source: Json): Option[String] =
+    source.hcursor.get[String]("@id").toOption
 
-  private def injectContext(json: Json) =
+  private def injectId(json: Json, sourceId: String) =
+    json.deepMerge(JsonObject("@id" -> Json.fromString(sourceId)).asJson)
+
+  private def injectContext(json: Json)              =
     if (includeContext)
       json.removeAllKeys(keywords.context).deepMerge(contextAsJson)
     else

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocumentSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocumentSuite.scala
@@ -45,7 +45,7 @@ class GraphResourceToDocumentSuite extends FunSuite with Fixtures with JsonAsser
 
   private val graphResourceToDocument = new GraphResourceToDocument(context, false)
 
-  test("If the source has an IRI ID it should be used") {
+  test("If the source has an expanded Iri `@id` it should be used") {
     val source =
       json"""
         {
@@ -70,7 +70,7 @@ class GraphResourceToDocumentSuite extends FunSuite with Fixtures with JsonAsser
     } yield json.equalsIgnoreArrayOrder(expectedJson)
   }
 
-  test("If the source has a non-IRI ID it should be used") {
+  test("If the source has a compacted Iri `@id` it should be used") {
     val source =
       json"""
         {
@@ -95,7 +95,7 @@ class GraphResourceToDocumentSuite extends FunSuite with Fixtures with JsonAsser
     } yield json.equalsIgnoreArrayOrder(expectedJson)
   }
 
-  test("If the source does not have an ID it should be injected") {
+  test("If the source does not have an `@id` it should be injected") {
     val source =
       json"""
         {

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocumentSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocumentSuite.scala
@@ -45,7 +45,7 @@ class GraphResourceToDocumentSuite extends FunSuite with Fixtures with JsonAsser
 
   private val graphResourceToDocument = new GraphResourceToDocument(context, false)
 
-  test("If the source has an ID it should be used") {
+  test("If the source has an IRI ID it should be used") {
     val source =
       json"""
         {
@@ -60,6 +60,31 @@ class GraphResourceToDocumentSuite extends FunSuite with Fixtures with JsonAsser
       json"""
         {
           "@id" : "http://nexus.example.com/john-doe",
+          "@type" : "http://schema.org/Person",
+          "name" : "John Doe"
+        }
+          """
+
+    for {
+      json <- graphResourceToDocument(elem).accepted.toOption
+    } yield json.equalsIgnoreArrayOrder(expectedJson)
+  }
+
+  test("If the source has a non-IRI ID it should be used") {
+    val source =
+      json"""
+        {
+          "@id": "nxv:JohnDoe",
+          "@type": "http://schema.org/Person",
+          "name": "John Doe"
+        }
+          """
+    val elem = elemFromSource(source)
+
+    val expectedJson =
+      json"""
+        {
+          "@id" : "nxv:JohnDoe",
           "@type" : "http://schema.org/Person",
           "name" : "John Doe"
         }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocumentSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/GraphResourceToDocumentSuite.scala
@@ -79,7 +79,7 @@ class GraphResourceToDocumentSuite extends FunSuite with Fixtures with JsonAsser
           "name": "John Doe"
         }
           """
-    val elem = elemFromSource(source)
+    val elem   = elemFromSource(source)
 
     val expectedJson =
       json"""


### PR DESCRIPTION
If the `@id` exists in the source, it should remain true to what's in the original source and not be overridden by its expanded version.