### PR TITLE
Add dedicated clients for composite views

### DIFF
--- a/delta/plugins/composite-views/src/main/resources/composite-views.conf
+++ b/delta/plugins/composite-views/src/main/resources/composite-views.conf
@@ -3,6 +3,13 @@ plugins.composite-views {
   enabled = true
   # the priority of the plugin
   priority = 5
+  # blazgraph instance for composite views
+  # by default it is the same as the one defined in the blazegraph plugin
+  blazegraph = {
+    base = ${plugins.blazegraph.base}
+    # credentials = ${plugins.blazegraph.credentials}
+    query-timeout = ${plugins.blazegraph.query-timeout}
+  }
   # the configuration of the composite views sources
   sources {
     max-sources = 5

--- a/delta/plugins/composite-views/src/main/resources/composite-views.conf
+++ b/delta/plugins/composite-views/src/main/resources/composite-views.conf
@@ -5,7 +5,7 @@ plugins.composite-views {
   priority = 5
   # blazgraph instance for composite views
   # by default it is the same as the one defined in the blazegraph plugin
-  blazegraph = {
+  blazegraph-access = {
     base = ${plugins.blazegraph.base}
     # credentials = ${plugins.blazegraph.credentials}
     query-timeout = ${plugins.blazegraph.query-timeout}

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -62,9 +62,9 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
     ) =>
       BlazegraphClient(
         client,
-        cfg.blazegraph.base,
-        cfg.blazegraph.credentials,
-        cfg.blazegraph.queryTimeout
+        cfg.blazegraphAccess.base,
+        cfg.blazegraphAccess.credentials,
+        cfg.blazegraphAccess.queryTimeout
       )(as.classicSystem)
   }
 
@@ -76,9 +76,9 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
     ) =>
       BlazegraphClient(
         client,
-        cfg.blazegraph.base,
-        cfg.blazegraph.credentials,
-        cfg.blazegraph.queryTimeout
+        cfg.blazegraphAccess.base,
+        cfg.blazegraphAccess.credentials,
+        cfg.blazegraphAccess.queryTimeout
       )(as.classicSystem)
   }
 

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -54,6 +54,34 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
     DeltaClient(httpClient, cfg.remoteSourceClient.retryDelay)(as, sc)
   }
 
+  make[BlazegraphClient].named("blazegraph-composite-indexing-client").from {
+    (
+        cfg: CompositeViewsConfig,
+        client: HttpClient @Id("http-indexing-client"),
+        as: ActorSystem[Nothing]
+    ) =>
+      BlazegraphClient(
+        client,
+        cfg.blazegraph.base,
+        cfg.blazegraph.credentials,
+        cfg.blazegraph.queryTimeout
+      )(as.classicSystem)
+  }
+
+  make[BlazegraphClient].named("blazegraph-composite-query-client").from {
+    (
+        cfg: CompositeViewsConfig,
+        client: HttpClient @Id("http-query-client"),
+        as: ActorSystem[Nothing]
+    ) =>
+      BlazegraphClient(
+        client,
+        cfg.blazegraph.base,
+        cfg.blazegraph.credentials,
+        cfg.blazegraph.queryTimeout
+      )(as.classicSystem)
+  }
+
   make[ValidateCompositeView].from {
     (
         aclCheck: AclCheck,
@@ -130,7 +158,7 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
   make[CompositeSpaces.Builder].from {
     (
         esClient: ElasticSearchClient,
-        blazeClient: BlazegraphClient @Id("blazegraph-indexing-client"),
+        blazeClient: BlazegraphClient @Id("blazegraph-composite-indexing-client"),
         cfg: CompositeViewsConfig,
         baseUri: BaseUri
     ) =>
@@ -197,7 +225,7 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
     (
         aclCheck: AclCheck,
         views: CompositeViews,
-        client: BlazegraphClient @Id("blazegraph-query-client"),
+        client: BlazegraphClient @Id("blazegraph-composite-query-client"),
         cfg: CompositeViewsConfig
     ) => BlazegraphQuery(aclCheck, views, client, cfg.prefix)
   }

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
@@ -1,7 +1,10 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config
 
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{RemoteSourceClientConfig, SourcesConfig}
+import akka.http.scaladsl.model.Uri
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.config.BlazegraphViewsConfig.Credentials
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphInstanceConfig, RemoteSourceClientConfig, SourcesConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientConfig
+import ch.epfl.bluebrain.nexus.delta.sdk.instances._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.{BatchConfig, EventLogConfig}
 import com.typesafe.config.Config
@@ -10,13 +13,15 @@ import pureconfig.generic.auto._
 import pureconfig.generic.semiauto.deriveReader
 import pureconfig.{ConfigReader, ConfigSource}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 /**
   * The composite view configuration.
   *
   * @param sources
   *   the configuration of the composite views sources
+  * @param blazegraph
+  *   the configuration of the Blazegraph instance used for composite views
   * @param prefix
   *   prefix for indices and namespaces
   * @param maxProjections
@@ -40,6 +45,7 @@ import scala.concurrent.duration.FiniteDuration
   */
 final case class CompositeViewsConfig(
     sources: SourcesConfig,
+    blazegraph: BlazegraphInstanceConfig,
     prefix: String,
     maxProjections: Int,
     eventLog: EventLogConfig,
@@ -62,6 +68,23 @@ object CompositeViewsConfig {
     */
   final case class SourcesConfig(
       maxSources: Int
+  )
+
+  /**
+    * The configuration of the blazegraph instance used for composite views. By default it uses values from the
+    * blazegraph plugin.
+    *
+    * @param base
+    *   the base uri to the Blazegraph HTTP endpoint
+    * @param credentials
+    *   the Blazegraph HTTP endpoint credentials
+    * @param queryTimeout
+    *   the Blazegraph query timeout
+    */
+  final case class BlazegraphInstanceConfig(
+      base: Uri,
+      credentials: Option[Credentials],
+      queryTimeout: Duration
   )
 
   /**

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config
 
 import akka.http.scaladsl.model.Uri
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.config.BlazegraphViewsConfig.Credentials
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphInstanceConfig, RemoteSourceClientConfig, SourcesConfig}
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphAccess, RemoteSourceClientConfig, SourcesConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.instances._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
@@ -20,7 +20,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
   *
   * @param sources
   *   the configuration of the composite views sources
-  * @param blazegraph
+  * @param blazegraphAccess
   *   the configuration of the Blazegraph instance used for composite views
   * @param prefix
   *   prefix for indices and namespaces
@@ -45,7 +45,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
   */
 final case class CompositeViewsConfig(
     sources: SourcesConfig,
-    blazegraph: BlazegraphInstanceConfig,
+    blazegraphAccess: BlazegraphAccess,
     prefix: String,
     maxProjections: Int,
     eventLog: EventLogConfig,
@@ -81,7 +81,7 @@ object CompositeViewsConfig {
     * @param queryTimeout
     *   the Blazegraph query timeout
     */
-  final case class BlazegraphInstanceConfig(
+  final case class BlazegraphAccess(
       base: Uri,
       credentials: Option[Credentials],
       queryTimeout: Duration

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptySet
 import ch.epfl.bluebrain.nexus.delta.kernel.Secret
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{RemoteSourceClientConfig, SourcesConfig}
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphInstanceConfig, RemoteSourceClientConfig, SourcesConfig}
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeView.Interval
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewProjection.{ElasticSearchProjection, SparqlProjection}
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewProjectionFields.{ElasticSearchProjectionFields, SparqlProjectionFields}
@@ -168,6 +168,7 @@ trait CompositeViewsFixture extends ConfigFixtures with EitherValuable {
 
   val config: CompositeViewsConfig = CompositeViewsConfig(
     SourcesConfig(1),
+    BlazegraphInstanceConfig("http://localhost:9999/blazegraph", None, 1.minute),
     "prefix",
     3,
     eventLogConfig,

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptySet
 import ch.epfl.bluebrain.nexus.delta.kernel.Secret
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphInstanceConfig, RemoteSourceClientConfig, SourcesConfig}
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphAccess, RemoteSourceClientConfig, SourcesConfig}
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeView.Interval
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewProjection.{ElasticSearchProjection, SparqlProjection}
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewProjectionFields.{ElasticSearchProjectionFields, SparqlProjectionFields}
@@ -168,7 +168,7 @@ trait CompositeViewsFixture extends ConfigFixtures with EitherValuable {
 
   val config: CompositeViewsConfig = CompositeViewsConfig(
     SourcesConfig(1),
-    BlazegraphInstanceConfig("http://localhost:9999/blazegraph", None, 1.minute),
+    BlazegraphAccess("http://localhost:9999/blazegraph", None, 1.minute),
     "prefix",
     3,
     eventLogConfig,


### PR DESCRIPTION
* Adds the possibility of pointing to a different instance for composite views than for blazegraph views.
* By default the same instance is used for both