### PR TITLE
Fix bug where filename in location could differ from `_filename` attribute

### DIFF
--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/SaveFile.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/SaveFile.scala
@@ -1,7 +1,7 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{BodyPartEntity, Uri}
+import akka.http.scaladsl.model.BodyPartEntity
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.Digest.ComputedDigest
@@ -70,6 +70,6 @@ object SaveFile {
     *
     * Example: uuid = 12345678-90ab-cdef-abcd-1234567890ab {org}/{proj}/1/2/3/4/5/6/7/8/{filename}
     */
-  def intermediateFolders(ref: ProjectRef, uuid: UUID, filename: String): Uri.Path =
-    Uri.Path(s"$ref/${uuid.toString.toLowerCase.takeWhile(_ != '-').mkString("/")}/$filename")
+  def intermediateFolders(ref: ProjectRef, uuid: UUID, filename: String): String =
+    s"$ref/${uuid.toString.toLowerCase.takeWhile(_ != '-').mkString("/")}/$filename"
 }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/remote/RemoteDiskStorageLinkFile.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/remote/RemoteDiskStorageLinkFile.scala
@@ -14,7 +14,7 @@ import monix.bio.IO
 class RemoteDiskStorageLinkFile(storage: RemoteDiskStorage, client: RemoteDiskStorageClient) extends LinkFile {
 
   def apply(sourcePath: Uri.Path, description: FileDescription): IO[MoveFileRejection, FileAttributes] = {
-    val destinationPath = intermediateFolders(storage.project, description.uuid, description.filename)
+    val destinationPath = Uri.Path(intermediateFolders(storage.project, description.uuid, description.filename))
     client.moveFile(storage.value.folder, sourcePath, destinationPath)(storage.value.endpoint).map {
       case RemoteDiskStorageFileAttributes(location, bytes, digest, _) =>
         FileAttributes(

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/remote/RemoteDiskStorageSaveFile.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/remote/RemoteDiskStorageSaveFile.scala
@@ -1,6 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.remote
 
-import akka.http.scaladsl.model.BodyPartEntity
+import akka.http.scaladsl.model.{BodyPartEntity, Uri}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.FileAttributes.FileAttributesOrigin.Client
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.{FileAttributes, FileDescription}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.Storage.RemoteDiskStorage
@@ -17,7 +17,7 @@ class RemoteDiskStorageSaveFile(storage: RemoteDiskStorage, client: RemoteDiskSt
       description: FileDescription,
       entity: BodyPartEntity
   ): IO[SaveFileRejection, FileAttributes] = {
-    val path = intermediateFolders(storage.project, description.uuid, description.filename)
+    val path = Uri.Path(intermediateFolders(storage.project, description.uuid, description.filename))
     client.createFile(storage.value.folder, path, entity)(storage.value.endpoint).map {
       case RemoteDiskStorageFileAttributes(location, bytes, digest, mediaType) =>
         FileAttributes(

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageSaveFile.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageSaveFile.scala
@@ -29,7 +29,7 @@ final class S3StorageSaveFile(storage: S3Storage, config: StorageTypeConfig)(imp
       entity: BodyPartEntity
   ): IO[SaveFileRejection, FileAttributes] = {
     val attributes = S3Attributes.settings(storage.value.alpakkaSettings(config))
-    val path       = intermediateFolders(storage.project, description.uuid, description.filename)
+    val path       = Uri.Path(intermediateFolders(storage.project, description.uuid, description.filename))
     val key        = path.toString
     def s3Sink     = S3.multipartUpload(storage.value.bucket, key).withAttributes(attributes)
     IO.deferFuture(

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FilesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FilesSpec.scala
@@ -43,6 +43,8 @@ import monix.execution.Scheduler
 import org.scalatest.DoNotDiscover
 import org.scalatest.concurrent.Eventually
 
+import java.net.URLDecoder
+
 @DoNotDiscover
 class FilesSpec(docker: RemoteStorageDocker)
     extends TestKit(ActorSystem("FilesSpec"))
@@ -161,6 +163,18 @@ class FilesSpec(docker: RemoteStorageDocker)
         actual shouldEqual expected
       }
 
+      "succeed when the file has special characters" in {
+        val specialFileName = "-._~:?#[ ]@!$&'()*,;="
+
+        files.create(fileId("specialFile"), Some(diskId), randomEntity(specialFileName, 1), None).accepted
+        val fetched = files.fetch(fileId("specialFile")).accepted
+
+        val decodedFilenameFromLocation =
+          URLDecoder.decode(fetched.value.attributes.location.path.lastSegment.get, "UTF-8")
+
+        decodedFilenameFromLocation shouldEqual specialFileName
+      }
+
       "succeed and tag with the id passed" in {
         withUUIDF(uuid2) {
           val file         = files
@@ -251,7 +265,11 @@ class FilesSpec(docker: RemoteStorageDocker)
         val path     = Uri.Path("my/file-3.txt")
         val tempAttr = attributes("myfile.txt").copy(digest = NotComputedDigest)
         val attr     =
-          tempAttr.copy(location = s"file:///app/nexustest/nexus/${tempAttr.path}", origin = Storage, mediaType = None)
+          tempAttr.copy(
+            location = Uri(s"file:///app/nexustest/nexus/${tempAttr.path}"),
+            origin = Storage,
+            mediaType = None
+          )
         val expected = mkResource(file2, projectRef, remoteRev, attr, RemoteStorageType, tags = Tags(tag -> 1))
 
         val result    = files
@@ -330,7 +348,7 @@ class FilesSpec(docker: RemoteStorageDocker)
 
       "succeed" in {
         val tempAttr  = attributes("myfile.txt")
-        val attr      = tempAttr.copy(location = s"file:///app/nexustest/nexus/${tempAttr.path}", origin = Storage)
+        val attr      = tempAttr.copy(location = Uri(s"file:///app/nexustest/nexus/${tempAttr.path}"), origin = Storage)
         val expected  = mkResource(file2, projectRef, remoteRev, attr, RemoteStorageType, rev = 2, tags = Tags(tag -> 1))
         val updatedF2 = for {
           _ <- files.updateAttributes(file2, projectRef)
@@ -345,7 +363,7 @@ class FilesSpec(docker: RemoteStorageDocker)
       "succeed" in {
         val path     = Uri.Path("my/file-4.txt")
         val tempAttr = attributes("file-4.txt").copy(digest = NotComputedDigest)
-        val attr     = tempAttr.copy(location = s"file:///app/nexustest/nexus/${tempAttr.path}", origin = Storage)
+        val attr     = tempAttr.copy(location = Uri(s"file:///app/nexustest/nexus/${tempAttr.path}"), origin = Storage)
         val expected = mkResource(file2, projectRef, remoteRev, attr, RemoteStorageType, rev = 3, tags = Tags(tag -> 1))
         files
           .updateLink(fileId("file2"), Some(remoteId), None, Some(`text/plain(UTF-8)`), path, 2)


### PR DESCRIPTION
Fixes #4379

If a file contained special characters, then in the local storage the file would be saved using akka.Uri.Path which had URI encoded characters in it. Hence a filename like `[tag]file.txt` would be saved as `%5Btag%5Dfile.txt` on disk.