### PR TITLE
Introduce aggregations on default views

### DIFF
--- a/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
+++ b/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
@@ -45,4 +45,7 @@ plugins.elasticsearch {
   }
   # the query config used when fetching all scoped events to obtain metrics
   metrics-query = ${app.defaults.query}
+  # when performing aggregations for default views, defines the maximum number
+  # of buckets for the aggregation
+  listing-bucket-size = 500
 }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsQuery.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsQuery.scala
@@ -34,6 +34,8 @@ trait ElasticSearchViewsQuery {
     * Retrieves a list of resources from all the available default elasticsearch views using specific pagination, filter
     * and ordering configuration.
     *
+    * TODO: remove and replace by DefaultViewsQuery
+    *
     * @param pagination
     *   the pagination configuration
     * @param params
@@ -50,6 +52,8 @@ trait ElasticSearchViewsQuery {
   /**
     * Retrieves a list of resources from all the available default elasticsearch views using specific pagination, filter
     * and ordering configuration.
+    *
+    * TODO: remove and replace by DefaultViewsQuery
     *
     * @param schema
     *   the schema where to search
@@ -71,6 +75,8 @@ trait ElasticSearchViewsQuery {
     * Retrieves a list of resources from all the available default elasticsearch views inside the passed ''org'' using
     * specific pagination, filter and ordering configuration.
     *
+    * TODO: remove and replace by DefaultViewsQuery
+    *
     * @param org
     *   the organization
     * @param pagination
@@ -90,6 +96,8 @@ trait ElasticSearchViewsQuery {
   /**
     * Retrieves a list of resources from all the available default elasticsearch views inside the passed ''org'' using
     * specific pagination, filter and ordering configuration.
+    *
+    * TODO: remove and replace by DefaultViewsQuery
     *
     * @param org
     *   the organization
@@ -114,6 +122,8 @@ trait ElasticSearchViewsQuery {
     * Retrieves a list of resources from the default elasticsearch view using specific pagination, filter and ordering
     * configuration.
     *
+    * TODO: remove and replace by DefaultViewsQuery
+    *
     * @param project
     *   the project where to search
     * @param pagination
@@ -133,6 +143,8 @@ trait ElasticSearchViewsQuery {
   /**
     * Retrieves a list of resources from the default elasticsearch view using specific pagination, filter and ordering
     * configuration. It will filter the resources with the passed ''schema''
+    *
+    * TODO: remove and replace by DefaultViewsQuery
     *
     * @param project
     *   the project where to search

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ValidateElasticSearchView.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ValidateElasticSearchView.scala
@@ -27,6 +27,8 @@ trait ValidateElasticSearchView {
 
 object ValidateElasticSearchView {
 
+  val always: ValidateElasticSearchView = (_: UUID, _: Int, _: ElasticSearchViewValue) => IO.unit
+
   def apply(
       validatePipeChain: PipeChain => Either[ProjectionErr, Unit],
       permissions: Permissions,

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/ElasticSearchClient.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/ElasticSearchClient.scala
@@ -21,7 +21,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.ServiceDescr
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.ServiceDescription.ResolvedServiceDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.ResultEntry.{ScoredResultEntry, UnscoredResultEntry}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SearchResults.{ScoredSearchResults, UnscoredSearchResults}
-import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{Pagination, ResultEntry, SearchResults, SortList}
+import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{AggregationResult, Pagination, ResultEntry, SearchResults, SortList}
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Name}
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import com.typesafe.scalalogging.Logger
@@ -491,6 +491,29 @@ class ElasticSearchClient(client: HttpClient, endpoint: Uri, maxIndexPathLength:
   }
 
   /**
+    * Perform an aggregation for the ''query'' inside the given indices
+    *
+    * @param params
+    *   the filter parameters
+    * @param indices
+    *   the indices to use (if empty, searches in all the indices)
+    * @param qp
+    *   the query parameters
+    * @param bucketSize
+    *   the maximum number of terms returned by a term aggregation
+    * @see
+    *   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-size
+    */
+  def aggregate(params: ResourcesSearchParams, indices: Set[String], qp: Query, bucketSize: Int)(implicit
+      base: BaseUri
+  ): HttpResult[AggregationResult] = {
+    val query          = QueryBuilder(params).aggregation(bucketSize)
+    val (indexPath, q) = indexPathAndQuery(indices, query)
+    val searchEndpoint = (endpoint / indexPath / searchPath).withQuery(Uri.Query(defaultQuery ++ qp.toMap))
+    client.fromJsonTo[AggregationResult](Post(searchEndpoint, q.build).withHttpCredentials)
+  }
+
+  /**
     * Refresh the given index
     */
   def refresh(index: IndexLabel): HttpResult[Boolean] =
@@ -585,6 +608,17 @@ object ElasticSearchClient {
         case None           => decodeUnscoredResults
       }
     )
+
+  implicit val aggregationDecoder: Decoder[AggregationResult] =
+    Decoder.decodeJsonObject.emap { obj =>
+      obj.asJson.hcursor
+        .downField("aggregations")
+        .focus
+        .flatMap(_.asObject) match {
+        case Some(obj) => Right(AggregationResult(fetchTotal(obj), obj))
+        case None      => Left("The response did not contain a valid 'aggregations' field.")
+      }
+    }
 
   final private[client] case class Count(value: Long)
   private[client] object Count {

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
@@ -47,6 +47,8 @@ import scala.concurrent.duration._
   *   default values for the view
   * @param metricsQuery
   *   query configuration for the metrics projection
+  * @param listingBucketSize
+  *   the maximum number of terms returned by a term aggregation for listing aggregations
   */
 final case class ElasticSearchViewsConfig(
     base: Uri,
@@ -62,7 +64,8 @@ final case class ElasticSearchViewsConfig(
     syncIndexingRefresh: Refresh,
     maxIndexPathLength: Int,
     defaults: Defaults,
-    metricsQuery: QueryConfig
+    metricsQuery: QueryConfig,
+    listingBucketSize: Int
 )
 
 object ElasticSearchViewsConfig {

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultSearchRequest.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultSearchRequest.scala
@@ -1,0 +1,119 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewRejection.InvalidResourceId
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewRejection, ResourcesSearchParams}
+import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
+import ch.epfl.bluebrain.nexus.delta.sdk.model.IdSegment
+import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{Pagination, SortList}
+import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContext
+import ch.epfl.bluebrain.nexus.delta.sdk.projects.model.{ApiMappings, ProjectBase}
+import ch.epfl.bluebrain.nexus.delta.sourcing.Predicate
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef, ResourceRef}
+import monix.bio.IO
+
+/**
+  * Search request on default elasticsearch views
+  */
+sealed trait DefaultSearchRequest extends Product with Serializable {
+
+  /**
+    * Filter to apply
+    */
+  def params: ResourcesSearchParams
+
+  /**
+    * Pagination to apply
+    */
+  def pagination: Pagination
+
+  /**
+    * Sort to apply
+    */
+  def sort: SortList
+
+  /**
+    * If the search applies to the project/org/root level
+    */
+  def predicate: Predicate
+
+}
+
+object DefaultSearchRequest {
+
+  /**
+    * Search to be performed on a project
+    */
+  case class ProjectSearch(ref: ProjectRef, params: ResourcesSearchParams, pagination: Pagination, sort: SortList)
+      extends DefaultSearchRequest {
+    override def predicate: Predicate = Predicate.Project(ref)
+  }
+
+  object ProjectSearch {
+    def apply(
+        ref: ProjectRef,
+        params: ResourcesSearchParams,
+        pagination: Pagination,
+        sort: SortList,
+        schema: IdSegment
+    )(fetchContext: FetchContext[ElasticSearchViewRejection]): IO[ElasticSearchViewRejection, ProjectSearch] =
+      fetchContext
+        .onRead(ref)
+        .flatMap { context =>
+          expandResourceRef(schema, context.apiMappings, context.base)
+        }
+        .map { schemaRef =>
+          ProjectSearch(ref, params.withSchema(schemaRef), pagination, sort: SortList)
+        }
+  }
+
+  /**
+    * Search to be performed on an org
+    */
+  case class OrgSearch(label: Label, params: ResourcesSearchParams, pagination: Pagination, sort: SortList)
+      extends DefaultSearchRequest {
+    override def predicate: Predicate = Predicate.Org(label)
+  }
+
+  object OrgSearch {
+    def apply(label: Label, params: ResourcesSearchParams, pagination: Pagination, sort: SortList, schema: IdSegment)(
+        fetchContext: FetchContext[ElasticSearchViewRejection]
+    ): IO[ElasticSearchViewRejection, OrgSearch] =
+      expandResourceRef(schema, fetchContext).map { resourceRef =>
+        OrgSearch(label, params.withSchema(resourceRef), pagination, sort)
+      }
+  }
+
+  /**
+    * Search to be performed on all default views
+    */
+  case class RootSearch(params: ResourcesSearchParams, pagination: Pagination, sort: SortList)
+      extends DefaultSearchRequest {
+    override def predicate: Predicate = Predicate.Root
+  }
+
+  object RootSearch {
+    def apply(params: ResourcesSearchParams, pagination: Pagination, sort: SortList, schema: IdSegment)(
+        fetchContext: FetchContext[ElasticSearchViewRejection]
+    ): IO[ElasticSearchViewRejection, RootSearch] =
+      expandResourceRef(schema, fetchContext).map { resourceRef =>
+        RootSearch(params.withSchema(resourceRef), pagination, sort)
+      }
+  }
+
+  private def expandResourceRef(
+      segment: IdSegment,
+      fetchContext: FetchContext[ElasticSearchViewRejection]
+  ): IO[InvalidResourceId, ResourceRef] =
+    expandResourceRef(segment, fetchContext.defaultApiMappings, ProjectBase(iri""))
+
+  private def expandResourceRef(
+      segment: IdSegment,
+      mappings: ApiMappings,
+      base: ProjectBase
+  ): IO[InvalidResourceId, ResourceRef] =
+    IO.fromOption(
+      segment.toIri(mappings, base).map(ResourceRef(_)),
+      InvalidResourceId(segment.asString)
+    )
+
+}

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsQuery.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsQuery.scala
@@ -1,0 +1,99 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import akka.http.scaladsl.model.Uri
+import ch.epfl.bluebrain.nexus.delta.kernel.database.Transactors
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchClient
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.config.ElasticSearchViewsConfig
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.permissions
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.ElasticSearchQueryError.{AuthorizationFailed, ElasticSearchClientError}
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclCheck
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress.{Project => ProjectAcl}
+import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
+import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
+import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{AggregationResult, SearchResults}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.View.IndexingView
+import ch.epfl.bluebrain.nexus.delta.sourcing.Predicate
+import io.circe.JsonObject
+import monix.bio.{IO, UIO}
+
+/**
+  * Allow to list resources from the default elasticsearch views
+  */
+trait DefaultViewsQuery[Result, Aggregate] {
+
+  /**
+    * Retrieves a list of resources from the provided search request
+    */
+  def list(searchRequest: DefaultSearchRequest)(implicit caller: Caller): IO[ElasticSearchQueryError, Result]
+
+  /**
+    * Retrieves aggregations for the provided search request
+    */
+  def aggregate(searchRequest: DefaultSearchRequest)(implicit caller: Caller): IO[ElasticSearchQueryError, Aggregate]
+}
+
+object DefaultViewsQuery {
+
+  type Elasticsearch = DefaultViewsQuery[SearchResults[JsonObject], AggregationResult]
+
+  def apply(
+      aclCheck: AclCheck,
+      client: ElasticSearchClient,
+      config: ElasticSearchViewsConfig,
+      prefix: String,
+      xas: Transactors
+  )(implicit baseUri: BaseUri): DefaultViewsQuery.Elasticsearch = {
+    val defaultViewsStore = DefaultViewsStore(prefix, xas)
+    apply(
+      defaultViewsStore.find,
+      aclCheck,
+      (request: DefaultSearchRequest, views: Set[IndexingView]) =>
+        client
+          .search(request.params, views.map(_.index), Uri.Query.Empty)(request.pagination, request.sort)
+          .mapError(ElasticSearchClientError),
+      (request: DefaultSearchRequest, views: Set[IndexingView]) =>
+        client
+          .aggregate(request.params, views.map(_.index), Uri.Query.Empty, config.listingBucketSize)
+          .mapError(ElasticSearchClientError)
+    )
+  }
+
+  def apply[Result, Aggregate](
+      fetchViews: Predicate => UIO[List[IndexingView]],
+      aclCheck: AclCheck,
+      listAction: (DefaultSearchRequest, Set[IndexingView]) => IO[ElasticSearchQueryError, Result],
+      aggregateAction: (DefaultSearchRequest, Set[IndexingView]) => IO[ElasticSearchQueryError, Aggregate]
+  ): DefaultViewsQuery[Result, Aggregate] = new DefaultViewsQuery[Result, Aggregate] {
+
+    private def filterViews(predicate: Predicate)(implicit caller: Caller) =
+      fetchViews(predicate)
+        .flatMap { allViews =>
+          aclCheck.mapFilter[IndexingView, IndexingView](
+            allViews,
+            v => ProjectAcl(v.ref.project) -> permissions.read,
+            identity
+          )(caller)
+        }
+        .flatMap { views =>
+          IO.raiseWhen(views.isEmpty)(AuthorizationFailed).as(views)
+        }
+
+    override def list(
+        searchRequest: DefaultSearchRequest
+    )(implicit caller: Caller): IO[ElasticSearchQueryError, Result] =
+      filterViews(searchRequest.predicate).flatMap { views =>
+        listAction(searchRequest, views)
+      }
+
+    /**
+      * Retrieves aggregations for from the provided search
+      */
+    override def aggregate(
+        searchRequest: DefaultSearchRequest
+    )(implicit caller: Caller): IO[ElasticSearchQueryError, Aggregate] =
+      filterViews(searchRequest.predicate).flatMap { views =>
+        aggregateAction(searchRequest, views)
+      }
+
+  }
+}

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsStore.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsStore.scala
@@ -1,0 +1,62 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import cats.syntax.all._
+import ch.epfl.bluebrain.nexus.delta.kernel.database.Transactors
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViews
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultViewId, permissions, ElasticSearchViewState}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.View.IndexingView
+import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sourcing.Predicate
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag
+import doobie._
+import doobie.implicits._
+import io.circe.{Decoder, Json}
+import monix.bio.{IO, UIO}
+
+/**
+  * Store to retrieve default elasticsearch views
+  */
+trait DefaultViewsStore {
+
+  /**
+    * Return views at the given predicate
+    */
+  def find(predicate: Predicate): UIO[List[IndexingView]]
+}
+
+object DefaultViewsStore {
+
+  import ch.epfl.bluebrain.nexus.delta.sourcing.implicits._
+
+  private[query] def asIndexingView(prefix: String, state: ElasticSearchViewState) =
+    IndexingView(
+      ViewRef(state.project, state.id),
+      ElasticSearchViews.index(state.uuid, state.indexingRev, prefix).value,
+      // Default views always require the `resources/read` permission
+      permissions.read
+    )
+
+  def apply(prefix: String, xas: Transactors): DefaultViewsStore = {
+    new DefaultViewsStore {
+      implicit val stateDecoder: Decoder[ElasticSearchViewState] = ElasticSearchViewState.serializer.codec
+      def find(predicate: Predicate): UIO[List[IndexingView]]    =
+        (fr"SELECT value FROM scoped_states" ++
+          Fragments.whereAndOpt(
+            Some(fr"type = ${ElasticSearchViews.entityType}"),
+            predicate.asFragment,
+            Some(fr"tag = ${Tag.Latest.value}"),
+            Some(fr"id = $defaultViewId"),
+            Some(fr"deprecated = false")
+          ))
+          .query[Json]
+          .to[List]
+          .transact(xas.read)
+          .flatMap { rows =>
+            rows.traverse { r =>
+              IO.fromEither(r.as[ElasticSearchViewState]).map(asIndexingView(prefix, _))
+            }
+          }
+          .hideErrors
+    }
+  }
+}

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/ElasticSearchQueryError.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/ElasticSearchQueryError.scala
@@ -1,0 +1,54 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import akka.http.scaladsl.model.StatusCodes
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClassUtils
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
+import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError
+import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.HttpResponseFields
+import io.circe.syntax.KeyOps
+import io.circe.{Encoder, JsonObject}
+
+/**
+  * Enumeration of errors raised while querying the Elasticsearch indices
+  */
+sealed abstract class ElasticSearchQueryError(val reason: String) extends Product with Serializable
+
+object ElasticSearchQueryError {
+
+  /**
+    * Error returned when attempting to query an Elasticsearch view and the caller does not have the right permissions
+    * defined in the view.
+    */
+  final case object AuthorizationFailed extends ElasticSearchQueryError(ServiceError.AuthorizationFailed.reason)
+
+  type AuthorizationFailed = AuthorizationFailed.type
+
+  /**
+    * Error returned when interacting with the elasticserch client
+    */
+  final case class ElasticSearchClientError(error: HttpClientError)
+      extends ElasticSearchQueryError("Error while interacting with the underlying ElasticSearch index")
+
+  /**
+    * Rejection returned when attempting to interact with a resource providing an id that cannot be resolved to an Iri.
+    *
+    * @param id
+    *   the resource identifier
+    */
+  final case class InvalidResourceId(id: String)
+      extends ElasticSearchQueryError(s"Resource identifier '$id' cannot be expanded to an Iri.")
+
+  implicit val elasticSearchQueryErrorEncoder: Encoder.AsObject[ElasticSearchQueryError] =
+    Encoder.AsObject.instance { r =>
+      JsonObject(keywords.tpe := ClassUtils.simpleName(r), "reason" := r.reason)
+    }
+
+  implicit val elasticSearchViewRejectionHttpResponseFields: HttpResponseFields[ElasticSearchQueryError] =
+    HttpResponseFields {
+      case AuthorizationFailed             => StatusCodes.Forbidden
+      case ElasticSearchClientError(error) => error.errorCode.getOrElse(StatusCodes.InternalServerError)
+      case InvalidResourceId(_)            => StatusCodes.BadRequest
+    }
+
+}

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchScopeInitializationSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchScopeInitializationSpec.scala
@@ -59,7 +59,7 @@ class ElasticSearchScopeInitializationSpec
   private lazy val views: ElasticSearchViews = ElasticSearchViews(
     fetchContext,
     ResolverContextResolution(rcr),
-    alwaysValidate,
+    ValidateElasticSearchView.always,
     eventLogConfig,
     "prefix",
     xas

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewGen.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewGen.scala
@@ -14,7 +14,7 @@ import java.util.UUID
 
 object ElasticSearchViewGen {
 
-  def resourceFor(
+  def stateFor(
       id: Iri,
       project: ProjectRef,
       value: ElasticSearchViewValue,
@@ -25,10 +25,8 @@ object ElasticSearchViewGen {
       deprecated: Boolean = false,
       tags: Tags = Tags.empty,
       createdBy: Subject = Anonymous,
-      updatedBy: Subject = Anonymous,
-      am: ApiMappings = ApiMappings.empty,
-      base: Iri = nxv.base
-  ): ViewResource =
+      updatedBy: Subject = Anonymous
+  ): ElasticSearchViewState =
     ElasticSearchViewState(
       id,
       project,
@@ -44,5 +42,33 @@ object ElasticSearchViewGen {
       Instant.EPOCH,
       updatedBy
     )
-      .toResource(am, ProjectBase.unsafe(base), JsonObject.empty, JsonObject.empty)
+
+  def resourceFor(
+      id: Iri,
+      project: ProjectRef,
+      value: ElasticSearchViewValue,
+      uuid: UUID = UUID.randomUUID(),
+      source: Json = Json.obj(),
+      rev: Int = 1,
+      indexingRev: Int = 1,
+      deprecated: Boolean = false,
+      tags: Tags = Tags.empty,
+      createdBy: Subject = Anonymous,
+      updatedBy: Subject = Anonymous,
+      am: ApiMappings = ApiMappings.empty,
+      base: Iri = nxv.base
+  ): ViewResource =
+    stateFor(
+      id,
+      project,
+      value,
+      uuid,
+      source,
+      rev,
+      indexingRev,
+      deprecated,
+      tags,
+      createdBy,
+      updatedBy
+    ).toResource(am, ProjectBase.unsafe(base), JsonObject.empty, JsonObject.empty)
 }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewSTMSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewSTMSpec.scala
@@ -95,7 +95,7 @@ class ElasticSearchViewSTMSpec
         updatedBy
       )
 
-    val eval = evaluate(alwaysValidate)(_, _)
+    val eval = evaluate(ValidateElasticSearchView.always)(_, _)
 
     "evaluating the CreateElasticSearchView command" should {
       "emit an ElasticSearchViewCreated for an IndexingElasticSearchViewValue" in {

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/Fixtures.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/Fixtures.scala
@@ -1,22 +1,17 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 
 import cats.syntax.all._
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.contexts
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.contexts.{elasticsearch, elasticsearchMetadata}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts, ElasticSearchViewValue}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ReferenceRegistry
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.pipes._
-import monix.bio.IO
-
-import java.util.UUID
 
 trait Fixtures {
   implicit private val cl: ClassLoader = getClass.getClassLoader
-
-  def alwaysValidate: ValidateElasticSearchView = (_: UUID, _: Int, _: ElasticSearchViewValue) => IO.unit
 
   private val listingsMetadataCtx =
     List(

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewSearchSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewSearchSuite.scala
@@ -1,0 +1,253 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import akka.http.scaladsl.model.Uri
+import cats.syntax.all._
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.{ElasticSearchBulk, IndexLabel}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ResourcesSearchParams
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ResourcesSearchParams.Type.{ExcludedType, IncludedType}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.DefaultViewSearchSuite.Sample
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchClientSetup, Fixtures}
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.sdk.DataResource
+import ch.epfl.bluebrain.nexus.delta.sdk.generators.ResourceGen
+import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
+import ch.epfl.bluebrain.nexus.delta.sdk.model.search.Pagination.FromPagination
+import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{Pagination, SearchResults, SortList, TimeRange}
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Subject, User}
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef, ResourceRef}
+import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
+import ch.epfl.bluebrain.nexus.testkit.{CirceLiteral, TestHelpers}
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Json, JsonObject}
+import monix.bio.UIO
+import munit.{AnyFixture, Location}
+
+import java.time.Instant
+
+class DefaultViewSearchSuite
+    extends BioSuite
+    with ElasticSearchClientSetup.Fixture
+    with TestHelpers
+    with CirceLiteral
+    with Fixtures {
+  override def munitFixtures: Seq[AnyFixture[_]] = List(esClient)
+
+  private lazy val client = esClient()
+
+  implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
+
+  // Resources are indexed in every view
+  private def epochPlus(plus: Long) = Instant.EPOCH.plusSeconds(plus)
+  private val realm                 = Label.unsafe("myrealm")
+  private val alice                 = User("Alice", realm)
+
+  private val orgType                 = nxv + "Organization"
+  private val orgSchema               = ResourceRef.Latest(nxv + "org")
+  private val bbp                     =
+    Sample(
+      "bbp",
+      Set(orgType),
+      2,
+      deprecated = false,
+      orgSchema,
+      createdAt = epochPlus(5L),
+      updatedAt = epochPlus(10L),
+      createdBy = alice
+    )
+  private val epfl                    =
+    Sample(
+      "epfl",
+      Set(orgType),
+      1,
+      deprecated = false,
+      orgSchema,
+      createdAt = epochPlus(10L),
+      updatedAt = epochPlus(10L),
+      updatedBy = alice
+    )
+  private val datasetSchema           = ResourceRef.Latest(nxv + "dataset")
+  private val traceTypes              = Set(nxv + "Dataset", nxv + "Trace")
+  private val trace                   = Sample(
+    "trace",
+    traceTypes,
+    3,
+    deprecated = false,
+    datasetSchema,
+    createdAt = epochPlus(15L),
+    updatedAt = epochPlus(30L)
+  )
+  private val cellTypes               = Set(nxv + "Dataset", nxv + "Cell")
+  private val cell                    =
+    Sample(
+      "cell",
+      cellTypes,
+      3,
+      deprecated = true,
+      datasetSchema,
+      createdAt = epochPlus(20L),
+      updatedAt = epochPlus(40L),
+      createdBy = alice
+    )
+  private val orgs                    = List(bbp, epfl)
+  private val deprecated              = List(cell)
+  private val createdByAlice          = List(bbp, cell)
+  private val createdBetween_8_and_16 = List(epfl, trace)
+  private val createdAfter_11         = List(trace, cell)
+  private val updatedBefore_12        = List(bbp, epfl)
+  private val updatedByAlice          = List(epfl)
+  private val allResources            = List(bbp, epfl, trace, cell)
+
+  private val defaultIndex = IndexLabel.unsafe("default_index")
+
+  object Ids {
+
+    /**
+      * Extract ids from documents from an Elasticsearch search raw response
+      */
+    def extractAll(json: Json)(implicit loc: Location): Seq[Iri] = {
+      for {
+        hits    <- json.hcursor.downField("hits").get[Vector[Json]]("hits")
+        sources <- hits.traverse(_.hcursor.get[Json]("_source"))
+        ids      = extract(sources)
+      } yield ids
+    }.rightValue
+
+    /**
+      * Extract ids from documents from results from [[SearchResults]]
+      */
+    def extractAll(results: SearchResults[JsonObject])(implicit loc: Location): Seq[Iri] =
+      extract(results.sources.map(_.asJson))
+
+    def extract(results: Seq[Json])(implicit loc: Location): Seq[Iri] =
+      results.traverse(extract).rightValue
+
+    def extract(json: Json): Decoder.Result[Iri] = json.hcursor.get[Iri]("@id")
+  }
+
+  private def search(params: ResourcesSearchParams) =
+    paginatedSearch(params, Pagination.FromPagination(0, 100), SortList.byCreationDateAndId)
+
+  private def paginatedSearch(params: ResourcesSearchParams, pagination: Pagination, sort: SortList) =
+    client
+      .search(params, Set(defaultIndex.value), Uri.Query.Empty)(pagination, sort)
+
+  private def aggregate(params: ResourcesSearchParams) =
+    client.aggregate(params, Set(defaultIndex.value), Uri.Query.Empty, 100)
+
+  test("Create the index and populate it ") {
+    val defaultMapping  = jsonObjectContentOf("defaults/default-mapping.json")
+    val defaultSettings = jsonObjectContentOf("defaults/default-settings.json")
+    for {
+      _    <- client.createIndex(defaultIndex, Some(defaultMapping), Some(defaultSettings))
+      bulk <- allResources.traverse { r =>
+                r.asDocument.map { d =>
+                  // We create a unique id across all indices
+                  ElasticSearchBulk.Index(defaultIndex, genString(), d)
+                }
+              }
+      _    <- client.bulk(bulk)
+      // We refresh explicitly
+      _    <- client.refresh(defaultIndex)
+    } yield ()
+  }
+
+  private val all                       = ResourcesSearchParams()
+  private val orgByType                 = ResourcesSearchParams(types = List(IncludedType(orgType)))
+  private val orgBySchema               = ResourcesSearchParams(schema = Some(orgSchema))
+  private val excludeDatasetType        = ResourcesSearchParams(types = List(ExcludedType(nxv + "Dataset")))
+  private val byDeprecated              = ResourcesSearchParams(deprecated = Some(true))
+  private val byCreated                 = ResourcesSearchParams(createdBy = Some(alice))
+  private val between_8_and_16          = TimeRange.Between.unsafe(epochPlus(8L), epochPlus(16))
+  private val byCreatedBetween_8_and_16 = ResourcesSearchParams(createdAt = between_8_and_16)
+  private val byCreatedAfter_11         = ResourcesSearchParams(createdAt = TimeRange.After(epochPlus(11L)))
+  private val byUpdated                 = ResourcesSearchParams(updatedBy = Some(alice))
+  private val byUpdated_Before_12       = ResourcesSearchParams(updatedAt = TimeRange.Before(epochPlus(12L)))
+
+  private val bbpResource    = bbp.asResourceF
+  private val byId           = ResourcesSearchParams(id = Some(bbpResource.id))
+  private val byLocatingId   = ResourcesSearchParams(locate = Some(bbpResource.id))
+  private val byLocatingSelf = ResourcesSearchParams(locate = Some(bbpResource.self))
+
+  // Action / params / matching resources
+  List(
+    ("all resources", all, allResources),
+    ("org resources by type", orgByType, orgs),
+    ("org resources by schema", orgBySchema, orgs),
+    ("all resources but the ones with 'Dataset' type", excludeDatasetType, orgs),
+    ("deprecated resources", byDeprecated, deprecated),
+    ("resources created by Alice", byCreated, createdByAlice),
+    ("resources created between 8 and 16", byCreatedBetween_8_and_16, createdBetween_8_and_16),
+    ("resources created after 11", byCreatedAfter_11, createdAfter_11),
+    ("resources updated by Alice", byUpdated, updatedByAlice),
+    ("resources updated before 12", byUpdated_Before_12, updatedBefore_12),
+    (s"resources with id ${bbpResource.id}", byId, List(bbp)),
+    (s"resources by locating id ${bbpResource.id}", byLocatingId, List(bbp)),
+    (s"resources by locating self ${bbpResource.self}", byLocatingSelf, List(bbp))
+  ).foreach { case (testName, params, expected) =>
+    test(s"Search: $testName") {
+      search(params).map(Ids.extractAll).assert(expected.map(_.id))
+    }
+  }
+
+  test("Apply pagination") {
+    val twoPerPage = FromPagination(0, 2)
+    val params     = ResourcesSearchParams()
+
+    for {
+      results <- paginatedSearch(params, twoPerPage, SortList.byCreationDateAndId)
+      _        = assertEquals(results.total, 4L)
+      _        = assertEquals(results.sources.size, 2)
+      // Token from Elasticsearch to fetch the next page
+      epflId   = epfl.asResourceF.id
+      _        = assertEquals(results.token, Some(s"""[10000,"$epflId"]"""))
+    } yield ()
+  }
+
+  test("Aggregate tests") {
+    // TODO create aggregate tests
+    aggregate(all)
+    //.assert(AggregationResult(JsonObject.empty))
+  }
+}
+
+object DefaultViewSearchSuite {
+
+  private val project = ProjectRef.unsafe("org", "proj")
+
+  final private case class Sample(
+      suffix: String,
+      types: Set[Iri],
+      rev: Int,
+      deprecated: Boolean,
+      schema: ResourceRef,
+      createdAt: Instant,
+      updatedAt: Instant,
+      createdBy: Subject = Anonymous,
+      updatedBy: Subject = Anonymous
+  ) {
+
+    def id: Iri = nxv + suffix
+
+    def asResourceF(implicit rcr: RemoteContextResolution): DataResource = {
+      val resource = ResourceGen.resource(id, project, Json.obj())
+      ResourceGen
+        .resourceFor(resource, types = types, rev = rev, deprecated = deprecated)
+        .copy(
+          createdAt = createdAt,
+          createdBy = createdBy,
+          updatedAt = updatedAt,
+          updatedBy = updatedBy,
+          schema = schema
+        )
+    }
+
+    def asDocument(implicit baseUri: BaseUri, rcr: RemoteContextResolution, jsonldApi: JsonLdApi): UIO[Json] =
+      asResourceF.toCompactedJsonLd.map(_.json).hideErrors
+
+  }
+
+}

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsQuerySuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsQuerySuite.scala
@@ -1,0 +1,128 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultViewId, permissions, ResourcesSearchParams}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.DefaultSearchRequest.{OrgSearch, ProjectSearch, RootSearch}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.ElasticSearchQueryError.AuthorizationFailed
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
+import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
+import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{Pagination, SortList}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.View.IndexingView
+import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sourcing.Predicate
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Group, User}
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef}
+import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
+import monix.bio.UIO
+
+class DefaultViewsQuerySuite extends BioSuite {
+
+  private val realm           = Label.unsafe("myrealm")
+  private val alice: Caller   = Caller(User("Alice", realm), Set(User("Alice", realm), Group("users", realm)))
+  private val bob: Caller     = Caller(User("Bob", realm), Set(User("Bob", realm), Group("users", realm)))
+  private val charlie: Caller = Caller(User("Charlie", realm), Set(User("Charlie", realm), Group("users", realm)))
+  private val anon: Caller    = Caller(Anonymous, Set(Anonymous))
+
+  private val org = Label.unsafe("org")
+
+  private val project1    = ProjectRef(org, Label.unsafe("proj"))
+  private val defaultView = ViewRef(project1, defaultViewId)
+
+  private val project2     = ProjectRef(org, Label.unsafe("proj2"))
+  private val defaultView2 = ViewRef(project2, defaultViewId)
+
+  private val org2         = Label.unsafe("org2")
+  private val project3     = ProjectRef(org2, Label.unsafe("proj3"))
+  private val defaultView3 = ViewRef(project3, defaultViewId)
+
+  private val aclCheck = AclSimpleCheck.unsafe(
+    // Bob has full access
+    (bob.subject, AclAddress.Root, Set(permissions.read)),
+    // Alice has full access to all resources in org
+    (alice.subject, AclAddress.Organization(org), Set(permissions.read)),
+    // Charlie has access to resources in project1
+    (charlie.subject, AclAddress.Project(project1), Set(permissions.read))
+  )
+
+  private def fetchViews(predicate: Predicate) = UIO.pure {
+    val viewRefs = predicate match {
+      case Predicate.Root             => List(defaultView, defaultView2, defaultView3)
+      case Predicate.Org(`org`)       => List(defaultView, defaultView2)
+      case Predicate.Org(`org2`)      => List(defaultView3)
+      case Predicate.Org(_)           => List.empty
+      case Predicate.Project(project) => List(ViewRef(project, defaultViewId))
+    }
+    viewRefs.map { ref =>
+      IndexingView(ref, "index", permissions.read)
+    }
+  }
+
+  private def action(views: Set[IndexingView]): UIO[List[ViewRef]] =
+    UIO.pure {
+      views.toList.map { v => v.ref }
+    }
+
+  private val defaultViewsQuery: DefaultViewsQuery[List[ViewRef], List[ViewRef]] = DefaultViewsQuery(
+    fetchViews,
+    aclCheck,
+    (_: DefaultSearchRequest, views: Set[IndexingView]) => action(views),
+    (_: DefaultSearchRequest, views: Set[IndexingView]) => action(views)
+  )
+
+  private val project1Search = ProjectSearch(project1, ResourcesSearchParams(), Pagination.OnePage, SortList.empty)
+  private val project2Search = ProjectSearch(project2, ResourcesSearchParams(), Pagination.OnePage, SortList.empty)
+  private val org1Search     = OrgSearch(org, ResourcesSearchParams(), Pagination.OnePage, SortList.empty)
+  private val rootSearch     = RootSearch(ResourcesSearchParams(), Pagination.OnePage, SortList.empty)
+
+  test(s"List default view for '$project1' a user with full access") {
+    defaultViewsQuery.list(project1Search)(bob).assert(List(defaultView))
+  }
+
+  test(s"List all default views in '$org' a user with full access") {
+    defaultViewsQuery.list(org1Search)(bob).assert(List(defaultView, defaultView2))
+  }
+
+  test(s"List all default views in 'root' for a user with full access") {
+    defaultViewsQuery.list(rootSearch)(bob).assert(List(defaultView, defaultView2, defaultView3))
+  }
+
+  test(s"List default view for for '$project1' for a user with limited access on '$org'") {
+    defaultViewsQuery.list(project1Search)(alice).assert(List(defaultView))
+  }
+
+  test(s"List all default views in '$org' for a user with limited access on '$org'") {
+    defaultViewsQuery.list(org1Search)(alice).assert(List(defaultView, defaultView2))
+  }
+
+  test(s"List only '$org' default views on 'root' in for a user with limited access on '$org'") {
+    defaultViewsQuery.list(rootSearch)(alice).assert(List(defaultView, defaultView2))
+  }
+
+  test(s"List default view for '$project1' for a user with limited access on '$project1'") {
+    defaultViewsQuery.list(project1Search)(charlie).assert(List(defaultView))
+  }
+
+  test(s"Raise an error for $project2 for a user with limited access on '$project1'") {
+    defaultViewsQuery.list(project2Search)(charlie).error(AuthorizationFailed)
+  }
+
+  test(s"List only '$project1' default view in '$org' for a user with limited access on '$project1'") {
+    defaultViewsQuery.list(org1Search)(charlie).assert(List(defaultView))
+  }
+
+  test(s"List only '$project1' default view in 'root' for a user with limited access on '$project1'") {
+    defaultViewsQuery.list(rootSearch)(charlie).assert(List(defaultView))
+  }
+
+  test(s"Raise an error for $project1 for Anonymous") {
+    defaultViewsQuery.list(project1Search)(anon).error(AuthorizationFailed)
+  }
+
+  test(s"Raise an error for $org for Anonymous") {
+    defaultViewsQuery.list(org1Search)(anon).error(AuthorizationFailed)
+  }
+
+  test(s"Raise an error for root for Anonymous") {
+    defaultViewsQuery.list(rootSearch)(anon).error(AuthorizationFailed)
+  }
+}

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsStoreSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsStoreSuite.scala
@@ -1,0 +1,102 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
+
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.IndexingElasticSearchViewValue
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultViewId, permissions, ElasticSearchViewState}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViewGen, ElasticSearchViews}
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.sdk.views.View.IndexingView
+import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sourcing.Predicate
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef, Tag}
+import ch.epfl.bluebrain.nexus.delta.sourcing.state.ScopedStateStoreFixture
+import ch.epfl.bluebrain.nexus.testkit.bio.{BioSuite, ResourceFixture}
+import munit.AnyFixture
+
+import java.util.UUID
+
+class DefaultViewsStoreSuite extends BioSuite {
+
+  override def munitFixtures: Seq[AnyFixture[_]] = List(defaultViewsStore)
+
+  private val org  = Label.unsafe("org")
+  private val org2 = Label.unsafe("org2")
+
+  private val project1         = ProjectRef(org, Label.unsafe("proj1"))
+  private val defaultView1     = ViewRef(project1, defaultViewId)
+  private val defaultView1Uuid = UUID.randomUUID()
+
+  private val project2         = ProjectRef(org, Label.unsafe("proj2"))
+  private val defaultView2     = ViewRef(project2, defaultViewId)
+  private val defaultView2Uuid = UUID.randomUUID()
+
+  private val project3         = ProjectRef(org2, Label.unsafe("proj3"))
+  private val defaultView3     = ViewRef(project3, defaultViewId)
+  private val defaultView3Uuid = UUID.randomUUID()
+
+  private val project4              = ProjectRef(org, Label.unsafe("proj4"))
+  private val deprecatedDefaultView = ViewRef(project4, defaultViewId)
+  private val customView            = ViewRef(project4, nxv + "my-view")
+
+  private val elasticsearchPrefix = "test"
+
+  def createView(ref: ViewRef, uuid: UUID = UUID.randomUUID(), deprecated: Boolean = false): ElasticSearchViewState =
+    ElasticSearchViewGen.stateFor(
+      ref.viewId,
+      ref.project,
+      IndexingElasticSearchViewValue(None, None),
+      uuid = uuid,
+      deprecated = deprecated
+    )
+
+  val defaultViewsStore: ResourceFixture.TaskFixture[DefaultViewsStore] = {
+
+    val tag = Tag.UserTag.unsafe("my-tag")
+
+    val views = List(
+      createView(defaultView1, defaultView1Uuid),
+      createView(defaultView2, defaultView2Uuid),
+      createView(defaultView3, defaultView3Uuid),
+      createView(deprecatedDefaultView, deprecated = true),
+      createView(customView)
+    )
+
+    ResourceFixture.suiteLocal(
+      "viewsStore",
+      ScopedStateStoreFixture
+        .store(
+          ElasticSearchViews.entityType,
+          ElasticSearchViewState.serializer
+        )(saveLatest = views, saveTagged = views.map(tag -> _))
+        .map { case (xas, _) =>
+          DefaultViewsStore(elasticsearchPrefix, xas)
+        }
+    )
+  }
+
+  private lazy val viewStore = defaultViewsStore()
+
+  private def findDefaultRefs(predicate: Predicate) =
+    viewStore.find(predicate).map(_.map(_.ref))
+
+  test("Construct indexing view correctly") {
+    assertEquals(
+      DefaultViewsStore.asIndexingView(
+        elasticsearchPrefix,
+        createView(defaultView1, defaultView1Uuid)
+      ),
+      IndexingView(defaultView1, s"test_${defaultView1Uuid}_1", permissions.read)
+    )
+  }
+
+  test(s"Get non-deprecated default views in '$project1'") {
+    findDefaultRefs(Predicate.Project(project1)).assert(List(defaultView1))
+  }
+
+  test(s"Get non-deprecated default views in '$org'") {
+    findDefaultRefs(Predicate.Org(org)).assert(List(defaultView1, defaultView2))
+  }
+
+  test(s"Get non-deprecated in all orgs") {
+    findDefaultRefs(Predicate.Root).assert(List(defaultView1, defaultView2, defaultView3))
+  }
+}

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/search/AggregationResult.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/model/search/AggregationResult.scala
@@ -1,0 +1,12 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.model.search
+
+import io.circe.JsonObject
+
+/**
+  * Defines the aggregation result
+  * @param total
+  *   the total number of results
+  * @param value
+  *   the value of the aggregations field in the elasticsearch response
+  */
+final case class AggregationResult(total: Long, value: JsonObject)

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/acls/AclSimpleCheck.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/acls/AclSimpleCheck.scala
@@ -7,6 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity
 import ch.epfl.bluebrain.nexus.testkit.IORef
 import monix.bio.{IO, UIO}
+import monix.execution.Scheduler
 
 /**
   * In-memory implementation of an [[AclCheck]]
@@ -55,5 +56,8 @@ object AclSimpleCheck {
           checker append (address, (subject, permissions))
         }
     }
+
+  def unsafe(input: (Identity, AclAddress, Set[Permission])*)(implicit s: Scheduler) =
+    apply(input: _*).runSyncUnsafe()
 
 }

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/state/ScopedStateStoreFixture.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/state/ScopedStateStoreFixture.scala
@@ -1,0 +1,33 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing.state
+
+import cats.effect.Resource
+import cats.syntax.all._
+import ch.epfl.bluebrain.nexus.delta.kernel.database.Transactors
+import ch.epfl.bluebrain.nexus.delta.sourcing.Serializer
+import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.EntityType
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
+import ch.epfl.bluebrain.nexus.delta.sourcing.query.RefreshStrategy
+import ch.epfl.bluebrain.nexus.delta.sourcing.state.State.ScopedState
+import ch.epfl.bluebrain.nexus.testkit.postgres.Doobie
+import doobie.implicits._
+import monix.bio.Task
+
+object ScopedStateStoreFixture {
+
+  private val queryConfig = QueryConfig(5, RefreshStrategy.Stop)
+
+  def store[Id, S <: ScopedState](
+      tpe: EntityType,
+      serializer: Serializer[Id, S]
+  )(saveLatest: List[S], saveTagged: List[(UserTag, S)]): Resource[Task, (Transactors, ScopedStateStore[Id, S])] =
+    Doobie.resource()(getClass.getClassLoader).evalMap { xas =>
+      val stateStore = ScopedStateStore(tpe, serializer, queryConfig, xas)
+      (
+        saveLatest.traverse(stateStore.unsafeSave) >>
+          saveTagged.traverse { case (tag, s) => stateStore.unsafeSave(s, tag) }
+      ).transact(xas.write).as {
+        (xas, stateStore)
+      }
+    }
+}

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/DoobieScalaTestFixture.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/DoobieScalaTestFixture.scala
@@ -16,8 +16,8 @@ trait DoobieScalaTestFixture
 
   implicit private val classLoader: ClassLoader = getClass.getClassLoader
 
-  var xas: Transactors                        = _
-  private var translactorTeardown: Task[Unit] = _
+  var xas: Transactors                       = _
+  private var transactorTeardown: Task[Unit] = _
 
   override def beforeAll(): Unit = {
     implicit val s: Scheduler   = Scheduler.global
@@ -28,12 +28,12 @@ trait DoobieScalaTestFixture
       .runSyncUnsafe()
     (transactors.execDDL("/scripts/drop-tables.ddl") >> transactors.execDDL("/scripts/schema.ddl")).runSyncUnsafe()
     xas = transactors
-    translactorTeardown = teardown
+    transactorTeardown = teardown
   }
 
   override def afterAll(): Unit = {
     implicit val s: Scheduler = Scheduler.global
-    translactorTeardown.runSyncUnsafe()
+    transactorTeardown.runSyncUnsafe()
     super.afterAll()
   }
 

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ArchiveSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ArchiveSpec.scala
@@ -148,20 +148,20 @@ class ArchiveSpec extends BaseSpec with ArchiveHelpers with CirceEq {
     }
 
     "fail on wrong path" in {
-      val wrong1 = jsonContentOf(s"/kg/archives/archive-wrong-path1.json")
+      val wrong1    = jsonContentOf(s"/kg/archives/archive-wrong-path1.json")
       val expected1 = jsonContentOf("/kg/archives/archive-path-invalid1.json")
 
       for {
-        _ <- deltaClient.put[Json](s"/archives/$fullId/archive2", wrong1, Tweety) { (json, response) =>
-          json shouldEqual expected1
-          response.status shouldEqual StatusCodes.BadRequest
-        }
-        wrong2 = jsonContentOf(s"/kg/archives/archive-wrong-path2.json")
+        _        <- deltaClient.put[Json](s"/archives/$fullId/archive2", wrong1, Tweety) { (json, response) =>
+                      json shouldEqual expected1
+                      response.status shouldEqual StatusCodes.BadRequest
+                    }
+        wrong2    = jsonContentOf(s"/kg/archives/archive-wrong-path2.json")
         expected2 = jsonContentOf("/kg/archives/archive-path-invalid2.json")
-        _ <- deltaClient.put[Json](s"/archives/$fullId/archive2", wrong2, Tweety) { (json, response) =>
-          json shouldEqual expected2
-          response.status shouldEqual StatusCodes.BadRequest
-        }
+        _        <- deltaClient.put[Json](s"/archives/$fullId/archive2", wrong2, Tweety) { (json, response) =>
+                      json shouldEqual expected2
+                      response.status shouldEqual StatusCodes.BadRequest
+                    }
       } yield succeed
     }
 


### PR DESCRIPTION
This PR include a start about introducing aggregations on default views in the listing operations.

A lot of things are WIP especially on the naming.

One of the purposes here is also to break `ElasticSearchViewsQuery` that does a lot of things:
* Listing operations on default views
* "Free search query" on all views
* Expand the schema reference to inject it in the params

Another one is to make things more modular by  having a store dedicated for default views, to avoid having a default dependency to ES when we can avoid it, and to expand the schema reference before submitting a search.

There is also a change of behaviour when performing a change at the org and root level: if a user has not access to a single view, a authorization error will be raised (instead of returning an empty result). 
The idea is to make it more consistent with the project level where it is already the case

TODO:
* Create tests for the aggregations themselves
* Replace `ElasticsearchViewsQuery` operations related to listing by `DefaultViewsQuery` in `ElasticsearchRoutes`
* Handle the expansion of the resource ref of the schema in the routes before passing it on to `DefaultViewsQuery`
* Delete the list methods of `ElasticSearchViewsQuery`
* In the Elasticsearch routes, remove the check when perfoming a search at the project level (it is handled by `DefaultViewsQuery` so that the ACL logic is now performed in one single place instead of 2)
* One option to explore may be to split `ElasticsearchRoutes` in 2:  one for the query operations, the other for the rest