### PR TITLE
Handle all error channels on delta start

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
@@ -22,7 +22,7 @@ import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.{Logger => Logging}
 import izumi.distage.model.Locator
-import monix.bio.{BIOApp, Task, UIO}
+import monix.bio.{BIOApp, Cause, Task, UIO}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.DurationInt
@@ -41,15 +41,12 @@ object Main extends BIOApp {
     System.setProperty("cats.effect.logNonDaemonThreadsOnExit", "false")
     val config = sys.env.get(pluginEnvVariable).fold(PluginLoaderConfig())(PluginLoaderConfig(_))
     start(config)
-      .use { _ =>
-        UIO.never
-      }
-      .as(ExitCode.Success)
-      .onErrorHandleWith { e =>
-        Task.delay(log.error("Delta failed to start", e)).as(ExitCode.Error)
-      }
-      .hideErrors
+      .use(_ => UIO.never)
+      .redeemCauseWith(logTerminalError, _ => UIO.pure(ExitCode.Success))
   }
+
+  private def logTerminalError: Cause[Throwable] => Task[ExitCode] = c =>
+    Task.delay(log.error("Delta failed to start", c.toThrowable)).as(ExitCode.Error)
 
   private[delta] def start(loaderConfig: PluginLoaderConfig): Resource[Task, Locator] =
     for {

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
@@ -42,11 +42,12 @@ object Main extends BIOApp {
     val config = sys.env.get(pluginEnvVariable).fold(PluginLoaderConfig())(PluginLoaderConfig(_))
     start(config)
       .use(_ => UIO.never)
-      .redeemCauseWith(logTerminalError, _ => UIO.pure(ExitCode.Success))
+      .as(ExitCode.Success)
+      .redeemCauseWith(logTerminalError, UIO.pure)
   }
 
-  private def logTerminalError: Cause[Throwable] => Task[ExitCode] = c =>
-    Task.delay(log.error("Delta failed to start", c.toThrowable)).as(ExitCode.Error)
+  private def logTerminalError: Cause[Throwable] => UIO[ExitCode] = c =>
+    UIO.delay(log.error("Delta failed to start", c.toThrowable)).as(ExitCode.Error)
 
   private[delta] def start(loaderConfig: PluginLoaderConfig): Resource[Task, Locator] =
     for {


### PR DESCRIPTION
Previously, the terminal error channel was not handled and these errors could be lost.

Closes #3707 