### PR TITLE
handle elasticsearch bulk update partial failures

### DIFF
--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchSink.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchSink.scala
@@ -1,18 +1,20 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing
 
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.Refresh
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.BulkResponse.{NoErrors, SomeErrors}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.{BulkItemOutcome, Refresh}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.{ElasticSearchBulk, ElasticSearchClient, IndexLabel}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.ElasticSearchSink.logger
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.ElasticSearchSink.{logger, BulkUpdateException}
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Operation.Sink
 import com.typesafe.scalalogging.Logger
 import fs2.Chunk
-import io.circe.Json
+import io.circe.{Json, JsonObject}
 import monix.bio.{Task, UIO}
 import shapeless.Typeable
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
 
 /**
   * Sink that pushes json documents into an Elasticsearch index
@@ -56,12 +58,19 @@ final class ElasticSearchSink private (
     if (bulk.nonEmpty) {
       client
         .bulk(bulk, refresh)
-        .redeemWith(
-          err =>
-            UIO
-              .delay(logger.error(s"Indexing in elasticsearch index ${index.value} failed", err))
-              .as(elements.map { _.failed(err) }),
-          _ => Task.pure(elements.map(_.void))
+        .map {
+          case NoErrors          => elements.map(_.void)
+          case SomeErrors(items) =>
+            elements.zip(Chunk.seq(items)).map {
+              case (element, BulkItemOutcome.Success)     => element.void
+              case (element, BulkItemOutcome.Error(json)) =>
+                element.failed(BulkUpdateException(json))
+            }
+        }
+        .onErrorHandleWith(err =>
+          UIO
+            .delay(logger.error(s"Indexing in elasticsearch index ${index.value} failed", err))
+            .as(elements.map(_.failed(err)))
         )
     } else {
       Task.pure(elements.map(_.void))
@@ -143,4 +152,7 @@ object ElasticSearchSink {
       refresh
     )
 
+  final case class BulkUpdateException(json: JsonObject)
+      extends Exception("Error updating elasticsearch: " + Json.fromJsonObject(json).noSpaces)
+      with NoStackTrace
 }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchSink.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchSink.scala
@@ -3,14 +3,13 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.BulkResponse.{MixedOutcomes, Success}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.{BulkResponse, Refresh}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.{ElasticSearchBulk, ElasticSearchClient, IndexLabel}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.ElasticSearchSink.{logger, BulkUpdateException}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.ElasticSearchSink.BulkUpdateException
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Operation.Sink
-import com.typesafe.scalalogging.Logger
 import fs2.Chunk
 import io.circe.{Json, JsonObject}
-import monix.bio.{Task, UIO}
+import monix.bio.Task
 import shapeless.Typeable
 
 import scala.concurrent.duration.FiniteDuration
@@ -67,11 +66,6 @@ final class ElasticSearchSink private (
                 element.failed(BulkUpdateException(json))
             }
         }
-        .onErrorHandleWith(err =>
-          UIO
-            .delay(logger.error(s"Indexing in elasticsearch index ${index.value} failed", err))
-            .as(elements.map(_.failed(err)))
-        )
     } else {
       Task.pure(elements.map(_.void))
     }
@@ -79,8 +73,6 @@ final class ElasticSearchSink private (
 }
 
 object ElasticSearchSink {
-
-  private val logger: Logger = Logger[ElasticSearchSink]
 
   /**
     * @return

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/ElasticSearchClientSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/ElasticSearchClientSpec.scala
@@ -4,7 +4,8 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Query
 import akka.testkit.TestKit
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ScalaTestElasticSearchClientSetup
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.{BulkItemOutcome, BulkResponse, Refresh}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.BulkResponse.MixedOutcomes.Outcome
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.{BulkResponse, Refresh}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError.HttpClientStatusError
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.ServiceDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
@@ -131,10 +132,10 @@ class ElasticSearchClientSpec(override val docker: ElasticSearchDocker)
       )
       val result     = esClient.bulk(operations).accepted
       result match {
-        case BulkResponse.NoErrors          => fail("errors expected")
-        case BulkResponse.SomeErrors(items) => {
-          every(items.take(5)) shouldBe BulkItemOutcome.Success
-          items(5) shouldBe a[BulkItemOutcome.Error]
+        case BulkResponse.Success              => fail("errors expected")
+        case BulkResponse.MixedOutcomes(items) => {
+          every(items.take(5)) shouldBe Outcome.Success
+          items(5) shouldBe an[Outcome.Error]
         }
       }
     }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/ElasticSearchClientSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/ElasticSearchClientSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Query
 import akka.testkit.TestKit
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ScalaTestElasticSearchClientSetup
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.Refresh
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient.{BulkItemOutcome, BulkResponse, Refresh}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError.HttpClientStatusError
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.ServiceDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
@@ -116,6 +116,26 @@ class ElasticSearchClientSpec(override val docker: ElasticSearchDocker)
       eventually {
         searchAllIn(index) shouldEqual
           Vector(jobj"""{"field1": "value3"}""", jobj"""{"field1": "value1", "field2" : "value2"}""")
+      }
+    }
+
+    "run bulk operation with errors" in {
+      val index      = IndexLabel(genString()).rightValue
+      val operations = List(
+        ElasticSearchBulk.Index(index, "1", json"""{ "field1" : "value1" }"""),
+        ElasticSearchBulk.Delete(index, "2"),
+        ElasticSearchBulk.Index(index, "2", json"""{ "field1" : 27 }"""),
+        ElasticSearchBulk.Delete(index, "3"),
+        ElasticSearchBulk.Create(index, "3", json"""{ "field1" : "value3" }"""),
+        ElasticSearchBulk.Update(index, "5", json"""{ "doc" : {"field2" : "value2"} }""")
+      )
+      val result     = esClient.bulk(operations).accepted
+      result match {
+        case BulkResponse.NoErrors          => fail("errors expected")
+        case BulkResponse.SomeErrors(items) => {
+          every(items.take(5)) shouldBe BulkItemOutcome.Success
+          items(5) shouldBe a[BulkItemOutcome.Error]
+        }
       }
     }
 

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/bio/BioAssertions.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/bio/BioAssertions.scala
@@ -43,7 +43,7 @@ trait BioAssertions { self: Assertions =>
       )
     }
 
-    def assert(expected: A, clue: Any = "values are not the same"): UIO[Unit] = io.redeemCause(
+    def assert(expected: A, clue: Any = "values are not the same")(implicit loc: Location): UIO[Unit] = io.redeemCause(
       {
         case Error(NonFatal(err)) =>
           exceptionHandler(err)


### PR DESCRIPTION
when a bulk elasticsearch update is partially rejected, make the element stream reflect that state accurately

Fixes #3677