### PR TITLE
Add possibility to disable indexing via configuration

### DIFF
--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -28,7 +28,7 @@ app {
     # Access to database for streaming access (indexing / SSEs)
     streaming = ${app.defaults.database.access}
 
-    name     = ${app.defaults.database.name}
+    name = ${app.defaults.database.name}
     username = ${app.defaults.database.username}
     password = ${app.defaults.database.password}
 
@@ -170,7 +170,7 @@ app {
 
   # Projects configuration
   projects {
-     # the projects event-log configuration
+    # the projects event-log configuration
     event-log = ${app.defaults.event-log}
     # the projects pagination config
     pagination = ${app.defaults.pagination}
@@ -230,10 +230,10 @@ app {
     events = 2000
     # custom quotas for certain projects
     custom {
-    #  "myorg/myproject" {
-    #    resources = 2000
-    #    events = 4000
-    #  }
+      #  "myorg/myproject" {
+      #    resources = 2000
+      #    events = 4000
+      #  }
     }
   }
 
@@ -293,7 +293,7 @@ app {
       # the maximum batching size, corresponding to the maximum number of elements
       # processed before saving the progress.
       max-elements = 30
-       # the maximum batching duration.
+      # the maximum batching duration.
       max-interval = 5 seconds
     }
     retry = ${app.defaults.constant-retry-strategy}
@@ -326,7 +326,7 @@ app {
 
     # default event log configuration
     event-log {
-      query-config =  ${app.defaults.query}
+      query-config = ${app.defaults.query}
       max-duration = 14 seconds
     }
 
@@ -360,6 +360,8 @@ app {
     indexing {
       # default prefix to use when creating indices
       prefix = "delta"
+      # disable all indexing
+      disable = false
     }
 
     # default retry strategy, possible value formats are defined at the following config path:

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/Main.scala
@@ -56,7 +56,7 @@ object Main extends BIOApp {
       (cfg, config, cl, pluginDefs) <- Resource.eval(loadPluginsAndConfig(loaderConfig))
       _                             <- Resource.eval(KamonMonitoring.initialize(config))
       modules                        = DeltaModule(cfg, config, cl)
-      (plugins, locator)            <- WiringInitializer(modules, pluginDefs)
+      (plugins, locator)            <- WiringInitializer(modules, pluginDefs, config)
       _                             <- bootstrap(locator, plugins)
     } yield locator
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/MainSuite.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/MainSuite.scala
@@ -39,7 +39,7 @@ class MainSuite extends BioSuite with MainSuite.Fixture {
   test("yield a correct plan") {
     val (cfg, config, cl, pDefs) = Main.loadPluginsAndConfig(pluginLoaderConfig).runSyncUnsafe()
     val pluginsInfoModule        = new ModuleDef { make[List[PluginDef]].from(pDefs) }
-    val modules: Module          = (DeltaModule(cfg, config, cl) :: pluginsInfoModule :: pDefs.map(_.module)).merge
+    val modules: Module          = (DeltaModule(cfg, config, cl) :: pluginsInfoModule :: pDefs.map(_.module(config))).merge
 
     PlanVerifier()
       .verify[Task](

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugin/PluginLoaderSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugin/PluginLoaderSpec.scala
@@ -1,6 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.plugin
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.epfl.bluebrain.nexus.delta.config.AppConfig
 import ch.epfl.bluebrain.nexus.delta.plugin.PluginsLoader.PluginLoaderConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.PriorityRoute
 import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
@@ -23,9 +24,10 @@ class PluginLoaderSpec extends AnyWordSpecLike with ScalatestRouteTest with Matc
 
   "A PluginLoader" should {
     val config = PluginLoaderConfig("../plugins/test-plugin/target")
+    val (_, appConfig) = AppConfig.load().accepted
     "load plugins from .jar in a directory" in {
       val (_, pluginsDef) = PluginsLoader(config).load.accepted
-      WiringInitializer(serviceModule, pluginsDef).use { case (_, locator) =>
+      WiringInitializer(serviceModule, pluginsDef, appConfig).use { case (_, locator) =>
         Task.delay {
           val route = locator.get[Set[PriorityRoute]].head
           pluginsDef.head.priority shouldEqual 10

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginDef.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchivePluginDef.scala
@@ -3,12 +3,13 @@ package ch.epfl.bluebrain.nexus.delta.plugins.archive
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 class ArchivePluginDef extends PluginDef {
 
-  override val module: ModuleDef = ArchivePluginModule
+  override val module: Config => ModuleDef = _ => ArchivePluginModule
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("archive"), BuildInfo.version)
 

--- a/delta/plugins/blazegraph/src/main/resources/blazegraph.conf
+++ b/delta/plugins/blazegraph/src/main/resources/blazegraph.conf
@@ -55,4 +55,6 @@ plugins.blazegraph {
     # the description of the default view
     description = "A Sparql view of all resources in the project."
   }
+  # turn off blazegraph indexing
+  disable-indexing = false
 }

--- a/delta/plugins/blazegraph/src/main/resources/blazegraph.conf
+++ b/delta/plugins/blazegraph/src/main/resources/blazegraph.conf
@@ -56,5 +56,5 @@ plugins.blazegraph {
     description = "A Sparql view of all resources in the project."
   }
   # turn off blazegraph indexing
-  disable-indexing = false
+  disable-indexing = ${app.defaults.indexing.disable}
 }

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginDef.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginDef.scala
@@ -10,7 +10,7 @@ import monix.bio.Task
 
 class BlazegraphPluginDef extends PluginDef {
 
-  override def module: Config => ModuleDef = _ => new BlazegraphPluginModule(priority)
+  override def module: Config => ModuleDef = new BlazegraphPluginModule(priority, _)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("blazegraph"), BuildInfo.version)
 

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginDef.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.blazegraph
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class BlazegraphPluginDef extends PluginDef {
 
-  override def module: ModuleDef = new BlazegraphPluginModule(priority)
+  override def module: Config => ModuleDef = _ => new BlazegraphPluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("blazegraph"), BuildInfo.version)
 

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
@@ -127,23 +127,25 @@ class BlazegraphPluginModule(priority: Int, appConfig: Config) extends ModuleDef
         )(api, clock, uuidF)
     }
 
-  make[BlazegraphCoordinator].fromEffect {
-    (
-        views: BlazegraphViews,
-        graphStream: GraphResourceStream,
-        registry: ReferenceRegistry,
-        supervisor: Supervisor,
-        client: BlazegraphClient @Id("blazegraph-indexing-client"),
-        baseUri: BaseUri
-    ) =>
-      BlazegraphCoordinator(
-        views,
-        graphStream,
-        registry,
-        supervisor,
-        client,
-        config.batch
-      )(baseUri)
+  if (config.indexingEnabled) {
+    make[BlazegraphCoordinator].fromEffect {
+      (
+          views: BlazegraphViews,
+          graphStream: GraphResourceStream,
+          registry: ReferenceRegistry,
+          supervisor: Supervisor,
+          client: BlazegraphClient @Id("blazegraph-indexing-client"),
+          baseUri: BaseUri
+      ) =>
+        BlazegraphCoordinator(
+          views,
+          graphStream,
+          registry,
+          supervisor,
+          client,
+          config.batch
+        )(baseUri)
+    }
   }
 
   make[BlazegraphViewsQuery].fromEffect {

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/config/BlazegraphViewsConfig.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/config/BlazegraphViewsConfig.scala
@@ -43,6 +43,10 @@ import scala.concurrent.duration._
   *   the maximum idle duration in between events on the indexing stream after which the stream will be stopped
   * @param syncIndexingTimeout
   *   the maximum duration for synchronous indexing to complete
+  * @param defaults
+  *   default values for the default Blazegraph views
+  * @param disableIndexing
+  *   if true, disables Blazegraph indexing
   */
 final case class BlazegraphViewsConfig(
     base: Uri,
@@ -58,8 +62,11 @@ final case class BlazegraphViewsConfig(
     maxViewRefs: Int,
     idleTimeout: Duration,
     syncIndexingTimeout: FiniteDuration,
-    defaults: Defaults
-)
+    defaults: Defaults,
+    disableIndexing: Boolean
+) {
+  def indexingEnabled: Boolean = !disableIndexing
+}
 
 object BlazegraphViewsConfig {
 

--- a/delta/plugins/composite-views/src/main/resources/composite-views.conf
+++ b/delta/plugins/composite-views/src/main/resources/composite-views.conf
@@ -37,5 +37,5 @@ plugins.composite-views {
   elasticsearch-batch = ${plugins.elasticsearch.batch}
 
   # turn of composite view indexing
-  disable-indexing = false
+  disable-indexing = ${app.defaults.indexing.disable}
 }

--- a/delta/plugins/composite-views/src/main/resources/composite-views.conf
+++ b/delta/plugins/composite-views/src/main/resources/composite-views.conf
@@ -35,4 +35,7 @@ plugins.composite-views {
 
   blazegraph-batch = ${plugins.blazegraph.batch}
   elasticsearch-batch = ${plugins.elasticsearch.batch}
+
+  # turn of composite view indexing
+  disable-indexing = false
 }

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginDef.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.compositeviews
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class CompositeViewsPluginDef extends PluginDef {
 
-  override def module: ModuleDef = new CompositeViewsPluginModule(priority)
+  override def module: Config => ModuleDef = _ => new CompositeViewsPluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("composite-views"), BuildInfo.version)
 

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginDef.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginDef.scala
@@ -10,7 +10,7 @@ import monix.bio.Task
 
 class CompositeViewsPluginDef extends PluginDef {
 
-  override def module: Config => ModuleDef = _ => new CompositeViewsPluginModule(priority)
+  override def module: Config => ModuleDef = new CompositeViewsPluginModule(priority, _)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("composite-views"), BuildInfo.version)
 

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -156,24 +156,26 @@ class CompositeViewsPluginModule(priority: Int, appConfig: Config) extends Modul
     CompositeGraphStream(local, remote)
   }
 
-  make[CompositeViewsCoordinator].fromEffect {
-    (
-        compositeViews: CompositeViews,
-        supervisor: Supervisor,
-        registry: ReferenceRegistry,
-        graphStream: CompositeGraphStream,
-        buildSpaces: CompositeSpaces.Builder,
-        compositeProjections: CompositeProjections,
-        cr: RemoteContextResolution @Id("aggregate")
-    ) =>
-      CompositeViewsCoordinator(
-        compositeViews,
-        supervisor,
-        PipeChain.compile(_, registry),
-        graphStream,
-        buildSpaces.apply,
-        compositeProjections
-      )(cr)
+  if (config.indexingEnabled) {
+    make[CompositeViewsCoordinator].fromEffect {
+      (
+          compositeViews: CompositeViews,
+          supervisor: Supervisor,
+          registry: ReferenceRegistry,
+          graphStream: CompositeGraphStream,
+          buildSpaces: CompositeSpaces.Builder,
+          compositeProjections: CompositeProjections,
+          cr: RemoteContextResolution @Id("aggregate")
+      ) =>
+        CompositeViewsCoordinator(
+          compositeViews,
+          supervisor,
+          PipeChain.compile(_, registry),
+          graphStream,
+          buildSpaces.apply,
+          compositeProjections
+        )(cr)
+    }
   }
 
   many[ProjectDeletionTask].add { (views: CompositeViews) => CompositeViewsDeletionTask(views) }

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
@@ -5,7 +5,6 @@ import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.{BatchConfig, EventLogConfig}
 import com.typesafe.config.Config
-import monix.bio.UIO
 import pureconfig.generic.auto._
 import pureconfig.generic.semiauto.deriveReader
 import pureconfig.{ConfigReader, ConfigSource}

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
@@ -83,13 +83,11 @@ object CompositeViewsConfig {
   /**
     * Converts a [[Config]] into an [[CompositeViewsConfig]]
     */
-  def load(config: Config): UIO[CompositeViewsConfig] =
-    UIO.delay {
-      ConfigSource
-        .fromConfig(config)
-        .at("plugins.composite-views")
-        .loadOrThrow[CompositeViewsConfig]
-    }
+  def load(config: Config): CompositeViewsConfig =
+    ConfigSource
+      .fromConfig(config)
+      .at("plugins.composite-views")
+      .loadOrThrow[CompositeViewsConfig]
 
   implicit final val compositeViewsConfigReader: ConfigReader[CompositeViewsConfig] =
     deriveReader[CompositeViewsConfig]

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
@@ -34,6 +34,8 @@ import scala.concurrent.duration.FiniteDuration
   *   the batch configuration for indexing into the elasticsearch projections
   * @param restartCheckInterval
   *   the interval at which a view will look for requested restarts
+  * @param disableIndexing
+  *   if true, disables the composite view indexing
   */
 final case class CompositeViewsConfig(
     sources: SourcesConfig,
@@ -45,8 +47,11 @@ final case class CompositeViewsConfig(
     minIntervalRebuild: FiniteDuration,
     blazegraphBatch: BatchConfig,
     elasticsearchBatch: BatchConfig,
-    restartCheckInterval: FiniteDuration
-)
+    restartCheckInterval: FiniteDuration,
+    disableIndexing: Boolean
+) {
+  def indexingEnabled: Boolean = !disableIndexing
+}
 
 object CompositeViewsConfig {
 

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
@@ -176,7 +176,8 @@ trait CompositeViewsFixture extends ConfigFixtures with EitherValuable {
     1.minute,
     batchConfig,
     batchConfig,
-    3.seconds
+    3.seconds,
+    false
   )
 }
 

--- a/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
+++ b/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
@@ -45,4 +45,6 @@ plugins.elasticsearch {
   }
   # the query config used when fetching all scoped events to obtain metrics
   metrics-query = ${app.defaults.query}
+  # turn off Elasticsearch indexing
+  disable-indexing = false
 }

--- a/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
+++ b/delta/plugins/elasticsearch/src/main/resources/elasticsearch.conf
@@ -46,5 +46,5 @@ plugins.elasticsearch {
   # the query config used when fetching all scoped events to obtain metrics
   metrics-query = ${app.defaults.query}
   # turn off Elasticsearch indexing
-  disable-indexing = false
+  disable-indexing = ${app.defaults.indexing.disable}
 }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginDef.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class ElasticSearchPluginDef extends PluginDef {
 
-  override def module: ModuleDef = new ElasticSearchPluginModule(priority)
+  override def module: Config => ModuleDef = _ => new ElasticSearchPluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("elasticsearch"), BuildInfo.version)
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginDef.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginDef.scala
@@ -10,7 +10,7 @@ import monix.bio.Task
 
 class ElasticSearchPluginDef extends PluginDef {
 
-  override def module: Config => ModuleDef = _ => new ElasticSearchPluginModule(priority)
+  override def module: Config => ModuleDef = new ElasticSearchPluginModule(priority, _)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("elasticsearch"), BuildInfo.version)
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
@@ -96,23 +96,25 @@ class ElasticSearchPluginModule(priority: Int, appConfig: Config) extends Module
       )(api, clock, uuidF)
   }
 
-  make[ElasticSearchCoordinator].fromEffect {
-    (
-        views: ElasticSearchViews,
-        graphStream: GraphResourceStream,
-        registry: ReferenceRegistry,
-        supervisor: Supervisor,
-        client: ElasticSearchClient,
-        cr: RemoteContextResolution @Id("aggregate")
-    ) =>
-      ElasticSearchCoordinator(
-        views,
-        graphStream,
-        registry,
-        supervisor,
-        client,
-        config.batch
-      )(cr)
+  if (config.indexingEnabled) {
+    make[ElasticSearchCoordinator].fromEffect {
+      (
+          views: ElasticSearchViews,
+          graphStream: GraphResourceStream,
+          registry: ReferenceRegistry,
+          supervisor: Supervisor,
+          client: ElasticSearchClient,
+          cr: RemoteContextResolution @Id("aggregate")
+      ) =>
+        ElasticSearchCoordinator(
+          views,
+          graphStream,
+          registry,
+          supervisor,
+          client,
+          config.batch
+        )(cr)
+    }
   }
 
   make[EventMetricsProjection].fromEffect {

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
@@ -47,6 +47,8 @@ import scala.concurrent.duration._
   *   default values for the view
   * @param metricsQuery
   *   query configuration for the metrics projection
+  * @param disableIndexing
+  *   if true, disables the Elasticsearch indexing
   */
 final case class ElasticSearchViewsConfig(
     base: Uri,

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
@@ -62,8 +62,11 @@ final case class ElasticSearchViewsConfig(
     syncIndexingRefresh: Refresh,
     maxIndexPathLength: Int,
     defaults: Defaults,
-    metricsQuery: QueryConfig
-)
+    metricsQuery: QueryConfig,
+    disableIndexing: Boolean
+) {
+  def indexingEnabled: Boolean = !disableIndexing
+}
 
 object ElasticSearchViewsConfig {
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/config/ElasticSearchViewsConfig.scala
@@ -44,7 +44,7 @@ import scala.concurrent.duration._
   * @param maxIndexPathLength
   *   the maximum length of the URL path for elasticsearch queries
   * @param defaults
-  *   default values for the view
+  *   default values for the default Elasticsearch views
   * @param metricsQuery
   *   query configuration for the metrics projection
   * @param disableIndexing

--- a/delta/plugins/graph-analytics/src/main/resources/graph-analytics.conf
+++ b/delta/plugins/graph-analytics/src/main/resources/graph-analytics.conf
@@ -22,4 +22,6 @@ plugins.graph-analytics {
     # the number of terms the coordinating node returns from each shard. This value must be higher than ''size''
     shard-size = 300
   }
+  # turn of graph-analytics indexing
+  disable-indexing = ${app.defaults.indexing.disable}
 }

--- a/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsPluginDef.scala
+++ b/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsPluginDef.scala
@@ -10,7 +10,7 @@ import monix.bio.Task
 
 class GraphAnalyticsPluginDef extends PluginDef {
 
-  override def module: Config => ModuleDef = _ => new GraphAnalyticsPluginModule(priority)
+  override def module: Config => ModuleDef = new GraphAnalyticsPluginModule(priority, _)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("graph-analytics"), BuildInfo.version)
 

--- a/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsPluginDef.scala
+++ b/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsPluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.graph.analytics
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class GraphAnalyticsPluginDef extends PluginDef {
 
-  override def module: ModuleDef = new GraphAnalyticsPluginModule(priority)
+  override def module: Config => ModuleDef = _ => new GraphAnalyticsPluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("graph-analytics"), BuildInfo.version)
 

--- a/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/config/GraphAnalyticsConfig.scala
+++ b/delta/plugins/graph-analytics/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/config/GraphAnalyticsConfig.scala
@@ -22,8 +22,11 @@ import scala.annotation.nowarn
 final case class GraphAnalyticsConfig(
     batch: BatchConfig,
     prefix: String,
-    termAggregations: TermAggregationsConfig
-)
+    termAggregations: TermAggregationsConfig,
+    disableIndexing: Boolean
+) {
+  def indexingDisabled: Boolean = !disableIndexing
+}
 
 object GraphAnalyticsConfig {
 

--- a/delta/plugins/jira/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/jira/JiraPluginDef.scala
+++ b/delta/plugins/jira/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/jira/JiraPluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.jira
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class JiraPluginDef extends PluginDef {
 
-  override def module: ModuleDef = new JiraPluginModule(priority)
+  override def module: Config => ModuleDef = _ => new JiraPluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("jira"), BuildInfo.version)
 

--- a/delta/plugins/project-deletion/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/projectdeletion/ProjectDeletionPluginDef.scala
+++ b/delta/plugins/project-deletion/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/projectdeletion/ProjectDeletionPluginDef.scala
@@ -4,6 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.projectdeletion.model.ProjectDeleti
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.{Task, UIO}
@@ -14,16 +15,17 @@ class ProjectDeletionPluginDef extends PluginDef {
   /**
     * Distage module definition for this plugin.
     */
-  override def module: ModuleDef = new ModuleDef {
-    make[ProjectDeletionConfig].fromEffect {
-      UIO.delay {
-        ConfigSource
-          .fromConfig(pluginConfigObject)
-          .loadOrThrow[ProjectDeletionConfig]
+  override def module: Config => ModuleDef = _ =>
+    new ModuleDef {
+      make[ProjectDeletionConfig].fromEffect {
+        UIO.delay {
+          ConfigSource
+            .fromConfig(pluginConfigObject)
+            .loadOrThrow[ProjectDeletionConfig]
+        }
       }
+      include(new ProjectDeletionModule(priority))
     }
-    include(new ProjectDeletionModule(priority))
-  }
 
   /**
     * Plugin description

--- a/delta/plugins/search/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/search/SearchPluginDef.scala
+++ b/delta/plugins/search/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/search/SearchPluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.search
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class SearchPluginDef extends PluginDef {
 
-  override def module: ModuleDef = new SearchPluginModule(priority)
+  override def module: Config => ModuleDef = _ => new SearchPluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("search"), BuildInfo.version)
 

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginDef.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/StoragePluginDef.scala
@@ -3,13 +3,14 @@ package ch.epfl.bluebrain.nexus.delta.plugins.storage
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Name
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 class StoragePluginDef extends PluginDef {
 
-  override def module: ModuleDef = new StoragePluginModule(priority)
+  override def module: Config => ModuleDef = _ => new StoragePluginModule(priority)
 
   override val info: PluginDescription = PluginDescription(Name.unsafe("storage"), BuildInfo.version)
 

--- a/delta/plugins/test-plugin/src/main/scala/ch/epfl/bluebrain/nexus/delta/testplugin/TestPluginDef.scala
+++ b/delta/plugins/test-plugin/src/main/scala/ch/epfl/bluebrain/nexus/delta/testplugin/TestPluginDef.scala
@@ -4,13 +4,14 @@ import ch.epfl.bluebrain.nexus.delta.sdk.PriorityRoute
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ComponentDescription.PluginDescription
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, Name}
 import ch.epfl.bluebrain.nexus.delta.sdk.plugin.{Plugin, PluginDef}
+import com.typesafe.config.Config
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.ModuleDef
 import monix.bio.Task
 
 case class TestPluginDef() extends PluginDef {
 
-  override def module: ModuleDef =
+  override def module: Config => ModuleDef = _ =>
     new ModuleDef {
       make[TestPlugin]
       make[TestPluginRoutes].from { (baseUri: BaseUri) =>

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/plugin/PluginDef.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/plugin/PluginDef.scala
@@ -12,9 +12,9 @@ import java.io.File
 trait PluginDef {
 
   /**
-    * Distage module definition for this plugin.
+    * Given a config, returns a distage module definition for this plugin.
     */
-  def module: ModuleDef
+  def module: Config => ModuleDef
 
   /**
     * Plugin description


### PR DESCRIPTION
This adds the possibilities to:
* Disable all indexing (ES, BG, CV, GA) by setting `app.defaults.indexing.disable` to `true` (defaults to false).
* Disable indexing for only one plugin by setting one (or more) of the following to `false`
    * `plugins.elasticsearch.disable-indexing`
    * `plugins.blazegraph.disable-indexing`
    * `plugins.composite-views.disable-indexing`
    * `plugins.graph-analytics.disable-indexing`

Closes #3942 