### PR TITLE
Separate projections errors handling from projections module

### DIFF
--- a/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/RetryStrategy.scala
+++ b/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/RetryStrategy.scala
@@ -57,7 +57,7 @@ object RetryStrategy {
   /**
     * Log errors when retrying
     */
-  def logIOError[E](logger: Logger, action: String): (E, RetryDetails) => IO[E, Unit] = {
+  def logError[E](logger: Logger, action: String): (E, RetryDetails) => IO[E, Unit] = {
     case (err, WillDelayAndRetry(nextDelay, retriesSoFar, _)) =>
       val message = s"""Error $err while $action: retrying in ${nextDelay.toMillis}ms (retries so far: $retriesSoFar)"""
       logger.warn(message)
@@ -122,7 +122,7 @@ object RetryStrategy {
     RetryStrategy(
       config,
       (t: Throwable) => NonFatal(t),
-      (t: Throwable, d: RetryDetails) => logIOError(logger, action)(t, d)
+      (t: Throwable, d: RetryDetails) => logError(logger, action)(t, d)
     )
 
 }

--- a/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/RetryStrategy.scala
+++ b/delta/kernel/src/main/scala/ch/epfl/bluebrain/nexus/delta/kernel/RetryStrategy.scala
@@ -1,14 +1,14 @@
 package ch.epfl.bluebrain.nexus.delta.kernel
 
-import com.typesafe.scalalogging.Logger
+import com.typesafe.scalalogging.{Logger => ScalaLoggingLogger}
 import monix.bio.{IO, UIO}
 import pureconfig.ConfigReader
 import pureconfig.error.{CannotConvert, ConfigReaderFailures, ConvertFailure}
 import pureconfig.generic.semiauto._
 import retry.RetryDetails.{GivingUp, WillDelayAndRetry}
 import retry.RetryPolicies._
-import retry.{RetryDetails, RetryPolicies, RetryPolicy}
 import retry.syntax.all._
+import retry.{RetryDetails, RetryPolicies, RetryPolicy}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
@@ -45,13 +45,25 @@ object RetryStrategy {
   /**
     * Log errors when retrying
     */
-  def logError[E](logger: Logger, action: String): (E, RetryDetails) => IO[E, Unit] = {
+  def logError[E](logger: ScalaLoggingLogger, action: String): (E, RetryDetails) => IO[E, Unit] = {
     case (err, WillDelayAndRetry(nextDelay, retriesSoFar, _)) =>
-      val message = s"""Error while $action: retrying in ${nextDelay.toMillis}ms (retries so far: $retriesSoFar)"""
-      UIO.delay(logger.warn(message, err))
+      val message = s"""Error $err while $action: retrying in ${nextDelay.toMillis}ms (retries so far: $retriesSoFar)"""
+      UIO.delay(logger.warn(message))
     case (err, GivingUp(totalRetries, _))                     =>
-      val message = s"""Error while $action, giving up (total retries: $totalRetries)"""
-      UIO.delay(logger.error(message, err))
+      val message = s"""Error $err while $action, giving up (total retries: $totalRetries)"""
+      UIO.delay(logger.error(message))
+  }
+
+  /**
+    * Log errors when retrying
+    */
+  def logIOError[E](logger: Logger, action: String): (E, RetryDetails) => IO[E, Unit] = {
+    case (err, WillDelayAndRetry(nextDelay, retriesSoFar, _)) =>
+      val message = s"""Error $err while $action: retrying in ${nextDelay.toMillis}ms (retries so far: $retriesSoFar)"""
+      logger.warn(message)
+    case (err, GivingUp(totalRetries, _))                     =>
+      val message = s"""Error $err while $action, giving up (total retries: $totalRetries)"""
+      logger.error(message)
   }
 
   /**
@@ -95,11 +107,22 @@ object RetryStrategy {
     * @param action
     *   the action that was performed
     */
-  def retryOnNonFatal(config: RetryStrategyConfig, logger: Logger, action: String): RetryStrategy[Throwable] =
+  def retryOnNonFatal(
+      config: RetryStrategyConfig,
+      logger: ScalaLoggingLogger,
+      action: String
+  ): RetryStrategy[Throwable] =
     RetryStrategy(
       config,
       (t: Throwable) => NonFatal(t),
       (t: Throwable, d: RetryDetails) => logError(logger, action)(t, d)
+    )
+
+  def retryOnNonFatal(config: RetryStrategyConfig, logger: Logger, action: String): RetryStrategy[Throwable] =
+    RetryStrategy(
+      config,
+      (t: Throwable) => NonFatal(t),
+      (t: Throwable, d: RetryDetails) => logIOError(logger, action)(t, d)
     )
 
 }

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphPluginModule.scala
@@ -32,7 +32,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.sse.SseEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.GraphResourceStream
 import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Label
-import ch.epfl.bluebrain.nexus.delta.sourcing.projections.Projections
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{ProjectionErrors, Projections}
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{ReferenceRegistry, Supervisor}
 import izumi.distage.model.definition.{Id, ModuleDef}
 import monix.bio.UIO
@@ -179,6 +179,7 @@ class BlazegraphPluginModule(priority: Int) extends ModuleDef {
         aclCheck: AclCheck,
         views: BlazegraphViews,
         projections: Projections,
+        projectionErrors: ProjectionErrors,
         viewsQuery: BlazegraphViewsQuery,
         schemeDirectives: DeltaSchemeDirectives,
         indexingAction: IndexingAction @Id("aggregate"),
@@ -196,6 +197,7 @@ class BlazegraphPluginModule(priority: Int) extends ModuleDef {
         identities,
         aclCheck,
         projections,
+        projectionErrors,
         schemeDirectives,
         indexingAction(_, _, _)(shift, cr)
       )(

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutes.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutes.scala
@@ -32,7 +32,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.{BaseUri, IdSegment}
 import ch.epfl.bluebrain.nexus.delta.sourcing.ProgressStatistics
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
-import ch.epfl.bluebrain.nexus.delta.sourcing.projections.Projections
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{ProjectionErrors, Projections}
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
@@ -51,6 +51,8 @@ import monix.execution.Scheduler
   *   to check the acls
   * @param projections
   *   the projections module
+  * @param projectionErrors
+  *   the projection errors module
   * @param schemeDirectives
   *   directives related to orgs and projects
   * @param index
@@ -62,6 +64,7 @@ class BlazegraphViewsRoutes(
     identities: Identities,
     aclCheck: AclCheck,
     projections: Projections,
+    projectionErrors: ProjectionErrors,
     schemeDirectives: DeltaSchemeDirectives,
     index: IndexingAction.Execute[BlazegraphView]
 )(implicit
@@ -196,8 +199,7 @@ class BlazegraphViewsRoutes(
                               views
                                 .fetch(id, ref)
                                 .map { view =>
-                                  projections
-                                    .failedElemSses(view.value.project, view.value.id, offset)
+                                  projectionErrors.failedElemSses(view.value.project, view.value.id, offset)
                                 }
                             )
                           }
@@ -333,6 +335,7 @@ object BlazegraphViewsRoutes {
       identities: Identities,
       aclCheck: AclCheck,
       projections: Projections,
+      projectionErrors: ProjectionErrors,
       schemeDirectives: DeltaSchemeDirectives,
       index: IndexingAction.Execute[BlazegraphView]
   )(implicit
@@ -349,6 +352,7 @@ object BlazegraphViewsRoutes {
       identities,
       aclCheck,
       projections,
+      projectionErrors: ProjectionErrors,
       schemeDirectives,
       index
     ).routes

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/projections/CompositeProjections.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/projections/CompositeProjections.scala
@@ -13,13 +13,13 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.{BatchConfig, QueryConfig}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.FailedElemLogStore
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream._
 import com.typesafe.scalalogging.Logger
 import fs2.{Pipe, Stream}
 import monix.bio.{Task, UIO}
 
 import concurrent.duration.FiniteDuration
-
 import java.time.Instant
 
 /**
@@ -125,7 +125,7 @@ object CompositeProjections {
       clock: Clock[UIO]
   ): CompositeProjections =
     new CompositeProjections {
-      private val projectionStore        = ProjectionStore(xas, query)
+      private val failedElemLogStore     = FailedElemLogStore(xas, query)
       private val compositeProgressStore = new CompositeProgressStore(xas)
 
       override def progress(view: ViewRef, rev: Int): UIO[CompositeProgress] =
@@ -142,7 +142,7 @@ object CompositeProjections {
           Projection.persist(
             progress,
             compositeProgressStore.save(view, rev, branch, _),
-            projectionStore.saveFailedElems(metadata, _)
+            failedElemLogStore.saveFailedElems(metadata, _)
           )(batch)
         )
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
@@ -35,7 +35,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.sse.SseEncoder
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.GraphResourceStream
 import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Label
-import ch.epfl.bluebrain.nexus.delta.sourcing.projections.Projections
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{ProjectionErrors, Projections}
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{PipeChain, ReferenceRegistry, Supervisor}
 import izumi.distage.model.definition.{Id, ModuleDef}
 import monix.bio.UIO
@@ -171,6 +171,7 @@ class ElasticSearchPluginModule(priority: Int) extends ModuleDef {
         aclCheck: AclCheck,
         views: ElasticSearchViews,
         projections: Projections,
+        projectionErrors: ProjectionErrors,
         schemeDirectives: DeltaSchemeDirectives,
         indexingAction: IndexingAction @Id("aggregate"),
         viewsQuery: ElasticSearchViewsQuery,
@@ -187,6 +188,7 @@ class ElasticSearchPluginModule(priority: Int) extends ModuleDef {
         views,
         viewsQuery,
         projections,
+        projectionErrors,
         schemeDirectives,
         indexingAction(_, _, _)(shift, cr)
       )(

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutes.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutes.scala
@@ -25,7 +25,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.routes.Tag
 import ch.epfl.bluebrain.nexus.delta.sourcing.ProgressStatistics
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
-import ch.epfl.bluebrain.nexus.delta.sourcing.projections.Projections
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{ProjectionErrors, Projections}
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 import io.circe.{Encoder, Json, JsonObject}
@@ -45,6 +45,8 @@ import monix.execution.Scheduler
   *   the elasticsearch views query operations bundle
   * @param projections
   *   the projections module
+  * @param projectionErrors
+  *   the projection errors module
   * @param schemeDirectives
   *   directives related to orgs and projects
   * @param index
@@ -56,6 +58,7 @@ final class ElasticSearchViewsRoutes(
     views: ElasticSearchViews,
     viewsQuery: ElasticSearchViewsQuery,
     projections: Projections,
+    projectionErrors: ProjectionErrors,
     schemeDirectives: DeltaSchemeDirectives,
     index: IndexingAction.Execute[ElasticSearchView]
 )(implicit
@@ -183,8 +186,7 @@ final class ElasticSearchViewsRoutes(
                           views
                             .fetch(id, ref)
                             .map { view =>
-                              projections
-                                .failedElemSses(view.value.project, view.value.id, offset)
+                              projectionErrors.failedElemSses(view.value.project, view.value.id, offset)
                             }
                         )
                       }
@@ -282,6 +284,7 @@ object ElasticSearchViewsRoutes {
       views: ElasticSearchViews,
       viewsQuery: ElasticSearchViewsQuery,
       projections: Projections,
+      projectionErrors: ProjectionErrors,
       schemeDirectives: DeltaSchemeDirectives,
       index: IndexingAction.Execute[ElasticSearchView]
   )(implicit
@@ -297,6 +300,7 @@ object ElasticSearchViewsRoutes {
       views,
       viewsQuery,
       projections,
+      projectionErrors,
       schemeDirectives,
       index
     ).routes

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchCoordinatorSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchCoordinatorSuite.scala
@@ -12,6 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ElemStream, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.{DroppedElem, FailedElem, SuccessElem}
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionErr.CouldNotFindPipeErr
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.SupervisorSetup.unapply
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream._
 import ch.epfl.bluebrain.nexus.testkit.CirceLiteral
 import ch.epfl.bluebrain.nexus.testkit.bio.{BioSuite, PatienceConfig}
@@ -34,10 +35,10 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
   private val indexingRev = 1
   private val rev         = 2
 
-  private lazy val (sv, projections) = supervisor()
-  private val project                = ProjectRef.unsafe("org", "proj")
-  private val id1                    = nxv + "view1"
-  private val view1                  = ActiveViewDef(
+  private lazy val (sv, projections, projectionErrors) = unapply(supervisor())
+  private val project                                  = ProjectRef.unsafe("org", "proj")
+  private val id1                                      = nxv + "view1"
+  private val view1                                    = ActiveViewDef(
     ViewRef(project, id1),
     projection = id1.toString,
     None,
@@ -234,7 +235,7 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
 
   test("There is one error for the coordinator projection before the signal") {
     for {
-      entries <- projections.failedElemEntries(ElasticSearchCoordinator.metadata.name, Offset.start).compile.toList
+      entries <- projectionErrors.failedElemEntries(ElasticSearchCoordinator.metadata.name, Offset.start).compile.toList
       r        = entries.assertOneElem
       _        = assertEquals(r.failedElemData.id, id3)
     } yield ()
@@ -242,7 +243,7 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
 
   test("There is one error for view 1") {
     for {
-      entries <- projections.failedElemEntries(view1.projection, Offset.start).compile.toList
+      entries <- projectionErrors.failedElemEntries(view1.projection, Offset.start).compile.toList
       r        = entries.assertOneElem
       _        = assertEquals(r.failedElemData.id, nxv + "failed")
       _        = assertEquals(r.failedElemData.entityType, PullRequest.entityType)
@@ -252,14 +253,14 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
 
   test("There is one error for view 2") {
     for {
-      entries <- projections.failedElemEntries(view2.projection, Offset.start).compile.toList
+      entries <- projectionErrors.failedElemEntries(view2.projection, Offset.start).compile.toList
       _        = entries.assertOneElem
     } yield ()
   }
 
   test("There are no errors for view 3") {
     for {
-      entries <- projections.failedElemEntries(view3.projection, Offset.start).compile.toList
+      entries <- projectionErrors.failedElemEntries(view3.projection, Offset.start).compile.toList
       _        = entries.assertEmpty()
     } yield ()
   }
@@ -306,7 +307,8 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
 
   test("Coordinator projection should have one error after failed elem offset 4") {
     for {
-      entries <- projections.failedElemEntries(ElasticSearchCoordinator.metadata.name, Offset.At(3L)).compile.toList
+      entries <-
+        projectionErrors.failedElemEntries(ElasticSearchCoordinator.metadata.name, Offset.At(3L)).compile.toList
       r        = entries.assertOneElem
       _        = assertEquals(r.failedElemData.id, nxv + "failed_coord")
     } yield ()
@@ -314,7 +316,7 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
 
   test("View 2_2 projection should have one error after failed elem offset 4") {
     for {
-      entries <- projections.failedElemEntries(updatedView2.projection, Offset.At(4L)).compile.toList
+      entries <- projectionErrors.failedElemEntries(updatedView2.projection, Offset.At(4L)).compile.toList
       r        = entries.assertOneElem
       _        = assertEquals(r.failedElemData.id, nxv + "failed")
     } yield ()

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/metrics/EventMetricsProjectionSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/metrics/EventMetricsProjectionSuite.scala
@@ -19,8 +19,8 @@ class EventMetricsProjectionSuite extends BioSuite with SupervisorSetup.Fixture 
 
   implicit private val patienceConfig: PatienceConfig = PatienceConfig(2.seconds, 10.millis)
 
-  private lazy val (sv, _) = supervisor()
-  private val sink         = CacheSink.events[Json]
+  private lazy val sv = supervisor().supervisor
+  private val sink    = CacheSink.events[Json]
 
   test("Start the metrics projection") {
     for {

--- a/delta/plugins/graph-analytics/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsCoordinatorSuite.scala
+++ b/delta/plugins/graph-analytics/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/GraphAnalyticsCoordinatorSuite.scala
@@ -9,6 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.projects.Projects
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ElemStream, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.{DroppedElem, FailedElem, SuccessElem}
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.SupervisorSetup.unapply
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{CacheSink, Elem, ExecutionStatus, ProjectionProgress, SupervisorSetup}
 import ch.epfl.bluebrain.nexus.testkit.bio.{BioSuite, PatienceConfig}
 import munit.AnyFixture
@@ -26,9 +27,9 @@ class GraphAnalyticsCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtu
 
   implicit private val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 10.millis)
 
-  private lazy val (sv, projections) = supervisor()
-  private val project1               = ProjectRef.unsafe("org", "proj1")
-  private val project1Id             = Projects.encodeId(project1)
+  private lazy val (sv, projections, _) = unapply(supervisor())
+  private val project1                  = ProjectRef.unsafe("org", "proj1")
+  private val project1Id                = Projects.encodeId(project1)
 
   private val project2   = ProjectRef.unsafe("org", "proj2")
   private val project2Id = Projects.encodeId(project1)

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/statistics/StoragesStatisticsSuite.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/statistics/StoragesStatisticsSuite.scala
@@ -10,6 +10,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.StoragesStatistics
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageStatEntry
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.SupervisorSetup
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.SupervisorSetup.unapply
 import ch.epfl.bluebrain.nexus.testkit.{IOValues, TestHelpers}
 import ch.epfl.bluebrain.nexus.testkit.bio.{BioSuite, PatienceConfig}
 import monix.bio.IO
@@ -28,8 +29,8 @@ class StoragesStatisticsSuite
 
   implicit private val patience: PatienceConfig = PatienceConfig(2.seconds, 10.milliseconds)
 
-  private lazy val client  = esClient()
-  private lazy val (sv, _) = supervisor()
+  private lazy val client     = esClient()
+  private lazy val (sv, _, _) = unapply(supervisor())
 
   private lazy val sink   = ElasticSearchSink.events(client, 2, 50.millis, index, Refresh.False)
   private val indexPrefix = "delta"

--- a/delta/sourcing-psql/src/main/resources/scripts/postgres/init/V1_09_M03_001__elem_errors_index.ddl
+++ b/delta/sourcing-psql/src/main/resources/scripts/postgres/init/V1_09_M03_001__elem_errors_index.ddl
@@ -1,0 +1,4 @@
+-----------------------------------------------------
+-- Index on the instant column of failed_elem_logs --
+-----------------------------------------------------
+CREATE INDEX IF NOT EXISTS failed_elem_logs_instant_idx ON public.failed_elem_logs(instant);

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/FailedElemLogStore.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/FailedElemLogStore.scala
@@ -1,0 +1,154 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing.projections
+
+import cats.effect.Clock
+import cats.implicits._
+import ch.epfl.bluebrain.nexus.delta.kernel.Logger
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.IOUtils
+import ch.epfl.bluebrain.nexus.delta.kernel.utils.ThrowableUtils._
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
+import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
+import ch.epfl.bluebrain.nexus.delta.sourcing.implicits._
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
+import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.FailedElem
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.FailedElemLogRow
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{ProjectionMetadata, ProjectionStore}
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+import fs2.Stream
+import monix.bio.{Task, UIO}
+
+import java.time.Instant
+
+/**
+  * Persistent operations for errors raised by projections
+  */
+trait FailedElemLogStore {
+
+  /**
+    * Saves a list of failed elems
+    *
+    * @param metadata
+    *   the metadata of the projection
+    * @param failures
+    *   the FailedElem to save
+    */
+  def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit]
+
+  /**
+    * Saves one failed elem
+    */
+  protected def saveFailedElem(metadata: ProjectionMetadata, failure: FailedElem, instant: Instant): ConnectionIO[Unit]
+
+  /**
+    * Get available failed elem entries for a given projection (provided by project and id), starting from a failed elem
+    * offset.
+    *
+    * @param projectionProject
+    *   the project the projection belongs to
+    * @param projectionId
+    *   IRI of the projection
+    * @param offset
+    *   failed elem offset
+    */
+  def failedElemEntries(
+      projectionProject: ProjectRef,
+      projectionId: Iri,
+      offset: Offset
+  ): Stream[Task, FailedElemLogRow]
+
+  /**
+    * Get available failed elem entries for a given projection by projection name, starting from a failed elem offset.
+    *
+    * @param projectionName
+    *   the name of the projection
+    * @param offset
+    *   failed elem offset
+    * @return
+    */
+  def failedElemEntries(
+      projectionName: String,
+      offset: Offset
+  ): Stream[Task, FailedElemLogRow]
+
+}
+
+object FailedElemLogStore {
+
+  private val logger: Logger = Logger[ProjectionStore]
+
+  def apply(xas: Transactors, config: QueryConfig)(implicit clock: Clock[UIO]): FailedElemLogStore =
+    new FailedElemLogStore {
+
+      override def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit] = {
+        val log  = logger.debug(s"[${metadata.name}] Saving ${failures.length} failed elems.")
+        val save = IOUtils.instant.flatMap { instant =>
+          failures.traverse(elem => saveFailedElem(metadata, elem, instant)).transact(xas.write).void.hideErrors
+        }
+        log >> save
+      }
+
+      override protected def saveFailedElem(
+          metadata: ProjectionMetadata,
+          failure: FailedElem,
+          instant: Instant
+      ): ConnectionIO[Unit] =
+        sql"""
+           | INSERT INTO public.failed_elem_logs (
+           |  projection_name,
+           |  projection_module,
+           |  projection_project,
+           |  projection_id,
+           |  entity_type,
+           |  elem_offset,
+           |  elem_id,
+           |  elem_project,
+           |  rev,
+           |  error_type,
+           |  message,
+           |  stack_trace,
+           |  instant
+           | )
+           | VALUES (
+           |  ${metadata.name},
+           |  ${metadata.module},
+           |  ${metadata.project},
+           |  ${metadata.resourceId},
+           |  ${failure.tpe},
+           |  ${failure.offset},
+           |  ${failure.id},
+           |  ${failure.project},
+           |  ${failure.rev},
+           |  ${failure.throwable.getClass.getCanonicalName},
+           |  ${failure.throwable.getMessage},
+           |  ${stackTraceAsString(failure.throwable)},
+           |  $instant
+           | )""".stripMargin.update.run.void
+
+      override def failedElemEntries(
+          projectionProject: ProjectRef,
+          projectionId: Iri,
+          offset: Offset
+      ): Stream[Task, FailedElemLogRow] =
+        sql"""SELECT * from public.failed_elem_logs
+           |WHERE projection_project = $projectionProject
+           |AND projection_id = $projectionId
+           |AND ordering > $offset
+           |ORDER BY ordering ASC""".stripMargin
+          .query[FailedElemLogRow]
+          .streamWithChunkSize(config.batchSize)
+          .transact(xas.read)
+
+      override def failedElemEntries(projectionName: String, offset: Offset): Stream[Task, FailedElemLogRow] =
+        sql"""SELECT * from public.failed_elem_logs
+           |WHERE projection_name = $projectionName
+           |AND ordering > $offset
+           |ORDER BY ordering ASC""".stripMargin
+          .query[FailedElemLogRow]
+          .streamWithChunkSize(config.batchSize)
+          .transact(xas.read)
+    }
+
+}

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/ProjectionErrors.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/ProjectionErrors.scala
@@ -1,0 +1,112 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing.projections
+
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import cats.effect.Clock
+import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
+import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
+import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
+import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
+import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.FailedElem
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionMetadata
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.FailedElemLogRow
+import fs2.Stream
+import io.circe.Printer
+import monix.bio.{Task, UIO}
+
+trait ProjectionErrors {
+
+  /**
+    * Saves a list of failed elems
+    *
+    * @param metadata
+    *   the metadata of the projection
+    * @param failures
+    *   the FailedElem to save
+    */
+  def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit]
+
+  /**
+    * Get available failed elem entries for a given projection (provided by project and id), starting from a failed elem
+    * offset.
+    *
+    * @param projectionProject
+    *   the project the projection belongs to
+    * @param projectionId
+    *   IRI of the projection
+    * @param offset
+    *   failed elem offset
+    */
+  def failedElemEntries(
+      projectionProject: ProjectRef,
+      projectionId: Iri,
+      offset: Offset
+  ): Stream[Task, FailedElemLogRow]
+
+  /**
+    * Get available failed elem entries for a given projection by projection name, starting from a failed elem offset.
+    *
+    * @param projectionName
+    *   the name of the projection
+    * @param offset
+    *   failed elem offset
+    * @return
+    */
+  def failedElemEntries(projectionName: String, offset: Offset): Stream[Task, FailedElemLogRow]
+
+  /**
+    * Get available failed elem entries for a given projection (provided by project and id), starting from a failed elem
+    * offset as a stream of Server Sent Events
+    *
+    * @param projectionProject
+    *   the project the projection belongs to
+    * @param projectionId
+    *   IRI of the projection
+    * @param offset
+    *   failed elem offset
+    */
+  def failedElemSses(projectionProject: ProjectRef, projectionId: Iri, offset: Offset)(implicit
+      rcr: RemoteContextResolution
+  ): Stream[Task, ServerSentEvent]
+
+}
+
+object ProjectionErrors {
+
+  implicit private val api: JsonLdApi = JsonLdJavaApi.lenient
+  private val defaultPrinter: Printer = Printer(dropNullValues = true, indent = "")
+
+  def apply(xas: Transactors, config: QueryConfig)(implicit clock: Clock[UIO]) = new ProjectionErrors {
+
+    val store = FailedElemLogStore(xas, config)
+
+    override def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit] =
+      store.saveFailedElems(metadata, failures)
+
+    override def failedElemEntries(
+        projectionProject: ProjectRef,
+        projectionId: Iri,
+        offset: Offset
+    ): Stream[Task, FailedElemLogRow] = store.failedElemEntries(projectionProject, projectionId, offset)
+
+    override def failedElemEntries(projectionName: String, offset: Offset): Stream[Task, FailedElemLogRow] =
+      store.failedElemEntries(projectionName, offset)
+
+    override def failedElemSses(projectionProject: ProjectRef, projectionId: Iri, offset: Offset)(implicit
+        rcr: RemoteContextResolution
+    ): Stream[Task, ServerSentEvent] =
+      failedElemEntries(projectionProject, projectionId, offset).evalMap { felem =>
+        felem.failedElemData.toCompactedJsonLd.map { compactJson =>
+          ServerSentEvent(
+            defaultPrinter.print(compactJson.json),
+            "IndexingFailure",
+            felem.ordering.value.toString
+          )
+        }
+      }
+  }
+
+}

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/Projections.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/Projections.scala
@@ -1,25 +1,16 @@
 package ch.epfl.bluebrain.nexus.delta.sourcing.projections
 
-import akka.http.scaladsl.model.sse.ServerSentEvent
 import cats.effect.Clock
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.IOUtils
-import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
-import ch.epfl.bluebrain.nexus.delta.rdf.implicits._
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdJavaApi}
-import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
-import ch.epfl.bluebrain.nexus.delta.sourcing.{ProgressStatistics, Transactors}
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ElemStream, ProjectRef, Tag}
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
 import ch.epfl.bluebrain.nexus.delta.sourcing.projections.model.ProjectionRestart
 import ch.epfl.bluebrain.nexus.delta.sourcing.query.StreamingQuery
-import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.FailedElem
-import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.FailedElemLogRow
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{ProjectionMetadata, ProjectionProgress, ProjectionStore, RemainingElems}
-import fs2.Stream
-import io.circe.Printer
-import monix.bio.{Task, UIO}
+import ch.epfl.bluebrain.nexus.delta.sourcing.{ProgressStatistics, Transactors}
+import monix.bio.UIO
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -58,56 +49,6 @@ trait Projections {
     *   the name of the projection
     */
   def delete(name: String): UIO[Unit]
-
-  /**
-    * Saves a list of failed elems
-    *
-    * @param metadata
-    *   the metadata of the projection
-    * @param failures
-    *   the FailedElem to save
-    */
-  def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit]
-
-  /**
-    * Get available failed elem entries for a given projection (provided by project and id), starting from a failed elem
-    * offset.
-    * @param projectionProject
-    *   the project the projection belongs to
-    * @param projectionId
-    *   IRI of the projection
-    * @param offset
-    *   failed elem offset
-    */
-  def failedElemEntries(
-      projectionProject: ProjectRef,
-      projectionId: Iri,
-      offset: Offset
-  ): Stream[Task, FailedElemLogRow]
-
-  /**
-    * Get available failed elem entries for a given projection by projection name, starting from a failed elem offset.
-    * @param projectionName
-    *   the name of the projection
-    * @param offset
-    *   failed elem offset
-    * @return
-    */
-  def failedElemEntries(projectionName: String, offset: Offset): Stream[Task, FailedElemLogRow]
-
-  /**
-    * Get available failed elem entries for a given projection (provided by project and id), starting from a failed elem
-    * offset as a stream of Server Sent Events
-    * @param projectionProject
-    *   the project the projection belongs to
-    * @param projectionId
-    *   IRI of the projection
-    * @param offset
-    *   failed elem offset
-    */
-  def failedElemSses(projectionProject: ProjectRef, projectionId: Iri, offset: Offset)(implicit
-      rcr: RemoteContextResolution
-  ): Stream[Task, ServerSentEvent]
 
   /**
     * Schedules a restart for the given projection at the given offset
@@ -169,41 +110,12 @@ object Projections {
       private val projectionStore        = ProjectionStore(xas, config)
       private val projectionRestartStore = new ProjectionRestartStore(xas, config)
 
-      implicit private val api: JsonLdApi = JsonLdJavaApi.lenient
-      private val defaultPrinter: Printer = Printer(dropNullValues = true, indent = "")
-
       override def progress(name: String): UIO[Option[ProjectionProgress]] = projectionStore.offset(name)
 
       override def save(metadata: ProjectionMetadata, progress: ProjectionProgress): UIO[Unit] =
         projectionStore.save(metadata, progress)
 
       override def delete(name: String): UIO[Unit] = projectionStore.delete(name)
-
-      override def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit] =
-        projectionStore.saveFailedElems(metadata, failures)
-
-      override def failedElemEntries(
-          projectionProject: ProjectRef,
-          projectionId: Iri,
-          offset: Offset
-      ): Stream[Task, FailedElemLogRow] =
-        projectionStore.failedElemEntries(projectionProject, projectionId, offset)
-
-      override def failedElemEntries(projectionName: String, offset: Offset): Stream[Task, FailedElemLogRow] =
-        projectionStore.failedElemEntries(projectionName, offset)
-
-      override def failedElemSses(projectionProject: ProjectRef, projectionId: Iri, offset: Offset)(implicit
-          rcr: RemoteContextResolution
-      ): Stream[Task, ServerSentEvent] =
-        failedElemEntries(projectionProject, projectionId, offset).evalMap { felem =>
-          felem.failedElemData.toCompactedJsonLd.map { compactJson =>
-            ServerSentEvent(
-              defaultPrinter.print(compactJson.json),
-              "IndexingFailure",
-              felem.ordering.value.toString
-            )
-          }
-        }
 
       override def scheduleRestart(projectionName: String)(implicit subject: Subject): UIO[Unit] = {
         IOUtils.instant.flatMap { now =>

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/ProjectionStore.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/ProjectionStore.scala
@@ -1,29 +1,24 @@
 package ch.epfl.bluebrain.nexus.delta.sourcing.stream
 
 import cats.effect.Clock
-import cats.implicits._
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.IOUtils
-import ch.epfl.bluebrain.nexus.delta.kernel.utils.ThrowableUtils._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
+import ch.epfl.bluebrain.nexus.delta.sourcing.implicits._
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{EntityType, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
-import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.ProjectionProgressRow
-import ch.epfl.bluebrain.nexus.delta.sourcing.implicits._
-import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.FailedElem
-import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.FailedElemLogRow
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.FailedElemLogRow.FailedElemData
-import com.typesafe.scalalogging.Logger
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionStore.ProjectionProgressRow
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2.Stream
-import io.circe.generic.semiauto.deriveEncoder
 import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
 import monix.bio.{Task, UIO}
 
 import java.time.Instant
@@ -65,54 +60,9 @@ trait ProjectionStore {
     */
   def entries: Stream[Task, ProjectionProgressRow]
 
-  /**
-    * Saves a list of failed elems
-    *
-    * @param metadata
-    *   the metadata of the projection
-    * @param failures
-    *   the FailedElem to save
-    */
-  def saveFailedElems(metadata: ProjectionMetadata, failures: List[FailedElem]): UIO[Unit]
-
-  /**
-    * Saves one failed elem
-    */
-  protected def saveFailedElem(metadata: ProjectionMetadata, failure: FailedElem, instant: Instant): ConnectionIO[Unit]
-
-  /**
-    * Get available failed elem entries for a given projection (provided by project and id), starting from a failed elem
-    * offset.
-    * @param projectionProject
-    *   the project the projection belongs to
-    * @param projectionId
-    *   IRI of the projection
-    * @param offset
-    *   failed elem offset
-    */
-  def failedElemEntries(
-      projectionProject: ProjectRef,
-      projectionId: Iri,
-      offset: Offset
-  ): Stream[Task, FailedElemLogRow]
-
-  /**
-    * Get available failed elem entries for a given projection by projection name, starting from a failed elem offset.
-    * @param projectionName
-    *   the name of the projection
-    * @param offset
-    *   failed elem offset
-    * @return
-    */
-  def failedElemEntries(
-      projectionName: String,
-      offset: Offset
-  ): Stream[Task, FailedElemLogRow]
-
 }
 
 object ProjectionStore {
-  private val logger: Logger = Logger[ProjectionStore]
 
   def apply(xas: Transactors, config: QueryConfig)(implicit clock: Clock[UIO]): ProjectionStore =
     new ProjectionStore {
@@ -162,80 +112,6 @@ object ProjectionStore {
           .query[ProjectionProgressRow]
           .streamWithChunkSize(config.batchSize)
           .transact(xas.read)
-
-      override def failedElemEntries(
-          projectionProject: ProjectRef,
-          projectionId: Iri,
-          offset: Offset
-      ): Stream[Task, FailedElemLogRow] =
-        sql"""SELECT * from public.failed_elem_logs
-             |WHERE projection_project = $projectionProject
-             |AND projection_id = $projectionId
-             |AND ordering > $offset
-             |ORDER BY ordering ASC""".stripMargin
-          .query[FailedElemLogRow]
-          .streamWithChunkSize(config.batchSize)
-          .transact(xas.read)
-
-      override def failedElemEntries(
-          projectionName: String,
-          offset: Offset
-      ): Stream[Task, FailedElemLogRow] =
-        sql"""SELECT * from public.failed_elem_logs
-             |WHERE projection_name = $projectionName
-             |AND ordering > $offset
-             |ORDER BY ordering ASC""".stripMargin
-          .query[FailedElemLogRow]
-          .streamWithChunkSize(config.batchSize)
-          .transact(xas.read)
-
-      override def saveFailedElems(
-          metadata: ProjectionMetadata,
-          failures: List[FailedElem]
-      ): UIO[Unit] = {
-        val log  = UIO(logger.debug(s"[{}] Saving {} failed elems.", metadata.name, failures.length))
-        val save = IOUtils.instant.flatMap { instant =>
-          failures.traverse(elem => saveFailedElem(metadata, elem, instant)).transact(xas.write).void.hideErrors
-        }
-        log >> save
-      }
-
-      override protected def saveFailedElem(
-          metadata: ProjectionMetadata,
-          failure: FailedElem,
-          instant: Instant
-      ): ConnectionIO[Unit] =
-        sql"""
-             | INSERT INTO public.failed_elem_logs (
-             |  projection_name,
-             |  projection_module,
-             |  projection_project,
-             |  projection_id,
-             |  entity_type,
-             |  elem_offset,
-             |  elem_id,
-             |  elem_project,
-             |  rev,
-             |  error_type,
-             |  message,
-             |  stack_trace,
-             |  instant
-             | )
-             | VALUES (
-             |  ${metadata.name},
-             |  ${metadata.module},
-             |  ${metadata.project},
-             |  ${metadata.resourceId},
-             |  ${failure.tpe},
-             |  ${failure.offset},
-             |  ${failure.id},
-             |  ${failure.project},
-             |  ${failure.rev},
-             |  ${failure.throwable.getClass.getCanonicalName},
-             |  ${failure.throwable.getMessage},
-             |  ${stackTraceAsString(failure.throwable)},
-             |  $instant
-             | )""".stripMargin.update.run.void
     }
 
   final case class ProjectionProgressRow(

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/Supervisor.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/Supervisor.scala
@@ -299,8 +299,7 @@ object Supervisor {
       val metadata = projection.metadata
       val strategy = projection.executionStrategy
       if (!strategy.shouldRun(metadata.name, cfg.cluster))
-        log.debug(s"Ignoring '${metadata.module}/${metadata.name}' with strategy '$strategy'.") >>
-          Task.pure(ignored)
+        log.debug(s"Ignoring '${metadata.module}/${metadata.name}' with strategy '$strategy'.").as(ignored)
       else
         log.info(s"Starting '${metadata.module}/${metadata.name}' with strategy '$strategy'.") >>
           init >>
@@ -334,10 +333,9 @@ object Supervisor {
           status     <- supervised.traverse { s =>
                           val metadata = s.metadata
                           if (!s.executionStrategy.shouldRun(name, cfg.cluster))
-                            Task.delay(
-                              log.info(s"'${metadata.module}/${metadata.name}' is ignored. Skipping restart...")
-                            ) >>
-                              Task.pure(ExecutionStatus.Ignored)
+                            log
+                              .info(s"'${metadata.module}/${metadata.name}' is ignored. Skipping restart...")
+                              .as(ExecutionStatus.Ignored)
                           else {
                             for {
                               _      <- log.info(s"Restarting '${metadata.module}/${metadata.name}'...")
@@ -361,8 +359,9 @@ object Supervisor {
                           val metadata      = s.metadata
                           val retryStrategy = createRetryStrategy(cfg, metadata, "destroying")
                           if (!s.executionStrategy.shouldRun(name, cfg.cluster))
-                            log.info(s"'${metadata.module}/${metadata.name}' is ignored. Skipping...") >>
-                              Task.pure(ExecutionStatus.Ignored)
+                            log
+                              .info(s"'${metadata.module}/${metadata.name}' is ignored. Skipping...")
+                              .as(ExecutionStatus.Ignored)
                           else {
                             for {
                               _      <- log.info(s"Destroying '${metadata.module}/${metadata.name}'...")

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/FailedElemLogStoreSuite.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/projections/FailedElemLogStoreSuite.scala
@@ -1,0 +1,148 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing.projections
+
+import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
+import ch.epfl.bluebrain.nexus.delta.sourcing.PurgeElemFailures
+import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.{EntityType, ProjectRef}
+import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
+import ch.epfl.bluebrain.nexus.delta.sourcing.postgres.Doobie
+import ch.epfl.bluebrain.nexus.delta.sourcing.query.RefreshStrategy
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.FailedElem
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionMetadata
+import ch.epfl.bluebrain.nexus.testkit.IOFixedClock
+import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
+import munit.AnyFixture
+
+import java.time.Instant
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+class FailedElemLogStoreSuite extends BioSuite with IOFixedClock with Doobie.Fixture with Doobie.Assertions {
+
+  override def munitFixtures: Seq[AnyFixture[_]] = List(doobie)
+
+  private lazy val xas = doobie()
+
+  private lazy val store = FailedElemLogStore(xas, QueryConfig(10, RefreshStrategy.Stop))
+
+  private val name     = "offset"
+  private val project  = ProjectRef.unsafe("org", "proj")
+  private val resource = iri"https://resource"
+  private val metadata = ProjectionMetadata("test", name, Some(project), Some(resource))
+
+  private val id    = nxv + "id"
+  private val error = new RuntimeException("boom")
+  private val rev   = 1
+  private val fail1 = FailedElem(EntityType("ACL"), id, Some(project), Instant.EPOCH, Offset.At(42L), error, rev)
+  private val fail2 = FailedElem(EntityType("Schema"), id, Some(project), Instant.EPOCH, Offset.At(42L), error, rev)
+
+  test("Return no failed elem entries by name") {
+    for {
+      entries <- store.failedElemEntries(name, Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Return no failed elem entries by (project, id)") {
+    for {
+      entries <- store.failedElemEntries(project, resource, Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Insert empty list of failed elem") {
+    for {
+      _       <- store.saveFailedElems(metadata, List.empty)
+      entries <- store.failedElemEntries(name, Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Return no failed elem entries by name") {
+    for {
+      entries <- store.failedElemEntries(name, Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Return no failed elem entries by (project, id)") {
+    for {
+      entries <- store.failedElemEntries(project, resource, Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Insert empty list of failed elem") {
+    for {
+      _       <- store.saveFailedElems(metadata, List.empty)
+      entries <- store.failedElemEntries(name, Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Insert failed elem") {
+    for {
+      _       <- store.saveFailedElems(metadata, List(fail1))
+      entries <- store.failedElemEntries(name, Offset.start).compile.toList
+      r        = entries.assertOneElem
+      _        = assertEquals(r.projectionMetadata, metadata)
+      _        = assertEquals(r.ordering, Offset.At(1L))
+      _        = assertEquals(r.instant, Instant.EPOCH)
+      elem     = r.failedElemData
+      _        = assertEquals(elem.offset, Offset.At(42L))
+      _        = assertEquals(elem.errorType, "java.lang.RuntimeException")
+      _        = assertEquals(elem.id, id)
+      _        = assertEquals(elem.entityType, EntityType("ACL"))
+      _        = assertEquals(elem.rev, rev)
+      _        = assertEquals(elem.project, Some(project))
+    } yield ()
+  }
+
+  test("Insert several failed elem") {
+    for {
+      _       <- store.saveFailedElems(metadata, List(fail1, fail2))
+      entries <- store.failedElemEntries(name, Offset.start).compile.toList
+      _        = entries.assertSize(3)
+    } yield ()
+  }
+
+  test("Return failed elem entries by (project, id)") {
+    for {
+      entries <- store.failedElemEntries(project, resource, Offset.start).compile.toList
+      _        = entries.assertSize(3)
+    } yield ()
+  }
+
+  test("Return empty if no failed elem is found by name") {
+    for {
+      entries <- store.failedElemEntries("other", Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Return empty if not found by (project, id)") {
+    for {
+      entries <- store.failedElemEntries(project, iri"https://example.com", Offset.start).compile.toList
+      _        = entries.assertEmpty()
+    } yield ()
+  }
+
+  test("Purge failed elements after predefined ttl") {
+    val failedElemTtl = 14.days
+
+    lazy val purgeElemFailures: FiniteDuration => PurgeElemFailures = timeTravel =>
+      new PurgeElemFailures(xas, failedElemTtl)(
+        IOFixedClock.ioClock(Instant.EPOCH.plusMillis(timeTravel.toMillis))
+      )
+
+    for {
+      _        <- purgeElemFailures(failedElemTtl - 500.millis)()
+      entries  <- store.failedElemEntries(project, resource, Offset.start).compile.toList
+      _         = entries.assertSize(3) // no elements are deleted after 13 days
+      _        <- purgeElemFailures(failedElemTtl + 500.millis)()
+      entries2 <- store.failedElemEntries(project, resource, Offset.start).compile.toList
+      _         = entries2.assertEmpty() // all elements were deleted after 14 days
+    } yield ()
+  }
+
+}

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/ProjectionStoreSuite.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/ProjectionStoreSuite.scala
@@ -1,20 +1,16 @@
 package ch.epfl.bluebrain.nexus.delta.sourcing.stream
 
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
-import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
-import ch.epfl.bluebrain.nexus.delta.sourcing.PurgeElemFailures
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.QueryConfig
-import ch.epfl.bluebrain.nexus.delta.sourcing.model.{EntityType, ProjectRef}
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
+import ch.epfl.bluebrain.nexus.delta.sourcing.postgres.Doobie
 import ch.epfl.bluebrain.nexus.delta.sourcing.query.RefreshStrategy
-import ch.epfl.bluebrain.nexus.delta.sourcing.stream.Elem.FailedElem
 import ch.epfl.bluebrain.nexus.testkit.IOFixedClock
 import ch.epfl.bluebrain.nexus.testkit.bio.BioSuite
-import ch.epfl.bluebrain.nexus.delta.sourcing.postgres.Doobie
 import munit.AnyFixture
 
 import java.time.Instant
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 class ProjectionStoreSuite extends BioSuite with IOFixedClock with Doobie.Fixture with Doobie.Assertions {
 
@@ -75,98 +71,4 @@ class ProjectionStoreSuite extends BioSuite with IOFixedClock with Doobie.Fixtur
       _       <- store.offset(name).assertNone
     } yield ()
   }
-
-  private val id    = nxv + "id"
-  private val error = new RuntimeException("boom")
-  private val rev   = 1
-  private val fail1 = FailedElem(EntityType("ACL"), id, Some(project), Instant.EPOCH, Offset.At(42L), error, rev)
-  private val fail2 = FailedElem(EntityType("Schema"), id, Some(project), Instant.EPOCH, Offset.At(42L), error, rev)
-
-  test("Return no failed elem entries by name") {
-    for {
-      entries <- store.failedElemEntries(name, Offset.start).compile.toList
-      _        = entries.assertEmpty()
-    } yield ()
-  }
-
-  test("Return no failed elem entries by (project, id)") {
-    for {
-      entries <- store.failedElemEntries(project, resource, Offset.start).compile.toList
-      _        = entries.assertEmpty()
-    } yield ()
-  }
-
-  test("Insert empty list of failed elem") {
-    for {
-      _       <- store.saveFailedElems(metadata, List.empty)
-      entries <- store.failedElemEntries(name, Offset.start).compile.toList
-      _        = entries.assertEmpty()
-    } yield ()
-  }
-
-  test("Insert failed elem") {
-    for {
-      _       <- store.saveFailedElems(metadata, List(fail1))
-      entries <- store.failedElemEntries(name, Offset.start).compile.toList
-      r        = entries.assertOneElem
-      _        = assertEquals(r.projectionMetadata, metadata)
-      _        = assertEquals(r.ordering, Offset.At(1L))
-      _        = assertEquals(r.instant, Instant.EPOCH)
-      elem     = r.failedElemData
-      _        = assertEquals(elem.offset, Offset.At(42L))
-      _        = assertEquals(elem.errorType, "java.lang.RuntimeException")
-      _        = assertEquals(elem.id, id)
-      _        = assertEquals(elem.entityType, EntityType("ACL"))
-      _        = assertEquals(elem.rev, rev)
-      _        = assertEquals(elem.project, Some(project))
-    } yield ()
-  }
-
-  test("Insert several failed elem") {
-    for {
-      _       <- store.saveFailedElems(metadata, List(fail1, fail2))
-      entries <- store.failedElemEntries(name, Offset.start).compile.toList
-      _        = entries.assertSize(3)
-    } yield ()
-  }
-
-  test("Return failed elem entries by (project, id)") {
-    for {
-      entries <- store.failedElemEntries(project, resource, Offset.start).compile.toList
-      _        = entries.assertSize(3)
-    } yield ()
-  }
-
-  test("Return empty if no failed elem is found by name") {
-    for {
-      entries <- store.failedElemEntries("other", Offset.start).compile.toList
-      _        = entries.assertEmpty()
-    } yield ()
-  }
-
-  test("Return empty if not found by (project, id)") {
-    for {
-      entries <- store.failedElemEntries(project, iri"https://example.com", Offset.start).compile.toList
-      _        = entries.assertEmpty()
-    } yield ()
-  }
-
-  test("Purge failed elements after predefined ttl") {
-    val failedElemTtl = 14.days
-
-    lazy val purgeElemFailures: FiniteDuration => PurgeElemFailures = timeTravel =>
-      new PurgeElemFailures(xas, failedElemTtl)(
-        IOFixedClock.ioClock(Instant.EPOCH.plusMillis(timeTravel.toMillis))
-      )
-
-    for {
-      _        <- purgeElemFailures(failedElemTtl - 500.millis)()
-      entries  <- store.failedElemEntries(project, resource, Offset.start).compile.toList
-      _         = entries.assertSize(3) // no elements are deleted after 13 days
-      _        <- purgeElemFailures(failedElemTtl + 500.millis)()
-      entries2 <- store.failedElemEntries(project, resource, Offset.start).compile.toList
-      _         = entries2.assertEmpty() // all elements were deleted after 14 days
-    } yield ()
-  }
-
 }

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/SupervisorSetup.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/SupervisorSetup.scala
@@ -4,7 +4,7 @@ import cats.effect.{Clock, Resource}
 import ch.epfl.bluebrain.nexus.delta.kernel.RetryStrategyConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.ProjectionConfig.ClusterConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.{BatchConfig, ProjectionConfig, QueryConfig}
-import ch.epfl.bluebrain.nexus.delta.sourcing.projections.Projections
+import ch.epfl.bluebrain.nexus.delta.sourcing.projections.{ProjectionErrors, Projections}
 import ch.epfl.bluebrain.nexus.delta.sourcing.query.RefreshStrategy
 import ch.epfl.bluebrain.nexus.testkit.bio.{BioSuite, ResourceFixture}
 import ch.epfl.bluebrain.nexus.delta.sourcing.postgres.Doobie
@@ -12,13 +12,18 @@ import monix.bio.{Task, UIO}
 
 import scala.concurrent.duration._
 
+final case class SupervisorSetup(supervisor: Supervisor, projections: Projections, projectionErrors: ProjectionErrors)
+
 object SupervisorSetup {
 
   val defaultQueryConfig: QueryConfig = QueryConfig(10, RefreshStrategy.Delay(10.millis))
 
+  def unapply(setup: SupervisorSetup): (Supervisor, Projections, ProjectionErrors) =
+    (setup.supervisor, setup.projections, setup.projectionErrors)
+
   def resource(
       cluster: ClusterConfig
-  )(implicit clock: Clock[UIO], cl: ClassLoader): Resource[Task, (Supervisor, Projections)] = {
+  )(implicit clock: Clock[UIO], cl: ClassLoader): Resource[Task, SupervisorSetup] = {
     val config: ProjectionConfig = ProjectionConfig(
       cluster,
       BatchConfig(3, 50.millis),
@@ -34,22 +39,23 @@ object SupervisorSetup {
 
   def resource(
       config: ProjectionConfig
-  )(implicit clock: Clock[UIO], cl: ClassLoader): Resource[Task, (Supervisor, Projections)] =
+  )(implicit clock: Clock[UIO], cl: ClassLoader): Resource[Task, SupervisorSetup] =
     Doobie.resource().flatMap { xas =>
-      val projections = Projections(xas, config.query, config.restartTtl)
-      Supervisor(projections, config).map(_ -> projections)
+      val projections      = Projections(xas, config.query, config.restartTtl)
+      val projectionErrors = ProjectionErrors(xas, config.query)
+      Supervisor(projections, projectionErrors, config).map(s => SupervisorSetup(s, projections, projectionErrors))
     }
 
   def suiteLocalFixture(name: String, cluster: ClusterConfig)(implicit
       clock: Clock[UIO],
       cl: ClassLoader
-  ): ResourceFixture.TaskFixture[(Supervisor, Projections)] =
+  ): ResourceFixture.TaskFixture[SupervisorSetup] =
     ResourceFixture.suiteLocal(name, resource(cluster))
 
   trait Fixture { self: BioSuite =>
-    val supervisor: ResourceFixture.TaskFixture[(Supervisor, Projections)]    =
+    val supervisor: ResourceFixture.TaskFixture[SupervisorSetup]    =
       SupervisorSetup.suiteLocalFixture("supervisor", ClusterConfig(1, 0))
-    val supervisor3_1: ResourceFixture.TaskFixture[(Supervisor, Projections)] =
+    val supervisor3_1: ResourceFixture.TaskFixture[SupervisorSetup] =
       SupervisorSetup.suiteLocalFixture("supervisor3", ClusterConfig(3, 1))
   }
 

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/SupervisorSuite.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/SupervisorSuite.scala
@@ -13,6 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.stream.ProjectionProgress.NoProgre
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.SupervisorSuite.UnstableDestroy
 import ch.epfl.bluebrain.nexus.testkit.bio.{BioSuite, PatienceConfig}
 import ch.epfl.bluebrain.nexus.delta.sourcing.postgres.Doobie
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.SupervisorSetup.unapply
 import fs2.Stream
 import monix.bio.Task
 import munit.AnyFixture
@@ -27,12 +28,12 @@ class SupervisorSuite extends BioSuite with SupervisorSetup.Fixture with Doobie.
 
   override def munitFixtures: Seq[AnyFixture[_]] = List(supervisor3_1)
 
-  private lazy val (sv, projections) = supervisor3_1()
+  private lazy val (sv, projections, _) = unapply(supervisor3_1())
   // name1 should run on the node with index 1 in a 3-node cluster
-  private val runnableByNode1        = ProjectionMetadata("test", "name1", None, None)
+  private val runnableByNode1           = ProjectionMetadata("test", "name1", None, None)
   // name2 should NOT run on the node with index 1 of a 3-node cluster
-  private val ignoredByNode1         = ProjectionMetadata("test", "name2", None, None)
-  private val random                 = ProjectionMetadata("test", "name3", None, None)
+  private val ignoredByNode1            = ProjectionMetadata("test", "name2", None, None)
+  private val random                    = ProjectionMetadata("test", "name3", None, None)
 
   private val rev = 1
 


### PR DESCRIPTION
Before handling properly #3979 and adding more complexity to `Projections`, these changes allow to keep complexity to a reasonable level.

This PR also changes the logger for `Supervisor` to one powered by log4cats