### PR TITLE
Add a dedicated user for aggregations integration tests

### DIFF
--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/Identity.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/Identity.scala
@@ -57,6 +57,11 @@ object Identity extends TestHelpers {
     val Alice = UserCredentials(genString(), genString(), testRealm)
   }
 
+  object aggregations {
+    val Charlie = UserCredentials(genString(), genString(), testRealm)
+    val Rose    = UserCredentials(genString(), genString(), testRealm)
+  }
+
   object orgs {
     val Fry   = UserCredentials(genString(), genString(), testRealm)
     val Leela = UserCredentials(genString(), genString(), testRealm)
@@ -89,6 +94,6 @@ object Identity extends TestHelpers {
   }
 
   lazy val allUsers =
-    acls.Marge :: archives.Tweety :: compositeviews.Jerry :: events.BugsBunny :: listings.Bob :: listings.Alice :: orgs.Fry :: orgs.Leela :: projects.Bojack :: projects.PrincessCarolyn :: resources.Rick :: resources.Morty :: storages.Coyote :: views.ScoobyDoo :: mash.Radar :: supervision.Mickey :: Nil
+    acls.Marge :: archives.Tweety :: compositeviews.Jerry :: events.BugsBunny :: listings.Bob :: listings.Alice :: aggregations.Charlie :: aggregations.Rose :: orgs.Fry :: orgs.Leela :: projects.Bojack :: projects.PrincessCarolyn :: resources.Rick :: resources.Morty :: storages.Coyote :: views.ScoobyDoo :: mash.Radar :: supervision.Mickey :: Nil
 
 }


### PR DESCRIPTION
Using the same user for the listing and aggregation tests makes tests flaky as some of the tests are made on all orgs and all projects and as both tests create resources, projects and orgs, they interact with each other