### PR TITLE
Remove the redirection on resolve endpoint and add metadata to response

### DIFF
--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchPluginModule.scala
@@ -284,7 +284,8 @@ class ElasticSearchPluginModule(priority: Int) extends ModuleDef {
         fusionConfig: FusionConfig,
         baseUri: BaseUri
     ) =>
-      new IdResolutionRoutes(identities, aclCheck, idResolution, baseUri)(
+      new IdResolutionRoutes(identities, aclCheck, idResolution)(
+        baseUri,
         s,
         ordering,
         rcr,

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/IdResolutionRoutes.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/IdResolutionRoutes.scala
@@ -3,9 +3,7 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.routes
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.IdResolutionResponse.{MultipleResults, SingleResult}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.ElasticSearchQueryError
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.{IdResolution, IdResolutionResponse}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.IdResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax.uriSyntax
 import ch.epfl.bluebrain.nexus.delta.rdf.utils.JsonKeyOrdering
@@ -15,16 +13,19 @@ import ch.epfl.bluebrain.nexus.delta.sdk.directives.DeltaDirectives._
 import ch.epfl.bluebrain.nexus.delta.sdk.fusion.FusionConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.Identities
 import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
-import monix.bio.{IO, UIO}
 import monix.execution.Scheduler
 
 class IdResolutionRoutes(
     identities: Identities,
     aclCheck: AclCheck,
-    idResolution: IdResolution,
-    baseUri: BaseUri
-)(implicit s: Scheduler, jko: JsonKeyOrdering, rcr: RemoteContextResolution, fusionConfig: FusionConfig)
-    extends AuthDirectives(identities, aclCheck) {
+    idResolution: IdResolution
+)(implicit
+    baseUri: BaseUri,
+    s: Scheduler,
+    jko: JsonKeyOrdering,
+    rcr: RemoteContextResolution,
+    fusionConfig: FusionConfig
+) extends AuthDirectives(identities, aclCheck) {
 
   def routes: Route = concat(resolutionRoute, proxyRoute)
 
@@ -33,11 +34,7 @@ class IdResolutionRoutes(
       extractCaller { implicit caller =>
         (get & iriSegment & pathEndOrSingleSlash) { iri =>
           val resolved = idResolution.resolve(iri)
-
-          emitOrFusionRedirect(
-            fusionUri(resolved),
-            emit(resolved)
-          )
+          emit(resolved)
         }
       }
     }
@@ -54,16 +51,6 @@ class IdResolutionRoutes(
         }
       }
     }
-
-  private def fusionUri(
-      resolved: IO[ElasticSearchQueryError, IdResolutionResponse.Result]
-  ): UIO[Uri] =
-    resolved
-      .flatMap {
-        case SingleResult(id, project, _) => fusionResourceUri(project, id.iri)
-        case MultipleResults(_)           => fusionLoginUri
-      }
-      .onErrorHandleWith { _ => fusionLoginUri }
 
   private def deltaResolveEndpoint(id: Uri): Uri =
     baseUri.endpoint / "resolve" / id.toString

--- a/docs/src/main/paradox/docs/delta/api/assets/id-resolution/single-resolution-response.json
+++ b/docs/src/main/paradox/docs/delta/api/assets/id-resolution/single-resolution-response.json
@@ -1,9 +1,24 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/"
-  },
+  "@context": [
+    "https://bluebrain.github.io/nexus/contexts/metadata.json",
+    {
+      "@vocab": "https://schema.org/"
+    }
+  ],
   "@id": "https://example.com/Alice",
   "@type": "Person",
   "name": "Alice",
-  "age": 42
+  "age": 42,
+  "_constrainedBy" : "https://bluebrain.github.io/nexus/schemas/unconstrained.json",
+  "_createdAt" : "1970-01-01T00:00:00Z",
+  "_createdBy" : "http://localhost/v1/anonymous",
+  "_deprecated" : false,
+  "_incoming" : "http://localhost/v1/resources/myorg/myproject/_/https%3A%2F%2Fexample.com%2FAlice/incoming",
+  "_outgoing" : "http://localhost/v1/resources/myorg/myproject/_/https%3A%2F%2Fexample.com%2FAlice/outgoing",
+  "_project" : "http://localhost/v1/projects/myorg/myproject",
+  "_rev" : 1,
+  "_schemaProject" : "http://localhost/v1/projects/myorg/myproject",
+  "_self" : "http://localhost/v1/resources/myorg/myproject/_/https%3A%2F%2Fexample.com%2FAlice",
+  "_updatedAt" : "1970-01-01T00:00:00Z",
+  "_updatedBy" : "http://localhost/v1/anonymous"
 }

--- a/docs/src/main/paradox/docs/delta/api/id-resolution.md
+++ b/docs/src/main/paradox/docs/delta/api/id-resolution.md
@@ -37,11 +37,6 @@ Response (single resource)
 Response (multiple choices)
 :   @@snip [response.json](assets/id-resolution/multiple-resolution-response.json)
 
-### Fusion Redirection
-
-When querying the resolve endpoint, it is possible to add the `Accept: text/html` header in order for Nexus Delta to
-redirect to the appropriate Nexus Fusion page.
-
 ## Resolve (Proxy Pass)
 
 @@@ note { .warning }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/IdResolutionSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/IdResolutionSpec.scala
@@ -9,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.utils.UrlUtils
 import ch.epfl.bluebrain.nexus.tests.BaseSpec
 import ch.epfl.bluebrain.nexus.tests.Identity.listings.{Alice, Bob}
 import ch.epfl.bluebrain.nexus.tests.iam.types.Permission.Organizations
-import io.circe.Json
+import io.circe.{Decoder, Json}
 import org.scalatest.Assertion
 
 class IdResolutionSpec extends BaseSpec {
@@ -36,6 +36,8 @@ class IdResolutionSpec extends BaseSpec {
   private val encodedReusedId       = UrlUtils.encode(reusedId)
   private val uniqueResourcePayload = resource(uniqueId)
   private val reusedResourcePayload = resource(reusedId)
+
+  private val addressOfProjectWithUniqueResource = "http://delta:8080/v1/projects/" + ref11
 
   private val neurosciencegraphSegment   = "neurosciencegraph/data/segment"
   private val proxyIdBase                = "http://localhost:8081"
@@ -84,7 +86,8 @@ class IdResolutionSpec extends BaseSpec {
       eventually {
         deltaClient.get[Json](s"/resolve/$encodedUniqueId", Bob) { (json, response) =>
           response.status shouldEqual StatusCodes.OK
-          json shouldEqual uniqueResourcePayload
+          json.topLevelField[String]("@id") shouldEqual uniqueId
+          json.topLevelField[String]("_project") shouldEqual addressOfProjectWithUniqueResource
         }
       }
     }
@@ -97,22 +100,6 @@ class IdResolutionSpec extends BaseSpec {
         }
       }
     }
-
-    "redirect to fusion login when if text/html accept header is present (no results)" in {
-      val fusionLoginPage = "https://bbp.epfl.ch/nexus/web/login"
-
-      deltaClient.get[String]("/resolve/unknownId", Bob, acceptTextHtml) { (_, response) =>
-        response isRedirectTo fusionLoginPage
-      }(PredefinedFromEntityUnmarshallers.stringUnmarshaller)
-    }
-
-    "redirect to fusion resource page if text/html accept header is present (single result)" in {
-      deltaClient.get[String](s"/resolve/$encodedUniqueId", Bob, acceptTextHtml) { (_, response) =>
-        response isRedirectTo fusionResourcePageFor(encodedUniqueId)
-      }(PredefinedFromEntityUnmarshallers.stringUnmarshaller)
-    }
-
-    "redirect to fusion resource selection page if text/html accept header is present (multiple result)" in { pending }
 
     "redirect to delta resolve if the request comes to the proxy endpoint" in {
       deltaClient.get[String](s"/resolve-proxy-pass/$neurosciencegraphSegment", Bob) { (_, response) =>
@@ -128,18 +115,22 @@ class IdResolutionSpec extends BaseSpec {
 
   }
 
-  implicit class HttpResponseOps(response: HttpResponse) {
+  implicit private class HttpResponseOps(response: HttpResponse) {
     def isRedirectTo(uri: String): Assertion = {
       response.status shouldEqual StatusCodes.SeeOther
       locationHeaderOf(response) shouldEqual uri
     }
   }
+
+  implicit private class JsonOps(json: Json) {
+    def topLevelField[A: Decoder](field: String): A =
+      json.hcursor.get[A](field).toOption.get
+  }
+
   private def locationHeaderOf(response: HttpResponse) =
     response.header[Location].value.uri.toString()
   private def acceptTextHtml                           =
     List(Accept(MediaRange.One(`text/html`, 1f)))
-  private def fusionResourcePageFor(encodedId: String) =
-    s"https://bbp.epfl.ch/nexus/web/$ref11/resources/$encodedId".replace("%3A", ":")
   private def fusionResolveEndpoint(encodedId: String) =
     s"https://bbp.epfl.ch/nexus/web/resolve/$encodedId".replace("%3A", ":")
   private def deltaResolveEndpoint(encodedId: String)  =


### PR DESCRIPTION
* On the `/v1/resolve`, there will no longer be any redirection
* When the id can be resolved uniquely, the response will now contain metadata