### PR TITLE
Allow using absolute paths

### DIFF
--- a/storage/src/main/resources/app.conf
+++ b/storage/src/main/resources/app.conf
@@ -34,6 +34,8 @@ app {
   storage {
     # the absolute path where the files are stored
     root-volume = "/tmp"
+    # additional path prefixes from which it is allowed to link
+    extra-prefixes = []
     # the relative path of the protected directory once the storage bucket is selected
     protected-directory = "nexus"
     # permissions fixer

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Rejection.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/Rejection.scala
@@ -33,11 +33,11 @@ object Rejection {
     * @param name
     *   the storage bucket name
     * @param path
-    *   the relative path to the file
+    *   the path to the file
     */
   final case class PathAlreadyExists(name: String, path: Path)
       extends Rejection(
-        s"The provided location inside the bucket '$name' with the relative path '$path' already exists."
+        s"The provided location inside the bucket '$name' with the path '$path' already exists."
       )
 
   /**
@@ -46,11 +46,11 @@ object Rejection {
     * @param name
     *   the storage bucket name
     * @param path
-    *   the relative path to the file
+    *   the path to the file
     */
   final case class PathNotFound(name: String, path: Path)
       extends Rejection(
-        s"The provided location inside the bucket '$name' with the relative path '$path' does not exist."
+        s"The provided location inside the bucket '$name' with the path '$path' does not exist."
       )
 
   /**
@@ -59,11 +59,11 @@ object Rejection {
     * @param name
     *   the storage bucket name
     * @param path
-    *   the relative path to the file
+    *   the path to the file
     */
   final case class PathContainsLinks(name: String, path: Path)
       extends Rejection(
-        s"The provided location inside the bucket '$name' with the relative path '$path' contains links. Please remove them in order to proceed with this call."
+        s"The provided location inside the bucket '$name' with the path '$path' contains links. Please remove them in order to proceed with this call."
       )
 
   /**

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/StorageError.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/StorageError.scala
@@ -56,11 +56,11 @@ object StorageError {
     * @param name
     *   the storage bucket name
     * @param path
-    *   the relative path to the file
+    *   the path to the file
     */
   final case class PathNotFound(name: String, path: Path)
       extends StorageError(
-        s"The provided location inside the bucket '$name' with the relative path '$path' does not exist."
+        s"The provided location inside the bucket '$name' with the path '$path' does not exist."
       )
 
   /**
@@ -69,11 +69,11 @@ object StorageError {
     * @param name
     *   the storage bucket name
     * @param path
-    *   the relative path to the file
+    *   the path to the file
     */
   final case class PathInvalid(name: String, path: Path)
       extends StorageError(
-        s"The provided location inside the bucket '$name' with the relative path '$path' is invalid."
+        s"The provided location inside the bucket '$name' with the path '$path' is invalid."
       )
 
   /**

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/AppConfig.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/config/AppConfig.scala
@@ -86,6 +86,7 @@ object AppConfig {
     */
   final case class StorageConfig(
       rootVolume: Path,
+      extraPrefixes: List[Path],
       protectedDirectory: Path,
       fixerEnabled: Boolean,
       fixerCommand: Vector[String]

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectives.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectives.scala
@@ -16,12 +16,12 @@ import scala.annotation.tailrec
 object StorageDirectives {
 
   /**
-    * Extracts the relative path from the unmatched segments
+    * Extracts the path from the unmatched segments
     *
     * @param name
     *   the storage bucket name
     */
-  def extractRelativePath(name: String): Directive1[Path] =
+  def extractPath(name: String): Directive1[Path] =
     extractUnmatchedPath.flatMap(p => validatePath(name, p).tmap(_ => relativize(p)))
 
   /**
@@ -67,19 +67,19 @@ object StorageDirectives {
     *
     * @param name
     *   the storage bucket name
-    * @param relativePath
-    *   the relative path location
+    * @param path
+    *   the path location
     * @param storages
     *   the storages bundle api
     * @return
     *   PathExists when the path exists inside the bucket, rejection otherwise
     */
-  def pathExists[F[_]](name: String, relativePath: Uri.Path)(implicit
+  def pathExists[F[_]](name: String, path: Uri.Path)(implicit
       storages: Storages[F, _]
   ): Directive1[PathExists] =
-    storages.pathExists(name, relativePath) match {
+    storages.pathExists(name, path) match {
       case exists: PathExists => provide(exists)
-      case _                  => reject(PathNotFound(name, relativePath))
+      case _                  => reject(PathNotFound(name, path))
     }
 
   /**
@@ -87,26 +87,26 @@ object StorageDirectives {
     *
     * @param name
     *   the storage bucket name
-    * @param relativePath
-    *   the relative path location
+    * @param path
+    *   the path location
     * @param storages
     *   the storages bundle api
     * @return
     *   PathDoesNotExist when the path does not exist inside the bucket, rejection otherwise
     */
-  def pathNotExists[F[_]](name: String, relativePath: Uri.Path)(implicit
+  def pathNotExists[F[_]](name: String, path: Uri.Path)(implicit
       storages: Storages[F, _]
   ): Directive1[PathDoesNotExist] =
-    storages.pathExists(name, relativePath) match {
+    storages.pathExists(name, path) match {
       case notExists: PathDoesNotExist => provide(notExists)
-      case _                           => reject(PathAlreadyExists(name, relativePath))
+      case _                           => reject(PathAlreadyExists(name, path))
     }
 
   /**
     * Extracts the relative file path from the unmatched segments
     */
   def extractRelativeFilePath(name: String): Directive1[Path] =
-    extractRelativePath(name).flatMap {
+    extractPath(name).flatMap {
       case path if path.reverse.startsWithSegment => provide(path)
       case path                                   => failWith(PathInvalid(name, path))
     }

--- a/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutes.scala
+++ b/storage/src/main/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutes.scala
@@ -34,15 +34,15 @@ class StorageRoutes()(implicit storages: Storages[Task, AkkaSource], hc: HttpCon
           }
         },
         // Consume files
-        (pathPrefix("files") & extractRelativePath(name)) { relativePath =>
+        (pathPrefix("files") & extractPath(name)) { path =>
           operationName(s"/${hc.prefix}/buckets/{}/files/{}") {
             bucketExists(name).apply { implicit bucketExistsEvidence =>
               concat(
                 put {
-                  pathNotExists(name, relativePath).apply { implicit pathNotExistEvidence =>
+                  pathNotExists(name, path).apply { implicit pathNotExistEvidence =>
                     // Upload file
                     fileUpload("file") { case (_, source) =>
-                      complete(Created -> storages.createFile(name, relativePath, source).runToFuture)
+                      complete(Created -> storages.createFile(name, path, source).runToFuture)
                     }
                   }
                 },
@@ -50,14 +50,14 @@ class StorageRoutes()(implicit storages: Storages[Task, AkkaSource], hc: HttpCon
                   // Link file/dir
                   entity(as[LinkFile]) { case LinkFile(source) =>
                     validatePath(name, source) {
-                      complete(storages.moveFile(name, source, relativePath).runWithStatus(OK))
+                      complete(storages.moveFile(name, source, path).runWithStatus(OK))
                     }
                   }
                 },
                 // Get file
                 get {
-                  pathExists(name, relativePath).apply { implicit pathExistsEvidence =>
-                    storages.getFile(name, relativePath) match {
+                  pathExists(name, path).apply { implicit pathExistsEvidence =>
+                    storages.getFile(name, path) match {
                       case Right((source, Some(_))) => complete(HttpEntity(`application/octet-stream`, source))
                       case Right((source, None))    => complete(HttpEntity(`application/x-tar`, source))
                       case Left(err)                => complete(err)
@@ -69,13 +69,13 @@ class StorageRoutes()(implicit storages: Storages[Task, AkkaSource], hc: HttpCon
           }
         },
         // Consume attributes
-        (pathPrefix("attributes") & extractRelativePath(name)) { relativePath =>
+        (pathPrefix("attributes") & extractPath(name)) { path =>
           operationName(s"/${hc.prefix}/buckets/{}/attributes/{}") {
             bucketExists(name).apply { implicit bucketExistsEvidence =>
               // Get file attributes
               get {
-                pathExists(name, relativePath).apply { implicit pathExistsEvidence =>
-                  val result = storages.getAttributes(name, relativePath).map[(StatusCode, FileAttributes)] {
+                pathExists(name, path).apply { implicit pathExistsEvidence =>
+                  val result = storages.getAttributes(name, path).map[(StatusCode, FileAttributes)] {
                     case attr @ FileAttributes(_, _, Digest.empty, _) => Accepted -> attr
                     case attr                                         => OK       -> attr
                   }
@@ -95,7 +95,7 @@ object StorageRoutes {
     * Link file request.
     *
     * @param source
-    *   the relative location of the file/dir
+    *   the location of the file/dir
     */
   final private[routes] case class LinkFile(source: Uri.Path)
 

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectivesSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageDirectivesSpec.scala
@@ -30,7 +30,7 @@ class StorageDirectivesSpec
           quote("{type}") -> "PathInvalid",
           quote(
             "{reason}"
-          )               -> s"The provided location inside the bucket 'name' with the relative path '$path' is invalid."
+          )               -> s"The provided location inside the bucket 'name' with the path '$path' is invalid."
         )
       )
 

--- a/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutesSpec.scala
+++ b/storage/src/test/scala/ch/epfl/bluebrain/nexus/storage/routes/StorageRoutesSpec.scala
@@ -137,7 +137,7 @@ class StorageRoutesSpec
               quote("{type}") -> "PathAlreadyExists",
               quote(
                 "{reason}"
-              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' already exists."
+              )               -> s"The provided location inside the bucket '$name' with the path '$filePathUri' already exists."
             )
           )
           storages.exists(name) wasCalled once
@@ -259,7 +259,7 @@ class StorageRoutesSpec
               quote("{type}") -> "PathInvalid",
               quote(
                 "{reason}"
-              )               -> s"The provided location inside the bucket '$name' with the relative path '$source' is invalid."
+              )               -> s"The provided location inside the bucket '$name' with the path '$source' is invalid."
             )
           )
         }
@@ -308,7 +308,7 @@ class StorageRoutesSpec
               quote("{type}") -> "PathNotFound",
               quote(
                 "{reason}"
-              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' does not exist."
+              )               -> s"The provided location inside the bucket '$name' with the path '$filePathUri' does not exist."
             )
           )
           storages.pathExists(name, filePathUri) wasCalled once
@@ -329,7 +329,7 @@ class StorageRoutesSpec
               quote("{type}") -> "PathNotFound",
               quote(
                 "{reason}"
-              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' does not exist."
+              )               -> s"The provided location inside the bucket '$name' with the path '$filePathUri' does not exist."
             )
           )
           storages.getFile(name, filePathUri) wasCalled once
@@ -381,7 +381,7 @@ class StorageRoutesSpec
               quote("{type}") -> "PathNotFound",
               quote(
                 "{reason}"
-              )               -> s"The provided location inside the bucket '$name' with the relative path '$filePathUri' does not exist."
+              )               -> s"The provided location inside the bucket '$name' with the path '$filePathUri' does not exist."
             )
           )
           storages.pathExists(name, filePathUri) wasCalled once


### PR DESCRIPTION
Resolves #4188

This extends the current behavior by allowing users to also specify absolute paths when linking, uploading, fetching files/directories. It also adds the possibility of linking a file from outside a project bucket, as long as the path has an configured extra prefix.

In short:
* If a relative path is specified, it is assumed to be relative to the project bucket.
* If an absolute path is specified, an operation will only happen if:
    * The path is a descendant of the base root path
    * The path is allowed by the extra-prefixes config