### PR TITLE
Handle untranslatable `\u0000` character during migration

### DIFF
--- a/delta/migration/src/test/resources/resource.json
+++ b/delta/migration/src/test/resources/resource.json
@@ -1,0 +1,15 @@
+{
+  "number": 1,
+  "field": "some text ",
+  "nested": {
+    "name": "alice",
+    "age": 100
+  },
+  "array": [
+    "one",
+    "two",
+    3
+  ],
+  "bool": true,
+  "nothing": null
+}

--- a/delta/migration/src/test/resources/u0000-resource.json
+++ b/delta/migration/src/test/resources/u0000-resource.json
@@ -1,0 +1,15 @@
+{
+  "number": 1,
+  "field": "some text \u0000",
+  "nested": {
+    "name": "alice\u0000",
+    "age": 100
+  },
+  "array": [
+    "one",
+    "two\u0000",
+    3
+  ],
+  "bool": true,
+  "nothing": null
+}


### PR DESCRIPTION
PostgreSQL does not support JSONs text fields that contain `\u0000`. As a fix, when this error occurs, we try to simply remove this value from the JSON.