### PR TITLE
Replace uses of 'archives/write' permission with 'resources/read'

### DIFF
--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -112,7 +112,6 @@ app {
       "schemas/write",
       "files/write",
       "storages/write",
-      "archives/write",
       "version/read",
       "quotas/read",
       "supervision/read"
@@ -139,7 +138,6 @@ app {
       "schemas/write",
       "files/write",
       "storages/write",
-      "archives/write",
       "version/read",
       "quotas/read"
     ]

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/package.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/package.scala
@@ -38,6 +38,6 @@ package object model {
     */
   object permissions {
     final val read: Permission  = Permissions.resources.read
-    final val write: Permission = Permission.unsafe("archives/write")
+    final val write: Permission = Permissions.resources.read
   }
 }

--- a/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveRoutesSpec.scala
+++ b/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveRoutesSpec.scala
@@ -81,9 +81,7 @@ class ArchiveRoutesSpec extends BaseRouteSpec with StorageFixtures with TryValue
 
   private val perms = Seq(
     Permissions.resources.write,
-    Permissions.resources.read,
-    model.permissions.read,
-    model.permissions.write
+    Permissions.resources.read
   )
 
   private val asSubject     = addCredentials(OAuth2BearerToken("user"))

--- a/docs/src/main/paradox/docs/delta/api/archives-api.md
+++ b/docs/src/main/paradox/docs/delta/api/archives-api.md
@@ -10,10 +10,7 @@ Each archive...
 
 @@@ note { .tip title="Authorization notes" }	
 
-When modifying archives, the caller must have `archives/write` permissions on the current path of the project or the 
-ancestor paths.
-
-When reading archives, the caller must have `resources/read` permissions on the current path of the project or the 
+For both reading and modifying archives, the caller must have `resources/read` permissions on the current path of the project or the 
 ancestor paths.
 
 Please visit @ref:[Authentication & authorization](authentication.md) section to learn more about it.

--- a/docs/src/main/paradox/docs/delta/api/assets/permissions/permissions-get.json
+++ b/docs/src/main/paradox/docs/delta/api/assets/permissions/permissions-get.json
@@ -18,7 +18,6 @@
     "acls/read",
     "projects/read",
     "permissions/read",
-    "archives/write",
     "organizations/create",
     "views/query",
     "storages/write",

--- a/docs/src/main/paradox/docs/delta/api/permissions-api.md
+++ b/docs/src/main/paradox/docs/delta/api/permissions-api.md
@@ -66,9 +66,6 @@ Currently, the following permissions are required:
 - default permissions for storages
     - `storages/write`
 
-- default permissions for archives
-    - `archives/write`
-
 - default permissions for the version endpoint
     - `version/read`
 

--- a/docs/src/main/paradox/docs/releases/v1.9-release-notes.md
+++ b/docs/src/main/paradox/docs/releases/v1.9-release-notes.md
@@ -109,6 +109,10 @@ Annotated source is now available as an output format when creating an archive.
 
 @ref:[More information](../delta/api/archives-api.md#payload)
 
+#### Require only `resources/read` permission for archive creation
+
+Creating an archive now requires only the `resources/read` permission instead of `archives/write`.
+
 ### Storages
 
 Storages can no longer be created with credentials that would get stored:

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/iam/types/AclListing.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/iam/types/AclListing.scala
@@ -143,13 +143,6 @@ object Permission {
     val list: List[Permission] = Write :: Nil
   }
 
-  object Archives {
-    val name              = "archives"
-    val Write: Permission = Permission(name, "write")
-
-    val list: List[Permission] = Write :: Nil
-  }
-
   object Quotas {
     val name             = "quotas"
     val Read: Permission = Permission(name, "read")
@@ -178,7 +171,6 @@ object Permission {
       Schemas.list ++
       Views.list ++
       Storages.list ++
-      Archives.list ++
       Quotas.list ++
       Supervision.list).toSet
 
@@ -193,7 +185,6 @@ object Permission {
       Schemas.list ++
       Views.list ++
       Storages.list ++
-      Archives.list ++
       Quotas.list).toSet
 
 }


### PR DESCRIPTION
Think this change depends on changing the permissions in forge ([these places](https://github.com/search?q=repo%3ABlueBrain%2Fnexus-web+archives%2Fwrite&type=code)) and I guess potentially other clients? Unless we know for sure that every user with `archives/write` also has `resources/read`.

Also not sure what to unit test here - is this alright? The archive `model.permissions` could be deleted and the route could point directly to the resource permissions.
