### PR TITLE
Add info on required Java option to doc; update pipelines

### DIFF
--- a/.github/workflows/ci-release-docker.yml
+++ b/.github/workflows/ci-release-docker.yml
@@ -21,7 +21,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           check-latest: true
-          cache: 'sbt'
       - name: Set up proxy for docker buildx
         run: |
           echo http_proxy=${http_proxy} >> $GITHUB_ENV

--- a/.github/workflows/ci-release-sonatype.yml
+++ b/.github/workflows/ci-release-sonatype.yml
@@ -27,6 +27,5 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           check-latest: true
-          cache: 'sbt'
       - name: Publish To Sonatype
         run: sbt -Dsbt.color=always -Dsbt.supershell=false ci-release

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -28,7 +28,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           check-latest: true
-          cache: 'sbt'
       - name: Set up proxy for docker buildx
         run: |
           echo http_proxy=${http_proxy} >> $GITHUB_ENV

--- a/docs/src/main/paradox/docs/getting-started/running-nexus/configuration/index.md
+++ b/docs/src/main/paradox/docs/getting-started/running-nexus/configuration/index.md
@@ -10,7 +10,7 @@ There are 3 ways to modify the default configuration:
   environment variables. In order to enable this style of configuration, the JVM property
   `-Dconfig.override_with_env_vars=true` needs to be set. Once set, a configuration flag can be overridden. For example: `CONFIG_FORCE_app_http_interface="127.0.0.1"`.
 
-In terms of JVM pool memory allocation, we recommend setting the following values to the `JAVA_OPTS` environment variable: `-Xms4g -Xmx4g`. The recommended values should be changed accordingly with the usage of Nexus Delta, the number of projects and the resources/schemas size.
+In terms of JVM pool memory allocation, we recommend setting the following values to the `JAVA_OPTS` environment variable: `-Xms4g -Xmx4g --add-opens=java.base/java.lang=ALL-UNNAMED`. The recommended values should be changed accordingly with the usage of Nexus Delta, the number of projects and the resources/schemas size.
 
 In order to successfully run Nexus Delta there is a minimum set of configuration flags that need to be specified
 

--- a/docs/src/main/paradox/docs/releases/v1.8-to-v1.9-migration.md
+++ b/docs/src/main/paradox/docs/releases/v1.8-to-v1.9-migration.md
@@ -49,3 +49,11 @@ Currently, both remote storages and composite views with remote sources can hold
 A remote storage might currently have a token stored in the storage definition. In 1.9, this should be moved to `plugins.storage.storages.remote-disk.credentials`, as shown @ref:[here](../getting-started/running-nexus/configuration/index.md#remote-storage-configuration)
 
 A composite view might currently have a token stored in the view definition. In 1.9, this should be moved to `plugins.composite-views.remote-source-credentials`, as shown @ref:[here](../getting-started/running-nexus/configuration/index.md#composite-views-plugin-configuration)
+
+## Java options
+
+As the official Nexus Delta image moves to JRE 17, one dependency now requires the addition of
+`--add-opens=java.base/java.lang=ALL-UNNAMED` in `JAVA_OPTS`. This option is present by
+default in the image. However, if you are setting a custom value for `JAVA_OPTS` in your
+deployment, it is required to append `--add-opens=java.base/java.lang=ALL-UNNAMED` to it.
+This is because the custom value will override the one from the image.

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - '/bin/bash'
       - '-c'
       - |
-        ln -s /opt/docker/plugins/disabled/project-deletion.jar /opt/docker/plugins/project-deletion.jar &&
+        ln -sf /opt/docker/plugins/disabled/project-deletion.jar /opt/docker/plugins/project-deletion.jar &&
         /opt/docker/bin/delta-app -Xmx4G
     ports:
       - 8080:8080


### PR DESCRIPTION
* Add information on required Java option since moving to JRE 17
* Remove caching that was slowing down release/snapshot pipelines
* Force linking the project deletion plugin file. This solves a small issue where the container could not be simply restarted because the link already existed.