### PR TITLE
Add scheduled GitHub Action for external link validation

### DIFF
--- a/.github/workflows/ci-docs-ext-links.yml
+++ b/.github/workflows/ci-docs-ext-links.yml
@@ -1,0 +1,14 @@
+name: Docs External Links Validation
+on:
+  schedule:
+    - cron: 0 0 * * SUN
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Review
+        run: sbt "project docs" clean scalafmtCheck scalafmtSbtCheck paradox paradoxValidateLinks

--- a/.github/workflows/ci-docs-ext-links.yml
+++ b/.github/workflows/ci-docs-ext-links.yml
@@ -2,6 +2,7 @@ name: Docs External Links Validation
 on:
   schedule:
     - cron: 0 0 * * SUN
+  workflow_dispatch:
 
 jobs:
   review:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Review
-        run: sbt "project docs" clean scalafmtCheck scalafmtSbtCheck paradox paradoxValidateLinks
+        run: sbt "project docs" clean scalafmtCheck scalafmtSbtCheck paradox paradoxValidateInternalLinks


### PR DESCRIPTION
* The `ci-docs.yml` pipeline will only validate internal links.
* The `ci-docs-ext-links.yml`
    * Will validate external links and run on a weekly basis
    * Can be triggered manually
    * Will send a notification to the person that has created the action, or to the last person who edited the cron syntax.