### PR TITLE
Composite view plugin to inherit blazegraph and elasticsearch batch config

### DIFF
--- a/delta/plugins/composite-views/src/main/resources/composite-views.conf
+++ b/delta/plugins/composite-views/src/main/resources/composite-views.conf
@@ -13,14 +13,14 @@ plugins.composite-views {
   prefix = ${app.defaults.indexing.prefix}
   # the composite views event log configuration
   event-log {
-    query-config =  ${app.defaults.query}
+    query-config = ${app.defaults.query}
     max-duration = 20 seconds
   }
   # the composite views pagination config
   pagination = ${app.defaults.pagination}
   # the HTTP client configuration for a remote source
   remote-source-client {
-    http  = ${app.defaults.http-client}
+    http = ${app.defaults.http-client}
     retry-delay = 1 minute
     # the maximum batching size, corresponding to the maximum number of Blazegraph documents uploaded on a bulk request.
     # in this window, duplicated persistence ids are discarded
@@ -30,20 +30,9 @@ plugins.composite-views {
   }
   # the minimum allowed value for periodic rebuild strategy
   min-interval-rebuild = 30 minutes
-  blazegraph-batch {
-    # the maximum batching size, corresponding to the maximum number of elements to push to Blazegraph
-    # uploaded on a bulk request.
-    max-elements = 10
-    # the maximum batching duration.
-    max-interval = 3 seconds
-  }
-  elasticsearch-batch {
-    # the maximum batching size, corresponding to the maximum number of Elasticsearch documents
-    # uploaded on a bulk request.
-    max-elements = 10
-    # the maximum batching duration.
-    max-interval = 3 seconds
-  }
   # the interval at which a view will look for requested restarts
   restart-check-interval = 3 seconds
+
+  blazegraph-batch = ${plugins.blazegraph.batch}
+  elasticsearch-batch = ${plugins.elasticsearch.batch}
 }


### PR DESCRIPTION
The composite view plugin will use by default the same batch values as defined in the blazegraph and elasticsearch plugin configurations.

Closes #3815 