### PR TITLE
Serialize types for all the states

### DIFF
--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/model/BlazegraphViewState.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/model/BlazegraphViewState.scala
@@ -124,7 +124,7 @@ object BlazegraphViewState {
     implicit val configuration: Configuration                    = Serializer.circeConfiguration
     implicit val valueCodec: Codec.AsObject[BlazegraphViewValue] = deriveConfiguredCodec[BlazegraphViewValue]
     implicit val codec: Codec.AsObject[BlazegraphViewState]      = deriveConfiguredCodec[BlazegraphViewState]
-    Serializer.dropNulls()
+    Serializer.dropNullsInjectType()
   }
 
 }

--- a/delta/plugins/blazegraph/src/test/resources/blazegraph/database/aggregate-view-state.json
+++ b/delta/plugins/blazegraph/src/test/resources/blazegraph/database/aggregate-view-state.json
@@ -1,28 +1,16 @@
 {
-  "createdAt": "1970-01-01T00:00:00Z",
-  "createdBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "deprecated": false,
-  "id": "https://bluebrain.github.io/nexus/vocabulary/aggregate-view",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/aggregate-view",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/AggregateSparqlView",
+    "https://bluebrain.github.io/nexus/vocabulary/View"
+  ],
   "rev": 1,
   "indexingRev": 1,
+  "deprecated": false,
   "source": {
     "elastic": "value"
   },
-  "tags": {
-    "mytag": 3
-  },
-  "updatedAt": "1970-01-01T00:00:00Z",
-  "updatedBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
   "value": {
     "@type": "AggregateBlazegraphViewValue",
     "name": "viewName",
@@ -33,5 +21,21 @@
         "viewId": "https://bluebrain.github.io/nexus/vocabulary/indexing-view"
       }
     ]
+  },
+  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
+  "tags": {
+    "mytag": 3
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
+  },
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   }
 }

--- a/delta/plugins/blazegraph/src/test/resources/blazegraph/database/indexing-view-state.json
+++ b/delta/plugins/blazegraph/src/test/resources/blazegraph/database/indexing-view-state.json
@@ -1,15 +1,19 @@
 {
+  "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/indexing-view",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/SparqlView",
+    "https://bluebrain.github.io/nexus/vocabulary/View"
+  ],
+  "rev": 1,
+  "indexingRev": 1,
+  "deprecated": false,
   "createdAt": "1970-01-01T00:00:00Z",
   "createdBy": {
     "@type": "User",
     "realm": "myrealm",
     "subject": "username"
   },
-  "deprecated": false,
-  "id": "https://bluebrain.github.io/nexus/vocabulary/indexing-view",
-  "project": "myorg/myproj",
-  "rev": 1,
-  "indexingRev": 1,
   "source": {
     "elastic": "value"
   },

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeViewState.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeViewState.scala
@@ -104,6 +104,6 @@ object CompositeViewState {
     implicit val configuration: Configuration                       = Serializer.circeConfiguration
     implicit val compositeViewValueCodec: Codec[CompositeViewValue] = CompositeViewValue.databaseCodec(crypto)
     implicit val codec: Codec.AsObject[CompositeViewState]          = deriveConfiguredCodec[CompositeViewState]
-    Serializer.dropNulls()
+    Serializer.dropNullsInjectType()
   }
 }

--- a/delta/plugins/composite-views/src/test/resources/composite-views/database/view-state.json
+++ b/delta/plugins/composite-views/src/test/resources/composite-views/database/view-state.json
@@ -1,14 +1,12 @@
 {
-  "createdAt": "1970-01-01T00:00:00Z",
-  "createdBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "myuser"
-  },
-  "deprecated": false,
-  "id": "http://example.com/composite-view",
   "project": "myorg/myproj",
+  "id": "http://example.com/composite-view",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/CompositeView",
+    "https://bluebrain.github.io/nexus/vocabulary/View"
+  ],
   "rev": 1,
+  "deprecated": false,
   "source": {
     "projections": [
       {
@@ -30,7 +28,7 @@
         },
         "includeDeprecated": false,
         "includeMetadata": false,
-        "includeContext" : false,
+        "includeContext": false,
         "mapping": {
         },
         "permission": "views/query",
@@ -86,16 +84,6 @@
       }
     ]
   },
-  "tags": {
-    "mytag": 3
-  },
-  "updatedAt": "1970-01-01T00:00:00Z",
-  "updatedBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "myuser"
-  },
-  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
   "value": {
     "projections": [
       {
@@ -118,7 +106,7 @@
         "id": "http://example.com/es-projection",
         "includeDeprecated": false,
         "includeMetadata": false,
-        "includeContext" : false,
+        "includeContext": false,
         "mapping": {
         },
         "permission": "views/query",
@@ -179,5 +167,21 @@
         "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa"
       }
     ]
+  },
+  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
+  "tags": {
+    "mytag": 3
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "myuser"
+  },
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "myuser"
   }
 }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewState.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewState.scala
@@ -139,6 +139,6 @@ object ElasticSearchViewState {
     implicit val configuration: Configuration                       = Serializer.circeConfiguration
     implicit val valueCodec: Codec.AsObject[ElasticSearchViewValue] = deriveConfiguredCodec[ElasticSearchViewValue]
     implicit val codec: Codec.AsObject[ElasticSearchViewState]      = deriveConfiguredCodec[ElasticSearchViewState]
-    Serializer.dropNulls()
+    Serializer.dropNullsInjectType()
   }
 }

--- a/delta/plugins/elasticsearch/src/test/resources/elasticsearch/database/aggregate-view-state.json
+++ b/delta/plugins/elasticsearch/src/test/resources/elasticsearch/database/aggregate-view-state.json
@@ -1,28 +1,16 @@
 {
-  "createdAt": "1970-01-01T00:00:00Z",
-  "createdBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "deprecated": false,
-  "id": "https://bluebrain.github.io/nexus/vocabulary/aggregate-view",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/aggregate-view",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/AggregateElasticSearchView",
+    "https://bluebrain.github.io/nexus/vocabulary/View"
+  ],
   "rev": 1,
   "indexingRev": 1,
+  "deprecated": false,
   "source": {
     "elastic": "value"
   },
-  "tags": {
-    "mytag": 3
-  },
-  "updatedAt": "1970-01-01T00:00:00Z",
-  "updatedBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
   "value": {
     "@type": "AggregateElasticSearchViewValue",
     "name": "viewName",
@@ -33,5 +21,21 @@
         "viewId": "https://bluebrain.github.io/nexus/vocabulary/indexing-view"
       }
     ]
+  },
+  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
+  "tags": {
+    "mytag": 3
+  },
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   }
 }

--- a/delta/plugins/elasticsearch/src/test/resources/elasticsearch/database/default-indexing-view-state.json
+++ b/delta/plugins/elasticsearch/src/test/resources/elasticsearch/database/default-indexing-view-state.json
@@ -1,28 +1,16 @@
 {
-  "createdAt": "1970-01-01T00:00:00Z",
-  "createdBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "deprecated": false,
-  "id": "https://bluebrain.github.io/nexus/vocabulary/indexing-view",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/indexing-view",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/ElasticSearchView",
+    "https://bluebrain.github.io/nexus/vocabulary/View"
+  ],
   "rev": 1,
   "indexingRev": 1,
+  "deprecated": false,
   "source": {
     "elastic": "value"
   },
-  "tags": {
-    "mytag": 3
-  },
-  "updatedAt": "1970-01-01T00:00:00Z",
-  "updatedBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
   "value": {
     "@type": "IndexingElasticSearchViewValue",
     "pipeline": [
@@ -37,5 +25,21 @@
       }
     ],
     "permission": "views/query"
+  },
+  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
+  "tags": {
+    "mytag": 3
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
+  },
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   }
 }

--- a/delta/plugins/elasticsearch/src/test/resources/elasticsearch/database/indexing-view-state.json
+++ b/delta/plugins/elasticsearch/src/test/resources/elasticsearch/database/indexing-view-state.json
@@ -1,28 +1,16 @@
 {
-  "createdAt": "1970-01-01T00:00:00Z",
-  "createdBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "deprecated": false,
-  "id": "https://bluebrain.github.io/nexus/vocabulary/indexing-view",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/indexing-view",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/ElasticSearchView",
+    "https://bluebrain.github.io/nexus/vocabulary/View"
+  ],
   "rev": 1,
   "indexingRev": 1,
+  "deprecated": false,
   "source": {
     "elastic": "value"
   },
-  "tags": {
-    "mytag": 3
-  },
-  "updatedAt": "1970-01-01T00:00:00Z",
-  "updatedBy": {
-    "@type": "User",
-    "realm": "myrealm",
-    "subject": "username"
-  },
-  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
   "value": {
     "@type": "IndexingElasticSearchViewValue",
     "name": "viewName",
@@ -70,5 +58,21 @@
       "analysis": {
       }
     }
+  },
+  "uuid": "f8468909-a797-4b10-8b5f-000cba337bfa",
+  "tags": {
+    "mytag": 3
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
+  },
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   }
 }

--- a/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/indexing/GraphAnalyticsStream.scala
+++ b/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/indexing/GraphAnalyticsStream.scala
@@ -50,12 +50,13 @@ object GraphAnalyticsStream {
          | AND $inIds
          | AND tag = ${Tag.latest.value}
          |""".stripMargin
-      .query[(Iri, Json)]
+      .query[(Iri, Option[Json])]
       .to[List]
       .transact(xas.streaming)
       .map { l =>
         l.foldLeft(emptyMapType) { case (acc, (id, json)) =>
-          acc ++ json.as[Set[Iri]].toOption.map(id -> _)
+          val types = json.flatMap(_.as[Set[Iri]].toOption).getOrElse(Set.empty)
+          acc + (id -> types)
         }
       }
   }.hideErrors

--- a/delta/plugins/graph-analytics/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsCoordinatorSuite.scala
+++ b/delta/plugins/graph-analytics/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsCoordinatorSuite.scala
@@ -133,7 +133,7 @@ class GraphAnalyticsCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtu
     } yield ()
   }
 
-  test(s"'$project2' is marked for deletetion, the associated projection should be destroyed.") {
+  test(s"'$project2' is marked for deletion, the associated projection should be destroyed.") {
     val projectionName = s"ga-$project2"
     for {
       _ <- sv.describe(projectionName).eventuallyNone

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileState.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileState.scala
@@ -9,8 +9,8 @@ import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.instances._
 import ch.epfl.bluebrain.nexus.delta.sourcing.Serializer
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Subject
-import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ProjectRef, ResourceRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ResourceRef.Latest
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ProjectRef, ResourceRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.state.State.ScopedState
 import io.circe.Codec
 import io.circe.generic.extras.Configuration
@@ -105,6 +105,6 @@ object FileState {
     implicit val fileAttributesCodec: Codec.AsObject[FileAttributes] =
       deriveConfiguredCodec[FileAttributes]
     implicit val codec: Codec.AsObject[FileState]                    = deriveConfiguredCodec[FileState]
-    Serializer()
+    Serializer.dropNullsInjectType()
   }
 }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/model/StorageState.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/model/StorageState.scala
@@ -102,6 +102,6 @@ object StorageState {
 
     implicit val storageValueCodec: Codec.AsObject[StorageValue] = StorageValue.databaseCodec(crypto)
     implicit val codec: Codec.AsObject[StorageState]             = deriveConfiguredCodec[StorageState]
-    Serializer.dropNulls()
+    Serializer.dropNullsInjectType()
   }
 }

--- a/delta/plugins/storage/src/test/resources/files/database/file-state.json
+++ b/delta/plugins/storage/src/test/resources/files/database/file-state.json
@@ -1,4 +1,11 @@
 {
+  "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/file",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/File"
+  ],
+  "rev": 5,
+  "deprecated": false,
   "attributes": {
     "bytes": 12,
     "digest": {
@@ -19,10 +26,6 @@
     "realm": "myrealm",
     "subject": "username"
   },
-  "deprecated": false,
-  "id": "https://bluebrain.github.io/nexus/vocabulary/file",
-  "project": "myorg/myproj",
-  "rev": 5,
   "storage": "https://bluebrain.github.io/nexus/vocabulary/disk-storage?rev=1",
   "storageType": "DiskStorage",
   "tags": {

--- a/delta/plugins/storage/src/test/resources/storages/storage-disk-state.json
+++ b/delta/plugins/storage/src/test/resources/storages/storage-disk-state.json
@@ -1,6 +1,12 @@
 {
-  "id": "https://bluebrain.github.io/nexus/vocabulary/disk-storage",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/disk-storage",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/Storage",
+    "https://bluebrain.github.io/nexus/vocabulary/DiskStorage"
+  ],
+  "rev": 1,
+  "deprecated": false,
   "value": {
     "default": true,
     "name": "diskName",
@@ -27,8 +33,6 @@
   "tags": {
     "mytag": 3
   },
-  "rev": 1,
-  "deprecated": false,
   "createdAt": "1970-01-01T00:00:00Z",
   "createdBy": {
     "subject": "username",

--- a/delta/plugins/storage/src/test/resources/storages/storage-remote-state.json
+++ b/delta/plugins/storage/src/test/resources/storages/storage-remote-state.json
@@ -1,6 +1,12 @@
 {
-  "id": "https://bluebrain.github.io/nexus/vocabulary/remote-disk-storage",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/remote-disk-storage",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/Storage",
+    "https://bluebrain.github.io/nexus/vocabulary/RemoteDiskStorage"
+  ],
+  "rev": 1,
+  "deprecated": false,
   "value": {
     "default": true,
     "name": "remoteName",
@@ -29,8 +35,6 @@
   "tags": {
     "mytag": 3
   },
-  "rev": 1,
-  "deprecated": false,
   "createdAt": "1970-01-01T00:00:00Z",
   "createdBy": {
     "subject": "username",

--- a/delta/plugins/storage/src/test/resources/storages/storage-s3-state.json
+++ b/delta/plugins/storage/src/test/resources/storages/storage-s3-state.json
@@ -1,6 +1,12 @@
 {
-  "id": "https://bluebrain.github.io/nexus/vocabulary/s3-storage",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/s3-storage",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/Storage",
+    "https://bluebrain.github.io/nexus/vocabulary/S3Storage"
+  ],
+  "rev": 1,
+  "deprecated": false,
   "value": {
     "default": true,
     "name": "s3name",
@@ -33,8 +39,6 @@
   "tags": {
     "mytag": 3
   },
-  "rev": 1,
-  "deprecated": false,
   "createdAt": "1970-01-01T00:00:00Z",
   "createdBy": {
     "subject": "username",

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/projects/model/ProjectState.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/projects/model/ProjectState.scala
@@ -134,7 +134,7 @@ object ProjectState {
       Encoder.encodeMap[String, Iri].contramapObject(_.value)
 
     implicit val coder: Codec.AsObject[ProjectState] = deriveConfiguredCodec[ProjectState]
-    Serializer(Projects.encodeId)
+    Serializer.dropNullsInjectType(Projects.encodeId)
   }
 
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/resolvers/model/ResolverState.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/resolvers/model/ResolverState.scala
@@ -107,6 +107,6 @@ object ResolverState {
     implicit val configuration: Configuration                      = Serializer.circeConfiguration
     implicit val resolverValueCodec: Codec.AsObject[ResolverValue] = deriveConfiguredCodec[ResolverValue]
     implicit val codec: Codec.AsObject[ResolverState]              = deriveConfiguredCodec[ResolverState]
-    Serializer.dropNulls()
+    Serializer.dropNullsInjectType()
   }
 }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/schemas/model/SchemaState.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/schemas/model/SchemaState.scala
@@ -99,7 +99,7 @@ object SchemaState {
     import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd.Database._
     implicit val configuration: Configuration       = Serializer.circeConfiguration
     implicit val codec: Codec.AsObject[SchemaState] = deriveConfiguredCodec[SchemaState]
-    Serializer()
+    Serializer.dropNullsInjectType()
   }
 
 }

--- a/delta/sdk/src/test/resources/projects/project-state.json
+++ b/delta/sdk/src/test/resources/projects/project-state.json
@@ -1,17 +1,20 @@
 {
   "label": "myproj",
-  "uuid": "fe1301a6-a105-4966-84af-32723fd003d2",
-  "organizationLabel": "myorg",
-  "organizationUuid": "b6bde92f-7836-4da6-8ead-2e0fd516ebe7",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/Project"
+  ],
   "rev": 1,
   "deprecated": false,
-  "markedForDeletion": false,
   "description": "some description",
+  "organizationLabel": "myorg",
+  "organizationUuid": "b6bde92f-7836-4da6-8ead-2e0fd516ebe7",
   "apiMappings": {
-      "nxv": "https://bluebrain.github.io/nexus/vocabulary/"
+    "nxv": "https://bluebrain.github.io/nexus/vocabulary/"
   },
   "base": "https://bluebrain.github.io/nexus/schemas/",
   "vocab": "https://bluebrain.github.io/nexus/vocabulary/",
+  "markedForDeletion": false,
+  "uuid": "fe1301a6-a105-4966-84af-32723fd003d2",
   "createdAt": "1970-01-01T00:00:00Z",
   "createdBy": {
     "subject": "username",

--- a/delta/sdk/src/test/resources/resolvers/resolver-cross-project-state-1.json
+++ b/delta/sdk/src/test/resources/resolvers/resolver-cross-project-state-1.json
@@ -1,58 +1,62 @@
 {
-  "id" : "https://bluebrain.github.io/nexus/vocabulary/myId",
-  "project" : "myorg/myproj",
-  "deprecated" : false,
-  "rev" : 1,
-  "value" : {
-    "@type" : "CrossProjectValue",
-    "identityResolution" : {
-      "@type" : "ProvidedIdentities",
-      "value" : [
+  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
+  "project": "myorg/myproj",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/CrossProject",
+    "https://bluebrain.github.io/nexus/vocabulary/Resolver"
+  ],
+  "rev": 1,
+  "deprecated": false,
+  "value": {
+    "@type": "CrossProjectValue",
+    "identityResolution": {
+      "@type": "ProvidedIdentities",
+      "value": [
         {
-          "@type" : "Authenticated",
-          "realm" : "myrealm"
+          "@type": "Authenticated",
+          "realm": "myrealm"
         },
         {
-          "@type" : "Anonymous"
+          "@type": "Anonymous"
         },
         {
-          "@type" : "Group",
-          "group" : "group",
-          "realm" : "myrealm"
+          "@type": "Group",
+          "group": "group",
+          "realm": "myrealm"
         },
         {
-          "@type" : "User",
-          "realm" : "myrealm",
-          "subject" : "username"
+          "@type": "User",
+          "realm": "myrealm",
+          "subject": "username"
         }
       ]
     },
-    "priority" : 42,
-    "projects" : [
+    "priority": 42,
+    "projects": [
       "myorg/myproj",
       "org2/proj2"
     ],
-    "resourceTypes" : [
+    "resourceTypes": [
       "https://bluebrain.github.io/nexus/schemas/unconstrained.json",
       "https://bluebrain.github.io/nexus/schemas/projects.json"
     ]
   },
-  "source" : {
-    "resolver" : "value"
+  "source": {
+    "resolver": "value"
   },
-  "tags" : {
-    "mytag" : 3
+  "tags": {
+    "mytag": 3
   },
-  "createdAt" : "1970-01-01T00:00:00Z",
-  "createdBy" : {
-    "@type" : "User",
-    "realm" : "myrealm",
-    "subject" : "username"
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   },
-  "updatedAt" : "1970-01-01T00:00:00Z",
-  "updatedBy" : {
-    "@type" : "User",
-    "realm" : "myrealm",
-    "subject" : "username"
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   }
 }

--- a/delta/sdk/src/test/resources/resolvers/resolver-cross-project-state-2.json
+++ b/delta/sdk/src/test/resources/resolvers/resolver-cross-project-state-2.json
@@ -1,8 +1,12 @@
 {
   "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
   "project": "myorg/myproj",
-  "deprecated": false,
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/CrossProject",
+    "https://bluebrain.github.io/nexus/vocabulary/Resolver"
+  ],
   "rev": 1,
+  "deprecated": false,
   "value": {
     "@type": "CrossProjectValue",
     "identityResolution": {

--- a/delta/sdk/src/test/resources/resolvers/resolver-in-project-state.json
+++ b/delta/sdk/src/test/resources/resolvers/resolver-in-project-state.json
@@ -1,28 +1,32 @@
 {
-  "id" : "https://bluebrain.github.io/nexus/vocabulary/myId",
-  "project" : "myorg/myproj",
-  "deprecated" : false,
-  "rev" : 1,
-  "value" : {
-    "@type" : "InProjectValue",
-    "priority" : 42
+  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
+  "project": "myorg/myproj",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/Resolver",
+    "https://bluebrain.github.io/nexus/vocabulary/InProject"
+  ],
+  "rev": 1,
+  "deprecated": false,
+  "value": {
+    "@type": "InProjectValue",
+    "priority": 42
   },
-  "source" : {
-    "resolver" : "value"
+  "source": {
+    "resolver": "value"
   },
-  "tags" : {
-    "mytag" : 3
+  "tags": {
+    "mytag": 3
   },
-  "createdAt" : "1970-01-01T00:00:00Z",
-  "createdBy" : {
-    "@type" : "User",
-    "realm" : "myrealm",
-    "subject" : "username"
+  "createdAt": "1970-01-01T00:00:00Z",
+  "createdBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   },
-  "updatedAt" : "1970-01-01T00:00:00Z",
-  "updatedBy" : {
-    "@type" : "User",
-    "realm" : "myrealm",
-    "subject" : "username"
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "updatedBy": {
+    "@type": "User",
+    "realm": "myrealm",
+    "subject": "username"
   }
 }

--- a/delta/sdk/src/test/resources/resources/resource-state.json
+++ b/delta/sdk/src/test/resources/resources/resource-state.json
@@ -1,6 +1,12 @@
 {
-  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
+  "types": [
+    "http://schema.org/Person"
+  ],
+  "rev": 2,
+  "deprecated": false,
+  "schema": "https://bluebrain.github.io/nexus/schemas/unconstrained.json?rev=1",
   "schemaProject": "myorg/myproj",
   "source": {
     "@context": {
@@ -44,12 +50,6 @@
         }
       ]
     }
-  ],
-  "rev": 2,
-  "deprecated": false,
-  "schema": "https://bluebrain.github.io/nexus/schemas/unconstrained.json?rev=1",
-  "types": [
-    "http://schema.org/Person"
   ],
   "tags": {
     "mytag": 3

--- a/delta/sdk/src/test/resources/schemas/schema-state.json
+++ b/delta/sdk/src/test/resources/schemas/schema-state.json
@@ -1,6 +1,11 @@
 {
-  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
   "project": "myorg/myproj",
+  "id": "https://bluebrain.github.io/nexus/vocabulary/myId",
+  "types": [
+    "https://bluebrain.github.io/nexus/vocabulary/Schema"
+  ],
+  "rev": 2,
+  "deprecated": false,
   "source": {
     "@id": "https://bluebrain.github.io/nexus/vocabulary/myId",
     "@context": [
@@ -166,8 +171,6 @@
       }
     ]
   ],
-  "rev": 2,
-  "deprecated": false,
   "tags": {
     "mytag": 3
   },

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/Serializer.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/Serializer.scala
@@ -3,9 +3,11 @@ package ch.epfl.bluebrain.nexus.delta.sourcing
 import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.sourcing.implicits._
+import ch.epfl.bluebrain.nexus.delta.sourcing.state.State.ScopedState
 import doobie.{Get, Put}
 import io.circe.generic.extras.Configuration
-import io.circe.{Codec, Printer}
+import io.circe.syntax._
+import io.circe.{Codec, Encoder, Printer}
 
 /**
   * Defines how to extract an id from an event/state and how to serialize and deserialize it
@@ -47,15 +49,38 @@ object Serializer {
     apply(identity[Iri])(codec)
 
   /**
-    * Defines a serializer with the default printer ignoring null values with a custom [[Id]] type
+    * Defines a serializer with the default printer ignoring null values with a custom [[Id]]
     */
   def dropNulls[Id, Value](extractId: Id => Iri)(implicit codec: Codec.AsObject[Value]): Serializer[Id, Value] =
     new Serializer(extractId, codec, dropNullsPrinter)
+
+  /**
+    * Defines a serializer with the default printer ignoring null values with a custom [[Id]] and injecting the resource
+    * types
+    */
+  def dropNullsInjectType[Id, State <: ScopedState](
+      extractId: Id => Iri
+  )(implicit codec: Codec.AsObject[State]): Serializer[Id, State] = {
+    val codecWithType = Codec.AsObject.from(
+      codec,
+      Encoder.AsObject.instance[State] { state =>
+        codec.mapJsonObject(_.+:("types" := state.types)).encodeObject(state)
+      }
+    )
+    dropNulls(extractId)(codecWithType)
+  }
 
   /**
     * Defines a serializer with the default printer ignoring null values with an [[Iri]] id
     */
   def dropNulls[Value]()(implicit codec: Codec.AsObject[Value]): Serializer[Iri, Value] =
     dropNulls(identity[Iri])(codec)
+
+  /**
+    * Defines a serializer for states with the default printer ignoring null values with an [[Iri]] id and injecting the
+    * resource types
+    */
+  def dropNullsInjectType[State <: ScopedState]()(implicit codec: Codec.AsObject[State]): Serializer[Iri, State] =
+    dropNullsInjectType(identity[Iri])(codec)
 
 }

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/PullRequest.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/PullRequest.scala
@@ -223,7 +223,7 @@ object PullRequest {
       import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Database._
       implicit val configuration: Configuration            = Configuration.default.withDiscriminator("@type")
       implicit val coder: Codec.AsObject[PullRequestState] = deriveConfiguredCodec[PullRequestState]
-      Serializer()
+      Serializer.dropNullsInjectType()
     }
 
     def toGraphResource(state: PullRequestState, base: Iri): GraphResource =


### PR DESCRIPTION
Fixes #3783 

* Serialize types for all types of resources even if they are constant
* Reorder fields in reference files for serialization tests
* Harden retrieving relationships in Graph-analytics