### PR TITLE
Validate index with indexing rev

### DIFF
--- a/delta/plugins/elasticsearch/src/main/resources/contexts/elasticsearch-metadata.json
+++ b/delta/plugins/elasticsearch/src/main/resources/contexts/elasticsearch-metadata.json
@@ -3,8 +3,7 @@
     "View": "https://bluebrain.github.io/nexus/vocabulary/View",
     "ElasticSearchView": "https://bluebrain.github.io/nexus/vocabulary/ElasticSearchView",
     "AggregateElasticSearchView": "https://bluebrain.github.io/nexus/vocabulary/AggregateElasticSearchView",
-    "_uuid": "https://bluebrain.github.io/nexus/vocabulary/uuid",
-    "_indexingRev": "https://bluebrain.github.io/nexus/vocabulary/indexingRev"
+    "_uuid": "https://bluebrain.github.io/nexus/vocabulary/uuid"
   },
   "@id": "https://bluebrain.github.io/nexus/contexts/elasticsearch-metadata.json"
 }

--- a/delta/plugins/elasticsearch/src/main/resources/contexts/elasticsearch.json
+++ b/delta/plugins/elasticsearch/src/main/resources/contexts/elasticsearch.json
@@ -18,8 +18,7 @@
       "viewId": {
         "@type": "@id"
       },
-      "_uuid": "https://bluebrain.github.io/nexus/vocabulary/uuid",
-      "_indexingRev": "https://bluebrain.github.io/nexus/vocabulary/indexingRev"
+      "_uuid": "https://bluebrain.github.io/nexus/vocabulary/uuid"
     },
     "https://bluebrain.github.io/nexus/contexts/pipeline.json"
   ],

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ValidateElasticSearchView.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ValidateElasticSearchView.scala
@@ -4,7 +4,7 @@ import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.{ElasticSearchClient, IndexLabel}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewRejection.{InvalidElasticSearchIndexPayload, InvalidPipeline, InvalidViewReferences, PermissionIsNotDefined, TooManyViewReferences, WrappedElasticSearchClientError}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.{AggregateElasticSearchViewValue, IndexingElasticSearchViewValue}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewRejection, ElasticSearchViewValue, defaultElasticsearchMapping, defaultElasticsearchSettings}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultElasticsearchMapping, defaultElasticsearchSettings, ElasticSearchViewRejection, ElasticSearchViewValue}
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClient.HttpResult
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError.HttpClientStatusError
 import ch.epfl.bluebrain.nexus.delta.sdk.permissions.Permissions
@@ -82,7 +82,11 @@ object ValidateElasticSearchView {
                              }
       } yield ()
 
-    override def apply(uuid: UUID, indexingRev: IndexingRev, value: ElasticSearchViewValue): IO[ElasticSearchViewRejection, Unit] =
+    override def apply(
+        uuid: UUID,
+        indexingRev: IndexingRev,
+        value: ElasticSearchViewValue
+    ): IO[ElasticSearchViewRejection, Unit] =
       value match {
         case v: AggregateElasticSearchViewValue =>
           validateAggregate(v.views)

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/IndexLabel.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/client/IndexLabel.scala
@@ -5,6 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.error.FormatError
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLdCursor
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoder
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError.ParsingFailure
+import ch.epfl.bluebrain.nexus.delta.sdk.views.IndexingRev
 import io.circe.{Decoder, Encoder}
 
 import java.util.UUID
@@ -79,8 +80,8 @@ object IndexLabel {
     * @param indexingRev
     *   the view's indexing revision
     */
-  final def fromView(prefix: String, uuid: UUID, indexingRev: Int): IndexLabel =
-    new IndexLabel(s"${prefix}_${uuid}_$indexingRev")
+  final def fromView(prefix: String, uuid: UUID, indexingRev: IndexingRev): IndexLabel =
+    new IndexLabel(s"${prefix}_${uuid}_${indexingRev.value}")
 
   implicit val indexLabelJsonLdDecoder: JsonLdDecoder[IndexLabel] =
     (cursor: ExpandedJsonLdCursor) =>

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/IndexingViewDef.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/IndexingViewDef.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyChain
 import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViews
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewState, contexts}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts, ElasticSearchViewState}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.GraphResourceStream
@@ -40,16 +40,16 @@ object IndexingViewDef {
     * Active view eligible to be run as a projection by the supervisor
     */
   final case class ActiveViewDef(
-                                  ref: ViewRef,
-                                  projection: String,
-                                  resourceTag: Option[UserTag],
-                                  pipeChain: Option[PipeChain],
-                                  index: IndexLabel,
-                                  mapping: JsonObject,
-                                  settings: JsonObject,
-                                  context: Option[ContextObject],
-                                  indexingRev: IndexingRev,
-                                  rev: Int
+      ref: ViewRef,
+      projection: String,
+      resourceTag: Option[UserTag],
+      pipeChain: Option[PipeChain],
+      index: IndexLabel,
+      mapping: JsonObject,
+      settings: JsonObject,
+      context: Option[ContextObject],
+      indexingRev: IndexingRev,
+      rev: Int
   ) extends IndexingViewDef {
 
     def projectionMetadata: ProjectionMetadata =

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/IndexingViewDef.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/IndexingViewDef.scala
@@ -4,11 +4,11 @@ import cats.data.NonEmptyChain
 import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViews
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts, ElasticSearchViewState}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewState, contexts}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.GraphResourceStream
-import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ElemStream, Tag}
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
@@ -40,16 +40,16 @@ object IndexingViewDef {
     * Active view eligible to be run as a projection by the supervisor
     */
   final case class ActiveViewDef(
-      ref: ViewRef,
-      projection: String,
-      resourceTag: Option[UserTag],
-      pipeChain: Option[PipeChain],
-      index: IndexLabel,
-      mapping: JsonObject,
-      settings: JsonObject,
-      context: Option[ContextObject],
-      indexingRev: Int,
-      rev: Int
+                                  ref: ViewRef,
+                                  projection: String,
+                                  resourceTag: Option[UserTag],
+                                  pipeChain: Option[PipeChain],
+                                  index: IndexLabel,
+                                  mapping: JsonObject,
+                                  settings: JsonObject,
+                                  context: Option[ContextObject],
+                                  indexingRev: IndexingRev,
+                                  rev: Int
   ) extends IndexingViewDef {
 
     def projectionMetadata: ProjectionMetadata =

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchView.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchView.scala
@@ -126,10 +126,9 @@ object ElasticSearchView {
       context: Option[ContextObject],
       permission: Permission,
       tags: Tags,
-      source: Json,
-      indexingRev: Int
+      source: Json
   ) extends ElasticSearchView {
-    override def metadata: Metadata = Metadata(Some(uuid), Some(indexingRev))
+    override def metadata: Metadata = Metadata(Some(uuid))
 
     override def tpe: ElasticSearchViewType = ElasticSearchViewType.ElasticSearch
   }
@@ -157,7 +156,7 @@ object ElasticSearchView {
       tags: Tags,
       source: Json
   ) extends ElasticSearchView {
-    override def metadata: Metadata         = Metadata(None, None)
+    override def metadata: Metadata         = Metadata(None)
     override def tpe: ElasticSearchViewType = ElasticSearchViewType.AggregateElasticSearch
   }
 
@@ -169,7 +168,7 @@ object ElasticSearchView {
     * @param indexingRev
     *   the optionally available indexing revision
     */
-  final case class Metadata(uuid: Option[UUID], indexingRev: Option[Int])
+  final case class Metadata(uuid: Option[UUID])
 
   val context: ContextValue = ContextValue(contexts.elasticsearch)
 
@@ -265,7 +264,6 @@ object ElasticSearchView {
     Encoder.encodeJsonObject.contramapObject(meta =>
       JsonObject.empty
         .addIfExists("_uuid", meta.uuid)
-        .addIfExists("_indexingRev", meta.indexingRev)
     )
 
   implicit val elasticSearchMetadataJsonLdEncoder: JsonLdEncoder[Metadata] =

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewState.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewState.scala
@@ -5,6 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue._
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.sdk.model.{ResourceF, ResourceUris, Tags}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.IndexingRev
 import ch.epfl.bluebrain.nexus.delta.sourcing.Serializer
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Subject
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ProjectRef, ResourceRef}
@@ -48,19 +49,19 @@ import scala.annotation.nowarn
   *   the subject that last updated the view
   */
 final case class ElasticSearchViewState(
-    id: Iri,
-    project: ProjectRef,
-    uuid: UUID,
-    value: ElasticSearchViewValue,
-    source: Json,
-    tags: Tags,
-    rev: Int,
-    indexingRev: Int,
-    deprecated: Boolean,
-    createdAt: Instant,
-    createdBy: Subject,
-    updatedAt: Instant,
-    updatedBy: Subject
+                                         id: Iri,
+                                         project: ProjectRef,
+                                         uuid: UUID,
+                                         value: ElasticSearchViewValue,
+                                         source: Json,
+                                         tags: Tags,
+                                         rev: Int,
+                                         indexingRev: IndexingRev,
+                                         deprecated: Boolean,
+                                         createdAt: Instant,
+                                         createdBy: Subject,
+                                         updatedAt: Instant,
+                                         updatedBy: Subject
 ) extends ScopedState {
 
   override def schema: ResourceRef = model.schema
@@ -94,8 +95,7 @@ final case class ElasticSearchViewState(
         context = context,
         permission = permission,
         tags = tags,
-        source = source,
-        indexingRev = indexingRev
+        source = source
       )
     case AggregateElasticSearchViewValue(name, description, views) =>
       AggregateElasticSearchView(

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewState.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewState.scala
@@ -49,19 +49,19 @@ import scala.annotation.nowarn
   *   the subject that last updated the view
   */
 final case class ElasticSearchViewState(
-                                         id: Iri,
-                                         project: ProjectRef,
-                                         uuid: UUID,
-                                         value: ElasticSearchViewValue,
-                                         source: Json,
-                                         tags: Tags,
-                                         rev: Int,
-                                         indexingRev: IndexingRev,
-                                         deprecated: Boolean,
-                                         createdAt: Instant,
-                                         createdBy: Subject,
-                                         updatedAt: Instant,
-                                         updatedBy: Subject
+    id: Iri,
+    project: ProjectRef,
+    uuid: UUID,
+    value: ElasticSearchViewValue,
+    source: Json,
+    tags: Tags,
+    rev: Int,
+    indexingRev: IndexingRev,
+    deprecated: Boolean,
+    createdAt: Instant,
+    createdBy: Subject,
+    updatedAt: Instant,
+    updatedBy: Subject
 ) extends ScopedState {
 
   override def schema: ResourceRef = model.schema

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewValue.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewValue.scala
@@ -135,15 +135,18 @@ object ElasticSearchViewValue {
       * @return
       *   the next indexing revision based on the differences between the given views
       */
-    def nextIndexingRev(view1: ElasticSearchViewValue,
-                        view2: ElasticSearchViewValue,
-                        currentIndexingRev: IndexingRev,
-                        newEventRev: Int
+    def nextIndexingRev(
+        view1: ElasticSearchViewValue,
+        view2: ElasticSearchViewValue,
+        currentIndexingRev: IndexingRev,
+        newEventRev: Int
     ): IndexingRev =
-      (view1.asIndexingValue, view2.asIndexingValue).mapN { case (v1, v2) =>
-        if (!v1.hasSameIndexingFields(v2)) IndexingRev(newEventRev)
-        else currentIndexingRev
-      }.getOrElse(currentIndexingRev)
+      (view1.asIndexingValue, view2.asIndexingValue)
+        .mapN { case (v1, v2) =>
+          if (!v1.hasSameIndexingFields(v2)) IndexingRev(newEventRev)
+          else currentIndexingRev
+        }
+        .getOrElse(currentIndexingRev)
   }
 
   /**

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewValue.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewValue.scala
@@ -1,5 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model
 
+import cats.syntax.all._
 import cats.data.{NonEmptyChain, NonEmptySet}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.IndexingElasticSearchViewValue
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.IndexingElasticSearchViewValue.defaultPipeline
@@ -8,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
-import ch.epfl.bluebrain.nexus.delta.sdk.views.{PipeStep, ViewRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, PipeStep, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.pipes.{DefaultLabelPredicates, DiscardMetadata, FilterDeprecated}
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.{PipeChain, PipeRef}
@@ -134,13 +135,15 @@ object ElasticSearchViewValue {
       * @return
       *   the next indexing revision based on the differences between the given views
       */
-    def nextIndexingRev(
-        view1: IndexingElasticSearchViewValue,
-        view2: IndexingElasticSearchViewValue,
-        currentRev: Int
-    ): Int =
-      if (!view1.hasSameIndexingFields(view2)) currentRev + 1
-      else currentRev
+    def nextIndexingRev(view1: ElasticSearchViewValue,
+                        view2: ElasticSearchViewValue,
+                        currentIndexingRev: IndexingRev,
+                        newEventRev: Int
+    ): IndexingRev =
+      (view1.asIndexingValue, view2.asIndexingValue).mapN { case (v1, v2) =>
+        if (!v1.hasSameIndexingFields(v2)) IndexingRev(newEventRev)
+        else currentIndexingRev
+      }.getOrElse(currentIndexingRev)
   }
 
   /**

--- a/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-compacted-1.json
+++ b/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-compacted-1.json
@@ -42,7 +42,6 @@
   ],
   "sourceAsText": true,
   "_uuid": "f85d862a-9ec0-4b9a-8aed-2938d7ca9981",
-  "_indexingRev": 1,
   "mapping": {
     "properties": {
       "@type": {

--- a/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-compacted-2.json
+++ b/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-compacted-2.json
@@ -24,7 +24,6 @@
   "resourceTypes": [],
   "sourceAsText": false,
   "_uuid": "f85d862a-9ec0-4b9a-8aed-2938d7ca9981",
-  "_indexingRev": 1,
   "mapping": {
     "properties": {
       "@type": {

--- a/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-compacted-3.json
+++ b/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-compacted-3.json
@@ -17,7 +17,6 @@
   "resourceTypes": [],
   "sourceAsText": false,
   "_uuid": "f85d862a-9ec0-4b9a-8aed-2938d7ca9981",
-  "_indexingRev": 1,
   "mapping": {
     "properties": {
       "@type": {

--- a/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-expanded.json
+++ b/delta/plugins/elasticsearch/src/test/resources/jsonld/indexing-view-expanded.json
@@ -120,11 +120,6 @@
         "@value": "f85d862a-9ec0-4b9a-8aed-2938d7ca9981"
       }
     ],
-    "https://bluebrain.github.io/nexus/vocabulary/indexingRev" : [
-      {
-        "@value" : 1
-      }
-    ],
     "@id": "https://bluebrain.github.io/nexus/vocabulary/myview"
   }
 ]

--- a/delta/plugins/elasticsearch/src/test/resources/routes/elasticsearch-view-read-response.json
+++ b/delta/plugins/elasticsearch/src/test/resources/routes/elasticsearch-view-read-response.json
@@ -16,7 +16,6 @@
   "_outgoing" : "{{self}}/outgoing",
   "_project" : "http://localhost/v1/projects/{{project}}",
   "_rev" : {{rev}},
-  "_indexingRev": {{indexingRev}},
   "_self" : "{{self}}",
   "_updatedAt" : "1970-01-01T00:00:00Z",
   "_updatedBy" : "{{updatedBy}}",

--- a/delta/plugins/elasticsearch/src/test/resources/routes/elasticsearch-view-write-response.json
+++ b/delta/plugins/elasticsearch/src/test/resources/routes/elasticsearch-view-write-response.json
@@ -14,7 +14,6 @@
   "_outgoing" : "{{self}}/outgoing",
   "_project" : "http://localhost/v1/projects/{{project}}",
   "_rev" : {{rev}},
-  "_indexingRev": {{indexingRev}},
   "_self" : "{{self}}",
   "_updatedAt" : "1970-01-01T00:00:00Z",
   "_updatedBy" : "{{updatedBy}}"

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchIndexingActionSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchIndexingActionSuite.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchIndexingActionSuite.{IdAcc, emptyAcc}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchIndexingActionSuite.{emptyAcc, IdAcc}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef.{ActiveViewDef, DeprecatedViewDef}

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchIndexingActionSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchIndexingActionSuite.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchIndexingActionSuite.{emptyAcc, IdAcc}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchIndexingActionSuite.{IdAcc, emptyAcc}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef.{ActiveViewDef, DeprecatedViewDef}
@@ -8,7 +8,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
-import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.PullRequest
 import ch.epfl.bluebrain.nexus.delta.sourcing.PullRequest.PullRequestState
 import ch.epfl.bluebrain.nexus.delta.sourcing.PullRequest.PullRequestState.PullRequestActive
@@ -33,7 +33,7 @@ class ElasticSearchIndexingActionSuite extends BioSuite with CirceLiteral with F
 
   private val instant = Instant.EPOCH
 
-  private val indexingRev = 1
+  private val indexingRev = IndexingRev.init
   private val rev         = 2
 
   private val project = ProjectRef.unsafe("org", "proj")

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewGen.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewGen.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewState, ElasticSearchViewValue, ViewResource}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Tags
+import ch.epfl.bluebrain.nexus.delta.sdk.views.IndexingRev
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Subject}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
 import io.circe.{Json, JsonObject}
@@ -13,17 +14,17 @@ import java.util.UUID
 object ElasticSearchViewGen {
 
   def stateFor(
-      id: Iri,
-      project: ProjectRef,
-      value: ElasticSearchViewValue,
-      uuid: UUID = UUID.randomUUID(),
-      source: Json = Json.obj(),
-      rev: Int = 1,
-      indexingRev: Int = 1,
-      deprecated: Boolean = false,
-      tags: Tags = Tags.empty,
-      createdBy: Subject = Anonymous,
-      updatedBy: Subject = Anonymous
+                id: Iri,
+                project: ProjectRef,
+                value: ElasticSearchViewValue,
+                uuid: UUID = UUID.randomUUID(),
+                source: Json = Json.obj(),
+                rev: Int = 1,
+                indexingRev: IndexingRev = IndexingRev.init,
+                deprecated: Boolean = false,
+                tags: Tags = Tags.empty,
+                createdBy: Subject = Anonymous,
+                updatedBy: Subject = Anonymous
   ): ElasticSearchViewState =
     ElasticSearchViewState(
       id,
@@ -48,7 +49,7 @@ object ElasticSearchViewGen {
       uuid: UUID = UUID.randomUUID(),
       source: Json = Json.obj(),
       rev: Int = 1,
-      indexingRev: Int = 1,
+      indexingRev: IndexingRev = IndexingRev.init,
       deprecated: Boolean = false,
       tags: Tags = Tags.empty,
       createdBy: Subject = Anonymous,

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewGen.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewGen.scala
@@ -14,17 +14,17 @@ import java.util.UUID
 object ElasticSearchViewGen {
 
   def stateFor(
-                id: Iri,
-                project: ProjectRef,
-                value: ElasticSearchViewValue,
-                uuid: UUID = UUID.randomUUID(),
-                source: Json = Json.obj(),
-                rev: Int = 1,
-                indexingRev: IndexingRev = IndexingRev.init,
-                deprecated: Boolean = false,
-                tags: Tags = Tags.empty,
-                createdBy: Subject = Anonymous,
-                updatedBy: Subject = Anonymous
+      id: Iri,
+      project: ProjectRef,
+      value: ElasticSearchViewValue,
+      uuid: UUID = UUID.randomUUID(),
+      source: Json = Json.obj(),
+      rev: Int = 1,
+      indexingRev: IndexingRev = IndexingRev.init,
+      deprecated: Boolean = false,
+      tags: Tags = Tags.empty,
+      createdBy: Subject = Anonymous,
+      updatedBy: Subject = Anonymous
   ): ElasticSearchViewState =
     ElasticSearchViewState(
       id,

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewSTMSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewSTMSpec.scala
@@ -13,7 +13,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Tags
 import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
-import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Subject, User}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef}
@@ -62,7 +62,7 @@ class ElasticSearchViewSTMSpec
     // format: on
 
     val invalidView: ValidateElasticSearchView =
-      (_: UUID, _: Int, _: ElasticSearchViewValue) => IO.raiseError(InvalidElasticSearchIndexPayload(None))
+      (_: UUID, _: IndexingRev, _: ElasticSearchViewValue) => IO.raiseError(InvalidElasticSearchIndexPayload(None))
 
     def current(
         id: Iri = id,
@@ -72,7 +72,7 @@ class ElasticSearchViewSTMSpec
         source: Json = source,
         tags: Tags = Tags.empty,
         rev: Int = 1,
-        indexingRev: Int = 1,
+        indexingRev: IndexingRev = IndexingRev.init,
         deprecated: Boolean = false,
         createdAt: Instant = epoch,
         createdBy: Subject = Anonymous,
@@ -248,7 +248,7 @@ class ElasticSearchViewSTMSpec
           value = indexingValueWithUserTag,
           source = source2,
           rev = 2,
-          indexingRev = 2,
+          indexingRev = IndexingRev(2),
           updatedAt = epochPlus10,
           updatedBy = subject
         )

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewValueSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewValueSuite.scala
@@ -4,7 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchVi
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.IndexingElasticSearchViewValue.nextIndexingRev
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.permissions
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
-import ch.epfl.bluebrain.nexus.delta.sdk.views.PipeStep
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, PipeStep}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
 import ch.epfl.bluebrain.nexus.delta.sourcing.stream.pipes.FilterDeprecated
 import io.circe.JsonObject
@@ -21,7 +21,8 @@ class ElasticSearchViewValueSuite extends FunSuite {
       IndexingElasticSearchViewValue(Some("name"), Some("description")),
       viewValue.copy(permission = permissions.read)
     )
-    viewValues.foreach(v => assertEquals(nextIndexingRev(v, viewValue, 1), 1))
+    val expected =  IndexingRev.init
+    viewValues.foreach(v => assertEquals(nextIndexingRev(v, viewValue, IndexingRev.init, 2), expected))
   }
 
   test("Views with different reindexing fields") {
@@ -32,7 +33,8 @@ class ElasticSearchViewValueSuite extends FunSuite {
       viewValue.copy(settings = Some(JsonObject.empty)),
       viewValue.copy(context = Some(ContextObject.apply(JsonObject.empty)))
     )
-    viewValues.foreach(v => assertEquals(nextIndexingRev(v, viewValue, 1), 2))
+    val expected =  IndexingRev(2)
+    viewValues.foreach(v => assertEquals(nextIndexingRev(v, viewValue, IndexingRev.init, 2), expected))
   }
 
 }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewValueSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewValueSuite.scala
@@ -21,7 +21,7 @@ class ElasticSearchViewValueSuite extends FunSuite {
       IndexingElasticSearchViewValue(Some("name"), Some("description")),
       viewValue.copy(permission = permissions.read)
     )
-    val expected =  IndexingRev.init
+    val expected   = IndexingRev.init
     viewValues.foreach(v => assertEquals(nextIndexingRev(v, viewValue, IndexingRev.init, 2), expected))
   }
 
@@ -33,7 +33,7 @@ class ElasticSearchViewValueSuite extends FunSuite {
       viewValue.copy(settings = Some(JsonObject.empty)),
       viewValue.copy(context = Some(ContextObject.apply(JsonObject.empty)))
     )
-    val expected =  IndexingRev(2)
+    val expected   = IndexingRev(2)
     viewValues.foreach(v => assertEquals(nextIndexingRev(v, viewValue, IndexingRev.init, 2), expected))
   }
 

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSpec.scala
@@ -70,19 +70,19 @@ class ElasticSearchViewsSpec
     val settings = json"""{ "analysis": { } }""".asObject.value
 
     def currentStateFor(
-                         id: Iri,
-                         project: Project,
-                         uuid: UUID,
-                         rev: Int,
-                         indexingRev: IndexingRev,
-                         deprecated: Boolean,
-                         createdAt: Instant,
-                         createdBy: Subject,
-                         updatedAt: Instant,
-                         updatedBy: Subject,
-                         value: ElasticSearchViewValue,
-                         source: Json,
-                         tags: Tags
+        id: Iri,
+        project: Project,
+        uuid: UUID,
+        rev: Int,
+        indexingRev: IndexingRev,
+        deprecated: Boolean,
+        createdAt: Instant,
+        createdBy: Subject,
+        updatedAt: Instant,
+        updatedBy: Subject,
+        value: ElasticSearchViewValue,
+        source: Json,
+        tags: Tags
     ): ElasticSearchViewState =
       ElasticSearchViewState(
         id = id,

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsSpec.scala
@@ -16,7 +16,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContextDummy
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.model.{ApiMappings, Project}
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.ResolverContextResolution
-import ch.epfl.bluebrain.nexus.delta.sdk.views.{PipeStep, ViewRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, PipeStep, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.EntityDependencyStore
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.EntityDependency.DependsOn
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Group, Subject, User}
@@ -70,19 +70,19 @@ class ElasticSearchViewsSpec
     val settings = json"""{ "analysis": { } }""".asObject.value
 
     def currentStateFor(
-        id: Iri,
-        project: Project,
-        uuid: UUID,
-        rev: Int,
-        indexingRev: Int,
-        deprecated: Boolean,
-        createdAt: Instant,
-        createdBy: Subject,
-        updatedAt: Instant,
-        updatedBy: Subject,
-        value: ElasticSearchViewValue,
-        source: Json,
-        tags: Tags
+                         id: Iri,
+                         project: Project,
+                         uuid: UUID,
+                         rev: Int,
+                         indexingRev: IndexingRev,
+                         deprecated: Boolean,
+                         createdAt: Instant,
+                         createdBy: Subject,
+                         updatedAt: Instant,
+                         updatedBy: Subject,
+                         value: ElasticSearchViewValue,
+                         source: Json,
+                         tags: Tags
     ): ElasticSearchViewState =
       ElasticSearchViewState(
         id = id,
@@ -105,7 +105,7 @@ class ElasticSearchViewsSpec
         project: Project = project,
         uuid: UUID = uuid,
         rev: Int = 1,
-        indexingRev: Int = 1,
+        indexingRev: IndexingRev = IndexingRev.init,
         deprecated: Boolean = false,
         createdAt: Instant = Instant.EPOCH,
         createdBy: Subject = alice.subject,

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/deletion/ElasticSearchDeletionTaskSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/deletion/ElasticSearchDeletionTaskSuite.scala
@@ -5,7 +5,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef.{ActiveViewDef, DeprecatedViewDef}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
-import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Subject}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
 import ch.epfl.bluebrain.nexus.testkit.CirceLiteral
@@ -18,7 +18,7 @@ class ElasticSearchDeletionTaskSuite extends BioSuite with CirceLiteral {
   implicit private val subject: Subject = Anonymous
 
   private val project     = ProjectRef.unsafe("org", "proj")
-  private val indexingRev = 1
+  private val indexingRev = IndexingRev.init
   private val rev         = 2
 
   private val active1    = ViewRef(project, nxv + "active1")

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchCoordinatorSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/ElasticSearchCoordinatorSuite.scala
@@ -6,7 +6,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViews, 
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.GraphResourceStream
-import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.PullRequest
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ElemStream, ProjectRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
@@ -32,7 +32,7 @@ class ElasticSearchCoordinatorSuite extends BioSuite with SupervisorSetup.Fixtur
 
   implicit private val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 10.millis)
 
-  private val indexingRev = 1
+  private val indexingRev = IndexingRev.init
   private val rev         = 2
 
   private lazy val (sv, projections, projectionErrors) = unapply(supervisor())

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/IndexingViewDefSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/indexing/IndexingViewDefSuite.scala
@@ -12,7 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObje
 import ch.epfl.bluebrain.nexus.delta.sdk.model.Tags
 import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.GraphResourceStream
-import ch.epfl.bluebrain.nexus.delta.sdk.views.{PipeStep, ViewRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, PipeStep, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.BatchConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Subject}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
@@ -78,7 +78,7 @@ class IndexingViewDefSuite extends BioSuite with CirceLiteral with Fixtures {
   private val aggregate = AggregateElasticSearchViewValue(NonEmptySet.of(viewRef))
   private val sink      = CacheSink.states[Json]
 
-  private val indexingRev = 1
+  private val indexingRev = IndexingRev.init
   private val rev         = 2
 
   private def state(v: ElasticSearchViewValue) = ElasticSearchViewState(
@@ -103,7 +103,7 @@ class IndexingViewDefSuite extends BioSuite with CirceLiteral with Fixtures {
       Some(
         ActiveViewDef(
           viewRef,
-          s"elasticsearch-$projectRef-$id-$indexingRev",
+          s"elasticsearch-$projectRef-$id-${indexingRev.value}",
           indexingCustom.resourceTag,
           indexingCustom.pipeChain,
           IndexLabel.fromView("prefix", uuid, indexingRev),
@@ -123,7 +123,7 @@ class IndexingViewDefSuite extends BioSuite with CirceLiteral with Fixtures {
       Some(
         ActiveViewDef(
           viewRef,
-          s"elasticsearch-$projectRef-$id-$indexingRev",
+          s"elasticsearch-$projectRef-$id-${indexingRev.value}",
           indexingDefault.resourceTag,
           indexingDefault.pipeChain,
           IndexLabel.fromView("prefix", uuid, indexingRev),

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewSerializationSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewSerializationSuite.scala
@@ -12,7 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.Tags
 import ch.epfl.bluebrain.nexus.delta.sdk.model.metrics.EventMetric._
 import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.sse.SseEncoder.SseData
-import ch.epfl.bluebrain.nexus.delta.sdk.views.{PipeStep, ViewRef}
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, PipeStep, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Subject, User}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Tag.UserTag
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{Label, ProjectRef}
@@ -125,7 +125,7 @@ class ElasticSearchViewSerializationSuite extends SerializationSuite {
       Json.obj("elastic" -> Json.fromString("value")),
       Tags(tag           -> 3),
       rev = 1,
-      indexingRev = 1,
+      indexingRev = IndexingRev.init,
       deprecated = false,
       createdAt = instant,
       createdBy = subject,

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewSpec.scala
@@ -50,8 +50,7 @@ class ElasticSearchViewSpec
       context = Some(ContextObject(jobj"""{"@vocab": "http://schema.org/"}""")),
       perm,
       tagsMap,
-      source,
-      1
+      source
     )
     "be converted to compacted Json-LD" in {
       forAll(

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchIndexingRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchIndexingRoutesSpec.scala
@@ -8,7 +8,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViews, 
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef.ActiveViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewRejection.{InvalidResourceId, ViewNotFound}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{permissions => esPermissions, ElasticSearchViewRejection}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewRejection, permissions => esPermissions}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.routes.ElasticSearchIndexingRoutes.FetchIndexingView
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
@@ -18,7 +18,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.model.IdSegment.{IriSegment, StringSegm
 import ch.epfl.bluebrain.nexus.delta.sdk.permissions.Permissions.events
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.{FetchContext, FetchContextDummy}
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.ResolverContextResolution
-import ch.epfl.bluebrain.nexus.delta.sdk.views.ViewRef
+import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.EntityType
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.Anonymous
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
@@ -61,7 +61,7 @@ class ElasticSearchIndexingRoutesSpec extends ElasticSearchViewsRoutesFixtures {
     JsonObject.empty,
     JsonObject.empty,
     None,
-    1,
+    IndexingRev.init,
     1
   )
   private val progress     = ProjectionProgress(Offset.at(15L), Instant.EPOCH, 9000L, 400L, 30L)

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchIndexingRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchIndexingRoutesSpec.scala
@@ -8,7 +8,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{ElasticSearchViews, 
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.IndexLabel
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.indexing.IndexingViewDef.ActiveViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewRejection.{InvalidResourceId, ViewNotFound}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{ElasticSearchViewRejection, permissions => esPermissions}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{permissions => esPermissions, ElasticSearchViewRejection}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.routes.ElasticSearchIndexingRoutes.FetchIndexingView
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -369,14 +369,14 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures {
   ): Json =
     jsonContentOf(
       "/routes/elasticsearch-view-write-response.json",
-      "project"     -> projectRef,
-      "id"          -> id,
-      "rev"         -> rev,
-      "uuid"        -> uuid,
-      "deprecated"  -> deprecated,
-      "createdBy"   -> createdBy.asIri,
-      "updatedBy"   -> updatedBy.asIri,
-      "self"        -> ResourceUris("views", projectRef, id).accessUri
+      "project"    -> projectRef,
+      "id"         -> id,
+      "rev"        -> rev,
+      "uuid"       -> uuid,
+      "deprecated" -> deprecated,
+      "createdBy"  -> createdBy.asIri,
+      "updatedBy"  -> updatedBy.asIri,
+      "self"       -> ResourceUris("views", projectRef, id).accessUri
     )
 
   private def elasticSearchView(

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -257,8 +257,6 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures {
           myId,
           includeDeprecated = false,
           rev = 4,
-          // indexing rev stays one as the update concerned non-indexing fields
-          indexingRev = 1,
           deprecated = true
         )
       }
@@ -365,7 +363,6 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures {
   private def elasticSearchViewMetadata(
       id: Iri,
       rev: Int = 1,
-      indexingRev: Int = 1,
       deprecated: Boolean = false,
       createdBy: Subject = Anonymous,
       updatedBy: Subject = Anonymous
@@ -375,7 +372,6 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures {
       "project"     -> projectRef,
       "id"          -> id,
       "rev"         -> rev,
-      "indexingRev" -> indexingRev,
       "uuid"        -> uuid,
       "deprecated"  -> deprecated,
       "createdBy"   -> createdBy.asIri,
@@ -387,7 +383,6 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures {
       id: Iri,
       includeDeprecated: Boolean = false,
       rev: Int = 1,
-      indexingRev: Int = 1,
       deprecated: Boolean = false,
       createdBy: Subject = Anonymous,
       updatedBy: Subject = Anonymous
@@ -398,7 +393,6 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures {
       "id"                -> id,
       "rev"               -> rev,
       "uuid"              -> uuid,
-      "indexingRev"       -> indexingRev,
       "deprecated"        -> deprecated,
       "createdBy"         -> createdBy.asIri,
       "updatedBy"         -> updatedBy.asIri,

--- a/tests/src/test/resources/kg/listings/default-view.json
+++ b/tests/src/test/resources/kg/listings/default-view.json
@@ -18,7 +18,6 @@
       "_constrainedBy": "https://bluebrain.github.io/nexus/schemas/views.json",
       "_project": "{{project}}",
       "_rev": 1,
-      "_indexingRev" : 1,
       "_deprecated": false,
       "_createdBy": "{{deltaUri}}/realms/{{realm}}/users/{{user}}",
       "_updatedBy": "{{deltaUri}}/realms/{{realm}}/users/{{user}}",

--- a/tests/src/test/resources/kg/views/elasticsearch/indexing-response.json
+++ b/tests/src/test/resources/kg/views/elasticsearch/indexing-response.json
@@ -14,7 +14,6 @@
   "_outgoing" : "{{self}}/outgoing",
   "_project" : "{{deltaUri}}/projects/{{project}}",
   "_rev" : 1,
-  "_indexingRev": 1,
   "_self" : "{{self}}",
   "_createdBy" : "{{deltaUri}}/realms/{{realm}}/users/{{user}}",
   "_updatedBy" : "{{deltaUri}}/realms/{{realm}}/users/{{user}}",

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigSpec.scala
@@ -345,7 +345,7 @@ class SearchConfigSpec extends BaseSpec {
     }
 
     "have curated field true if curated" in {
-      val query    = queryField(curatedTraceId, "curated")
+      val query = queryField(curatedTraceId, "curated")
 
       assertOneSource(query) { json =>
         json shouldBe json"""{ "curated": true }"""
@@ -353,7 +353,7 @@ class SearchConfigSpec extends BaseSpec {
     }
 
     "have curated field false if unassessed" in {
-      val query    = queryField(unassessedTraceId, "curated")
+      val query = queryField(unassessedTraceId, "curated")
 
       assertOneSource(query) { json =>
         json shouldBe json"""{ "curated": false }"""


### PR DESCRIPTION
Fixes #4154 

* Use `IndexingRev` value class for this property to make it less confusing with rev 
* remove `_indexingRev`as response metadata, it is better if it remains an implementation detail