### PR TITLE
Improve authentication failed message

### DIFF
--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutes.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutes.scala
@@ -24,8 +24,8 @@ final class ErrorRoutes()(implicit
     baseUriPrefix(baseUri.prefix) {
       pathPrefix("errors") {
         pathPrefix("invalid") {
-          (get & pathEndOrSingleSlash) {
-            emit(IO.pure(AuthorizationFailed))
+          (get & extractRequest & pathEndOrSingleSlash) { request =>
+            emit(IO.pure(AuthorizationFailed(request)))
           }
         }
       }

--- a/delta/app/src/test/resources/errors/authorization-failed.json
+++ b/delta/app/src/test/resources/errors/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The supplied authentication is not authorized to access this resource."
-}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/AclsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/AclsRoutesSpec.scala
@@ -107,8 +107,7 @@ class AclsRoutesSpec extends BaseRouteSpec {
       forAll(paths) { case (path, address) =>
         val json = aclJson(userAcl(address)).removeKeys("_path")
         Put(s"/v1/acls$path", json.toEntity) ~> asUser ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ElemRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ElemRoutesSpec.scala
@@ -101,13 +101,11 @@ class ElemRoutesSpec extends BaseRouteSpec with CirceLiteral with IOFromMap {
 
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> `Last-Event-ID`("2") ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
 
         Head(endpoint) ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ErrorRoutesSpec.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.delta.routes
 
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import ch.epfl.bluebrain.nexus.delta.sdk.utils.BaseRouteSpec
 
@@ -11,8 +10,7 @@ class ErrorRoutesSpec extends BaseRouteSpec {
   "The error route" should {
     "return the expected error when fetching the invalid error" in {
       Get("/v1/errors/invalid") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
   }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/EventsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/EventsRoutesSpec.scala
@@ -122,8 +122,7 @@ class EventsRoutesSpec extends BaseRouteSpec with IOFromMap {
 
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> `Last-Event-ID`("2") ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/OrganizationsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/OrganizationsRoutesSpec.scala
@@ -89,8 +89,7 @@ class OrganizationsRoutesSpec extends BaseRouteSpec with IOFromMap {
       val input = json"""{"description": "${org1.description.value}"}"""
 
       Put("/v1/orgs/org1", input.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -256,8 +255,7 @@ class OrganizationsRoutesSpec extends BaseRouteSpec with IOFromMap {
         )
       ) { path =>
         Get(path) ~> routes ~> check {
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
-          response.status shouldEqual StatusCodes.Forbidden
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/PermissionsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/PermissionsRoutesSpec.scala
@@ -41,8 +41,7 @@ class PermissionsRoutesSpec extends BaseRouteSpec with CatsIOValues {
     "fail to fetch permissions without permissions/read permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(permissionsPerms.write)).accepted
       Get("/v1/permissions") ~> Accept(`*/*`) ~> route ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -81,31 +80,27 @@ class PermissionsRoutesSpec extends BaseRouteSpec with CatsIOValues {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(permissionsPerms.write)).accepted
       val replace = json"""{"permissions": ["${realms.write}"]}"""
       Put("/v1/permissions?rev=1", replace.toEntity) ~> Accept(`*/*`) ~> route ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
     "fail to append permissions without permissions/write permission" in {
       val append = json"""{"@type": "Append", "permissions": ["${realms.read}", "${orgs.read}"]}"""
       Patch("/v1/permissions?rev=2", append.toEntity) ~> Accept(`*/*`) ~> route ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
     "fail to subtract permissions without permissions/write permission" in {
       val subtract = json"""{"@type": "Subtract", "permissions": ["${realms.read}", "${realms.write}"]}"""
       Patch("/v1/permissions?rev=3", subtract.toEntity) ~> Accept(`*/*`) ~> route ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
     "fail to delete permissions without permissions/write permission" in {
       Delete("/v1/permissions?rev=4") ~> Accept(`*/*`) ~> route ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ProjectsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ProjectsRoutesSpec.scala
@@ -126,8 +126,7 @@ class ProjectsRoutesSpec extends BaseRouteSpec with IOFromMap {
     "fail to create a project without projects/create permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Put("/v1/projects/org1/proj", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -195,8 +194,7 @@ class ProjectsRoutesSpec extends BaseRouteSpec with IOFromMap {
     "fail to update a project without projects/write permission" in {
       aclCheck.delete(AclAddress.Project(Label.unsafe("org1"), Label.unsafe("proj"))).accepted
       Put("/v1/projects/org1/proj?rev=1", payloadUpdated.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -236,8 +234,7 @@ class ProjectsRoutesSpec extends BaseRouteSpec with IOFromMap {
     "fail to deprecate a project without projects/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(projectsPermissions.write)).accepted
       Delete("/v1/projects/org1/proj?rev=2") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -325,8 +322,7 @@ class ProjectsRoutesSpec extends BaseRouteSpec with IOFromMap {
         )
       ) { path =>
         Get(path) ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }
@@ -470,8 +466,7 @@ class ProjectsRoutesSpec extends BaseRouteSpec with IOFromMap {
     "fail to get the project statistics without resources/read permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(resources.read)).accepted
       Get("/v1/projects/org1/proj/statistics") ~> routes ~> check {
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
-        response.status shouldEqual StatusCodes.Forbidden
+        response.shouldBeForbidden
       }
     }
 
@@ -521,8 +516,7 @@ class ProjectsRoutesSpec extends BaseRouteSpec with IOFromMap {
 
     "fail to delete a project without projects/delete permission" in {
       Delete("/v1/projects/org1/proj?rev=3&prune=true") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/QuotasRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/QuotasRoutesSpec.scala
@@ -60,8 +60,7 @@ class QuotasRoutesSpec extends BaseRouteSpec {
 
       "fail without quotas/read permissions" in {
         Get(s"/v1/quotas/org/project") ~> asAlice ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/RealmsRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/RealmsRoutesSpec.scala
@@ -95,8 +95,7 @@ class RealmsRoutesSpec extends BaseRouteSpec with IOFromMap {
       val input = json"""{"name": "${githubName.value}", "openIdConfig": "$githubOpenId", "logo": "$githubLogo"}"""
 
       Put("/v1/realms/github", input.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -142,15 +141,13 @@ class RealmsRoutesSpec extends BaseRouteSpec with IOFromMap {
     "fail to fetch a realm  without realms/read permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(realmsPermissions.read)).accepted
       Get("/v1/realms/github") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
     "fail to list realms  without realms/read permission" in {
       Get("/v1/realms") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResolversRoutesSpec.scala
@@ -124,10 +124,8 @@ class ResolversRoutesSpec extends BaseRouteSpec {
       ResolversRoutes(identities, aclCheck, resolvers, multiResolution, groupDirectives, IndexingAction.noop)
     )
 
-  private def withId(id: String, payload: Json) =
+  private def withId(id: String, payload: Json)   =
     payload.deepMerge(Json.obj("@id" -> id.asJson))
-
-  private val authorizationFailedResponse       = jsonContentOf("errors/authorization-failed.json")
 
   private val inProjectPayload                    = jsonContentOf("resolvers/in-project-success.json")
   private val crossProjectUseCurrentPayload       = jsonContentOf("resolvers/cross-project-use-current-caller-success.json")
@@ -226,13 +224,11 @@ class ResolversRoutesSpec extends BaseRouteSpec {
           create(genString(), project2.ref, inProjectPayload) ++ create(genString(), project2.ref, inProjectPayload)
         ) { case (_, request) =>
           request ~> asBob ~> routes ~> check {
-            status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual authorizationFailedResponse
+            response.shouldBeForbidden
           }
 
           request ~> routes ~> check {
-            status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual authorizationFailedResponse
+            response.shouldBeForbidden
           }
         }
       }
@@ -323,8 +319,7 @@ class ResolversRoutesSpec extends BaseRouteSpec {
           )
         ) { request =>
           request ~> check {
-            status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual authorizationFailedResponse
+            response.shouldBeForbidden
           }
         }
       }
@@ -354,8 +349,7 @@ class ResolversRoutesSpec extends BaseRouteSpec {
           s"/v1/resolvers/${project2.ref}/in-project-put/tags?rev=2",
           tagPayload.toEntity
         ) ~> asBob ~> routes ~> check {
-          status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual authorizationFailedResponse
+          response.shouldBeForbidden
         }
       }
     }
@@ -435,8 +429,7 @@ class ResolversRoutesSpec extends BaseRouteSpec {
           )
         ) { request =>
           request ~> check {
-            status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual authorizationFailedResponse
+            response.shouldBeForbidden
           }
         }
       }
@@ -650,8 +643,7 @@ class ResolversRoutesSpec extends BaseRouteSpec {
           )
         ) { request =>
           request ~> check {
-            status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual authorizationFailedResponse
+            response.shouldBeForbidden
           }
         }
       }
@@ -760,8 +752,7 @@ class ResolversRoutesSpec extends BaseRouteSpec {
 
       "fail if the user does not have the right permission" in {
         Get(s"/v1/resolvers/${project.ref}/in-project-post/$idSchemaEncoded") ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
@@ -142,8 +142,7 @@ class ResourcesRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues
     "fail to create a resource without resources/write permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Post("/v1/resources/myorg/myproject", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -271,8 +270,7 @@ class ResourcesRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues
     "fail to update a resource without resources/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(resources.write)).accepted
       Put("/v1/resources/myorg/myproject/_/myid?rev=1", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -314,8 +312,7 @@ class ResourcesRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues
     "fail to refresh a resource without resources/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(resources.write)).accepted
       Put("/v1/resources/myorg/myproject/_/myid/refresh", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -349,8 +346,7 @@ class ResourcesRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues
     "fail to deprecate a resource without resources/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(resources.write)).accepted
       Delete("/v1/resources/myorg/myproject/_/myid?rev=4") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -398,8 +394,7 @@ class ResourcesRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues
       )
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesRoutesSpec.scala
@@ -349,8 +349,7 @@ class ResourcesRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues
     "fail to update a schema without resources/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(resources.write)).accepted
       Put(s"/v1/resources/$projectRef/_/someId/update-schema") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesTrialRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ResourcesTrialRoutesSpec.scala
@@ -130,8 +130,7 @@ class ResourcesTrialRoutesSpec extends BaseRouteSpec with ResourceInstanceFixtur
     "fail to generate a resource for a user without access" in {
       val payload = json"""{ "resource": $validSource }"""
       Post(s"/v1/trial/resources/$projectRef/", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -201,8 +200,7 @@ class ResourcesTrialRoutesSpec extends BaseRouteSpec with ResourceInstanceFixtur
 
     "fail to validate for a user without access" in {
       Get(s"/v1/resources/$projectRef/_/myId/validate") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SchemasRoutesSpec.scala
@@ -89,8 +89,7 @@ class SchemasRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues {
     "fail to create a schema without schemas/write permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Post("/v1/schemas/myorg/myproject", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -133,8 +132,7 @@ class SchemasRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues {
     "fail to update a schema without schemas/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(schemas.write)).accepted
       Put(s"/v1/schemas/myorg/myproject/myid?rev=1", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -172,8 +170,7 @@ class SchemasRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues {
     "fail to refresh a schema without schemas/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(schemas.write)).accepted
       Put(s"/v1/schemas/myorg/myproject/myid/refresh", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -203,8 +200,7 @@ class SchemasRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues {
     "fail to deprecate a schema without schemas/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(schemas.write)).accepted
       Delete("/v1/schemas/myorg/myproject/myid?rev=3") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -248,8 +244,7 @@ class SchemasRoutesSpec extends BaseRouteSpec with IOFromMap with CatsIOValues {
       forAll(endpoints) { endpoint =>
         forAll(List("", "?rev=1", "?tags=mytag")) { suffix =>
           Get(s"$endpoint$suffix") ~> routes ~> check {
-            response.status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+            response.shouldBeForbidden
           }
         }
       }

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SupervisionRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/SupervisionRoutesSpec.scala
@@ -44,8 +44,7 @@ class SupervisionRoutesSpec extends BaseRouteSpec {
 
     "be forbidden without supervision/read permission" in {
       Get("/v1/supervision/projections") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/VersionRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/VersionRoutesSpec.scala
@@ -55,8 +55,7 @@ class VersionRoutesSpec extends BaseRouteSpec {
     "fail fetching plugins information without version/read permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Get("/v1/version") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveDownload.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveDownload.scala
@@ -23,6 +23,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.FileResponse
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.Response.Complete
 import ch.epfl.bluebrain.nexus.delta.sdk.error.SDKError
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdContent
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.AnnotatedSource
@@ -51,8 +52,6 @@ trait ArchiveDownload {
     *   the archive value
     * @param project
     *   the archive parent project
-    * @param format
-    *   the requested archive format
     * @param ignoreNotFound
     *   do not fail when resource references are not found
     * @param caller
@@ -180,11 +179,10 @@ object ArchiveDownload {
         // the required permissions are checked for each file content fetch
         val entry      = fetchFileContent(ref.ref, refProject, caller)
           .adaptError {
-            case _: FileRejection.FileNotFound                 => ResourceNotFound(ref.ref, project)
-            case _: FileRejection.TagNotFound                  => ResourceNotFound(ref.ref, project)
-            case _: FileRejection.RevisionNotFound             => ResourceNotFound(ref.ref, project)
-            case FileRejection.AuthorizationFailed(addr, perm) => AuthorizationFailed(addr, perm)
-            case other: FileRejection                          => WrappedFileRejection(other)
+            case _: FileRejection.FileNotFound     => ResourceNotFound(ref.ref, project)
+            case _: FileRejection.TagNotFound      => ResourceNotFound(ref.ref, project)
+            case _: FileRejection.RevisionNotFound => ResourceNotFound(ref.ref, project)
+            case other: FileRejection              => WrappedFileRejection(other)
           }
           .map { case FileResponse(fileMetadata, content) =>
             val path                        = pathOf(ref, project, fileMetadata.filename)

--- a/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/ArchiveRejection.scala
+++ b/delta/plugins/archive/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/model/ArchiveRejection.scala
@@ -13,10 +13,8 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.{RdfError, Vocabulary}
-import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.HttpResponseFields
-import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContext.ContextRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.{ProjectRef, ResourceRef}
@@ -149,19 +147,6 @@ object ArchiveRejection {
       extends ArchiveRejection(s"The resource '${ref.toString}' was not found in project '$project'.")
 
   /**
-    * Rejection returned when the caller does not have permission to access a referenced resource.
-    *
-    * @param address
-    *   the address on which the permission was checked
-    * @param permission
-    *   the permission that was required
-    */
-  final case class AuthorizationFailed(address: AclAddress, permission: Permission)
-      extends ArchiveRejection(
-        s"The permission '$permission' required for accessing a resource at '$address' is missing."
-      )
-
-  /**
     * Wrapper for file rejections.
     *
     * @param rejection
@@ -204,7 +189,6 @@ object ArchiveRejection {
       case DecodingFailed(_)                  => StatusCodes.BadRequest
       case InvalidJsonLdFormat(_, _)          => StatusCodes.BadRequest
       case ResourceNotFound(_, _)             => StatusCodes.NotFound
-      case AuthorizationFailed(_, _)          => StatusCodes.Forbidden
       case BlankArchiveId                     => StatusCodes.BadRequest
       case InvalidFileSelf(_)                 => StatusCodes.BadRequest
       case WrappedFileRejection(rejection)    => rejection.status

--- a/delta/plugins/archive/src/test/resources/responses/authorization-failed.json
+++ b/delta/plugins/archive/src/test/resources/responses/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The supplied authentication is not authorized to access this resource."
-}

--- a/delta/plugins/archive/src/test/resources/responses/file-authorization-failed.json
+++ b/delta/plugins/archive/src/test/resources/responses/file-authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The permission 'disk/read' required for accessing a resource at '/org/proj' is missing."
-}

--- a/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveDownloadSpec.scala
+++ b/delta/plugins/archive/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/archive/ArchiveDownloadSpec.scala
@@ -11,7 +11,7 @@ import cats.effect.IO
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UrlUtils.encode
 import ch.epfl.bluebrain.nexus.delta.plugins.archive.FileSelf.ParsingError
 import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.ArchiveReference.{FileReference, FileSelfReference, ResourceReference}
-import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.ArchiveRejection.{AuthorizationFailed, InvalidFileSelf, ResourceNotFound}
+import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.ArchiveRejection.{InvalidFileSelf, ResourceNotFound}
 import ch.epfl.bluebrain.nexus.delta.plugins.archive.model.{ArchiveRejection, ArchiveValue}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.RemoteContextResolutionFixture
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.files.model.FileAttributes.FileAttributesOrigin.Client
@@ -27,6 +27,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.AkkaSource
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.FileResponse
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewsQuery.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/BlazegraphViewsQuery.scala
@@ -4,7 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.search.Pagination.FromPagination
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceUtils.ioContentOf
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.SparqlQueryResponseType.{Aux, SparqlResultsJson}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client._
-import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewRejection.{AuthorizationFailed, _}
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewRejection._
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewValue.{AggregateBlazegraphViewValue, IndexingBlazegraphViewValue}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.SparqlLink.{SparqlExternalLink, SparqlResourceLink}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model._
@@ -14,6 +14,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.effect.migration._
 import ch.epfl.bluebrain.nexus.delta.rdf.query.SparqlQuery
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress.{Project => ProjectAcl}
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.ExpandIri
 import ch.epfl.bluebrain.nexus.delta.sdk.model.IdSegment.IriSegment
@@ -175,9 +176,11 @@ object BlazegraphViewsQuery {
           indices <- view match {
                        case i: IndexingView  =>
                          aclCheck
-                           .authorizeForOr(i.ref.project, i.permission)(AuthorizationFailed)
+                           .authorizeForOr(i.ref.project, i.permission)(
+                             AuthorizationFailed(i.ref.project, i.permission)
+                           )
                            .as(Set(i.index))
-                           .toBIO[AuthorizationFailed]
+                           .toBIO[BlazegraphViewRejection]
                        case a: AggregateView =>
                          aclCheck
                            .mapFilter[IndexingView, String](

--- a/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/model/BlazegraphViewRejection.scala
+++ b/delta/plugins/blazegraph/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/model/BlazegraphViewRejection.scala
@@ -12,7 +12,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.{RdfError, Vocabulary}
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection.{BlankId, UnexpectedId}
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.HttpResponseFields
@@ -195,13 +194,6 @@ object BlazegraphViewRejection {
       extends BlazegraphViewRejection(s"Resource identifier '$id' cannot be expanded to an Iri.")
 
   /**
-    * Rejection returned when attempting to query a BlazegraphView and the caller does not have the right permissions
-    * defined in the view.
-    */
-  final case object AuthorizationFailed extends BlazegraphViewRejection(ServiceError.AuthorizationFailed.reason)
-  type AuthorizationFailed = AuthorizationFailed.type
-
-  /**
     * Signals a rejection caused when interacting with the blazegraph client
     */
   final case class WrappedBlazegraphClientError(error: SparqlClientError) extends BlazegraphViewRejection(error.reason)
@@ -252,7 +244,6 @@ object BlazegraphViewRejection {
       case ResourceAlreadyExists(_, _)  => StatusCodes.Conflict
       case IncorrectRev(_, _)           => StatusCodes.Conflict
       case ProjectContextRejection(rej) => rej.status
-      case AuthorizationFailed          => StatusCodes.Forbidden
       case _                            => StatusCodes.BadRequest
     }
 }

--- a/delta/plugins/blazegraph/src/test/resources/routes/errors/authorization-failed.json
+++ b/delta/plugins/blazegraph/src/test/resources/routes/errors/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The supplied authentication is not authorized to access this resource."
-}

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsIndexingRoutesSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsIndexingRoutesSpec.scala
@@ -102,8 +102,7 @@ class BlazegraphViewsIndexingRoutesSpec extends BlazegraphViewRoutesFixtures wit
     )
     forAll(endpoints) { endpoint =>
       Get(endpoint) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
   }
@@ -150,8 +149,7 @@ class BlazegraphViewsIndexingRoutesSpec extends BlazegraphViewRoutesFixtures wit
   "fail to restart offset from view without resources/write permission" in {
 
     Delete(s"$viewEndpoint/offset") ~> routes ~> check {
-      response.status shouldEqual StatusCodes.Forbidden
-      response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+      response.shouldBeForbidden
     }
   }
 
@@ -175,8 +173,7 @@ class BlazegraphViewsIndexingRoutesSpec extends BlazegraphViewRoutesFixtures wit
     )
     forAll(endpoints) { endpoint =>
       Get(endpoint) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
   }

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsQuerySpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsQuerySpec.scala
@@ -12,7 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.BlazegraphViewsQuery.BlazegraphQueryContext
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.SparqlQueryResponseType.SparqlNTriples
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.client.{BlazegraphClient, SparqlWriteQuery}
-import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewRejection.{AuthorizationFailed, ProjectContextRejection, ViewIsDeprecated}
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewRejection.{ProjectContextRejection, ViewIsDeprecated}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.BlazegraphViewValue.{AggregateBlazegraphViewValue, IndexingBlazegraphViewValue}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.SparqlLink.{SparqlExternalLink, SparqlResourceLink}
 import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model._
@@ -25,6 +25,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.query.SparqlQuery.SparqlConstructQuery
 import ch.epfl.bluebrain.nexus.delta.sdk.ConfigFixtures
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
 import ch.epfl.bluebrain.nexus.delta.sdk.http.{HttpClient, HttpClientConfig, HttpClientWorthRetry}
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
@@ -233,7 +234,7 @@ class BlazegraphViewsQuerySpec(docker: BlazegraphDocker)
 
     "query an indexed view without permissions" in eventually {
       val proj = view1Proj1.project
-      viewsQuery.query(view1Proj1.viewId, proj, constructQuery, SparqlNTriples)(anon).rejectedWith[AuthorizationFailed]
+      viewsQuery.query(view1Proj1.viewId, proj, constructQuery, SparqlNTriples)(anon).terminated[AuthorizationFailed]
     }
 
     "query a deprecated indexed view" in eventually {

--- a/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutesSpec.scala
+++ b/delta/plugins/blazegraph/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/blazegraph/routes/BlazegraphViewsRoutesSpec.scala
@@ -91,8 +91,7 @@ class BlazegraphViewsRoutesSpec extends BlazegraphViewRoutesFixtures {
     "fail to create a view without permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Post("/v1/views/org/proj", indexingSource.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
     "create an indexing view" in {
@@ -149,8 +148,7 @@ class BlazegraphViewsRoutesSpec extends BlazegraphViewRoutesFixtures {
     }
     "fail to update a view without permission" in {
       Put("/v1/views/org/proj/aggregate-view?rev=1", aggregateSource.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
     "update a view" in {
@@ -177,8 +175,7 @@ class BlazegraphViewsRoutesSpec extends BlazegraphViewRoutesFixtures {
 
     "fail to deprecate a view without permission" in {
       Delete("/v1/views/org/proj/indexing-view?rev=3") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
     "reject a deprecation of a view without rev" in {
@@ -204,9 +201,7 @@ class BlazegraphViewsRoutesSpec extends BlazegraphViewRoutesFixtures {
 
     "fail to fetch a view without permission" in {
       Get("/v1/views/org/proj/indexing-view") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
-
+        response.shouldBeForbidden
       }
     }
     "fetch a view" in {
@@ -318,8 +313,7 @@ class BlazegraphViewsRoutesSpec extends BlazegraphViewRoutesFixtures {
         )
       ) { req =>
         req ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeViewRejection.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/model/CompositeViewRejection.scala
@@ -13,7 +13,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.{RdfError, Vocabulary}
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
@@ -291,13 +290,6 @@ object CompositeViewRejection {
   final case class DecodingFailed(error: JsonLdDecoderError) extends CompositeViewRejection(error.getMessage)
 
   /**
-    * Rejection returned when attempting to query a Blazegraph index and the caller does not have the right permissions
-    * defined in the view.
-    */
-  final case object AuthorizationFailed extends CompositeViewRejection(ServiceError.AuthorizationFailed.reason)
-  type AuthorizationFailed = AuthorizationFailed.type
-
-  /**
     * Signals a rejection caused when interacting with the blazegraph client
     */
   final case class WrappedBlazegraphClientError(error: SparqlClientError) extends CompositeViewRejection(error.reason)
@@ -349,7 +341,6 @@ object CompositeViewRejection {
       case ResourceAlreadyExists(_, _)            => StatusCodes.Conflict
       case IncorrectRev(_, _)                     => StatusCodes.Conflict
       case ProjectContextRejection(rej)           => rej.status
-      case AuthorizationFailed                    => StatusCodes.Forbidden
       case WrappedElasticSearchClientError(error) => error.errorCode.getOrElse(StatusCodes.InternalServerError)
       case _                                      => StatusCodes.BadRequest
     }

--- a/delta/plugins/composite-views/src/test/resources/routes/errors/authorization-failed.json
+++ b/delta/plugins/composite-views/src/test/resources/routes/errors/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The supplied authentication is not authorized to access this resource."
-}

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/BlazegraphQuerySpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/BlazegraphQuerySpec.scala
@@ -7,7 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.permissions
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.indexing.CompositeViewDef.ActiveViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.indexing.{commonNamespace, projectionNamespace}
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewProjection.{ElasticSearchProjection, SparqlProjection}
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewRejection.{AuthorizationFailed, ProjectionNotFound}
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewRejection.ProjectionNotFound
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewSource.ProjectSource
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.ProjectionType.SparqlProjectionType
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.TemplateSparqlConstructQuery
@@ -18,6 +18,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.graph.NTriples
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
@@ -26,13 +27,13 @@ import ch.epfl.bluebrain.nexus.delta.sdk.permissions.model.Permission
 import ch.epfl.bluebrain.nexus.delta.sdk.views.{IndexingRev, ViewRef}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Group, User}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Label
-import ch.epfl.bluebrain.nexus.testkit.scalatest.bio.BioSpec
+import ch.epfl.bluebrain.nexus.testkit.scalatest.ce.CatsEffectSpec
 import io.circe.JsonObject
 import org.scalatest.CancelAfterFailure
 
 import java.util.UUID
 
-class BlazegraphQuerySpec extends BioSpec with CancelAfterFailure {
+class BlazegraphQuerySpec extends CatsEffectSpec with CancelAfterFailure {
 
   implicit val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
 

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/ElasticSearchQuerySpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/ElasticSearchQuerySpec.scala
@@ -7,7 +7,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.permissions
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.indexing.CompositeViewDef.ActiveViewDef
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.indexing.projectionIndex
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewProjection.{ElasticSearchProjection, SparqlProjection}
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewRejection.{AuthorizationFailed, ProjectionNotFound}
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewRejection.ProjectionNotFound
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.CompositeViewSource.ProjectSource
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.ProjectionType.ElasticSearchProjectionType
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.TemplateSparqlConstructQuery
@@ -17,6 +17,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue.ContextObject
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ProjectGen
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClient.HttpResult
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError.HttpUnexpectedError

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/routes/CompositeViewsIndexingRoutesSpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/routes/CompositeViewsIndexingRoutesSpec.scala
@@ -123,8 +123,7 @@ class CompositeViewsIndexingRoutesSpec extends CompositeViewsRoutesFixtures {
       forAll(endpoints) { endpoint =>
         forAll(List(Get(endpoint), Delete(endpoint))) { req =>
           req ~> routes ~> check {
-            response.status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+            response.shouldBeForbidden
           }
         }
       }
@@ -184,8 +183,7 @@ class CompositeViewsIndexingRoutesSpec extends CompositeViewsRoutesFixtures {
 
     "fail to fetch indexing description without permission" in {
       Get(s"$viewEndpoint/description") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -245,8 +243,7 @@ class CompositeViewsIndexingRoutesSpec extends CompositeViewsRoutesFixtures {
       )
       forAll(endpoints) { endpoint =>
         Get(endpoint) ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
     }

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/routes/CompositeViewsRoutesSpec.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/routes/CompositeViewsRoutesSpec.scala
@@ -101,8 +101,7 @@ class CompositeViewsRoutesSpec extends CompositeViewsRoutesFixtures {
     "fail to create a view without permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Post("/v1/views/myorg/myproj", viewSource.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -123,8 +122,7 @@ class CompositeViewsRoutesSpec extends CompositeViewsRoutesFixtures {
 
     "fail to update a view without permission" in {
       Put(s"/v1/views/myorg/myproj/$uuid?rev=1", viewSource.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -152,8 +150,7 @@ class CompositeViewsRoutesSpec extends CompositeViewsRoutesFixtures {
 
     "fail to fetch a view without permission" in {
       Get(s"/v1/views/myorg/myproj/$uuid") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -255,8 +252,7 @@ class CompositeViewsRoutesSpec extends CompositeViewsRoutesFixtures {
 
     "fail to deprecate a view without permission" in {
       Delete(s"/v1/views/myorg/myproj/$uuid?rev=3") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/IdResolution.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/IdResolution.scala
@@ -4,7 +4,6 @@ import ch.epfl.bluebrain.nexus.delta.kernel.search.Pagination.FromPagination
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.IdResolutionResponse._
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ResourcesSearchParams
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.DefaultSearchRequest.RootSearch
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.ElasticSearchQueryError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.{DefaultViewsQuery, ElasticSearchQueryError}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
 import ch.epfl.bluebrain.nexus.delta.rdf.RdfError
@@ -13,6 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.{JsonLdApi, JsonLdOptions}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.{CompactedJsonLd, ExpandedJsonLd}
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdContent
 import ch.epfl.bluebrain.nexus.delta.sdk.model.ResourceF._
@@ -70,7 +70,7 @@ class IdResolution(
       .list(request)
       .flatMap { searchResults =>
         searchResults.results match {
-          case Nil         => IO.raiseError(AuthorizationFailed)
+          case Nil         => IO.terminate(AuthorizationFailed("No resource matches the provided id."))
           case Seq(result) => projectRefFromSource(result.source).flatMap(fetchSingleResult)
           case _           => UIO.pure(MultipleResults(searchResults))
         }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewRejection.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/model/ElasticSearchViewRejection.scala
@@ -11,7 +11,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.decoder.JsonLdDecoderError
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
 import ch.epfl.bluebrain.nexus.delta.rdf.{RdfError, Vocabulary}
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError
 import ch.epfl.bluebrain.nexus.delta.sdk.jsonld.JsonLdRejection
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.HttpResponseFields
@@ -202,14 +201,6 @@ object ElasticSearchViewRejection {
       )
 
   /**
-    * Rejection returned when attempting to query an elasticsearchview and the caller does not have the right
-    * permissions defined in the view.
-    */
-  final case object AuthorizationFailed extends ElasticSearchViewRejection(ServiceError.AuthorizationFailed.reason)
-
-  type AuthorizationFailed = AuthorizationFailed.type
-
-  /**
     * Signals a rejection caused when interacting with the elasticserch client
     */
   final case class WrappedElasticSearchClientError(error: HttpClientError)
@@ -272,7 +263,6 @@ object ElasticSearchViewRejection {
       case ResourceAlreadyExists(_, _)            => StatusCodes.Conflict
       case IncorrectRev(_, _)                     => StatusCodes.Conflict
       case ProjectContextRejection(rej)           => rej.status
-      case AuthorizationFailed                    => StatusCodes.Forbidden
       case WrappedElasticSearchClientError(error) => error.errorCode.getOrElse(StatusCodes.InternalServerError)
       case _                                      => StatusCodes.BadRequest
     }

--- a/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/ElasticSearchQueryError.scala
+++ b/delta/plugins/elasticsearch/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/ElasticSearchQueryError.scala
@@ -6,7 +6,6 @@ import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.JsonLdContext.keywords
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.encoder.JsonLdEncoder
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientError
 import ch.epfl.bluebrain.nexus.delta.sdk.marshalling.HttpResponseFields
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContext.ContextRejection
@@ -19,14 +18,6 @@ import io.circe.{Encoder, JsonObject}
 sealed abstract class ElasticSearchQueryError(val reason: String)
 
 object ElasticSearchQueryError {
-
-  /**
-    * Error returned when attempting to query an Elasticsearch view and the caller does not have the right permissions
-    * defined in the view.
-    */
-  final case object AuthorizationFailed extends ElasticSearchQueryError(ServiceError.AuthorizationFailed.reason)
-
-  type AuthorizationFailed = AuthorizationFailed.type
 
   /**
     * Signals a rejection caused when interacting with other APIs when fetching a resource
@@ -59,7 +50,6 @@ object ElasticSearchQueryError {
 
   implicit val elasticSearchViewRejectionHttpResponseFields: HttpResponseFields[ElasticSearchQueryError] =
     HttpResponseFields {
-      case AuthorizationFailed             => StatusCodes.Forbidden
       case ElasticSearchClientError(error) => error.errorCode.getOrElse(StatusCodes.InternalServerError)
       case InvalidResourceId(_)            => StatusCodes.BadRequest
       case ProjectContextRejection(rej)    => rej.status

--- a/delta/plugins/elasticsearch/src/test/resources/routes/errors/authorization-failed.json
+++ b/delta/plugins/elasticsearch/src/test/resources/routes/errors/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The supplied authentication is not authorized to access this resource."
-}

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsQuerySuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/ElasticSearchViewsQuerySuite.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.ElasticSearchViewsQuerySuite.Sample
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.client.ElasticSearchBulk
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewRejection.{AuthorizationFailed, DifferentElasticSearchViewType, ProjectContextRejection, ViewIsDeprecated, ViewNotFound}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewRejection.{DifferentElasticSearchViewType, ProjectContextRejection, ViewIsDeprecated, ViewNotFound}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.ElasticSearchViewValue.{AggregateElasticSearchViewValue, IndexingElasticSearchViewValue}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultViewId, permissions, ElasticSearchViewRejection, ElasticSearchViewType}
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
@@ -15,6 +15,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.{ProjectGen, ResourceGen}
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
@@ -305,7 +306,7 @@ class ElasticSearchViewsQuerySuite
 
   test("Query a view without permissions") {
     implicit val caller: Caller = anon
-    viewsQuery.query(view1Proj1, JsonObject.empty, Query.Empty).error(AuthorizationFailed)
+    viewsQuery.query(view1Proj1, JsonObject.empty, Query.Empty).terminated[AuthorizationFailed]
   }
 
   test("Query the deprecated view should raise an deprecation error") {
@@ -353,7 +354,7 @@ class ElasticSearchViewsQuerySuite
     implicit val caller: Caller = anon
     viewsQuery
       .mapping(view1Proj1.viewId, project1.ref)
-      .assertError(_ == AuthorizationFailed)
+      .terminated[AuthorizationFailed]
   }
 
   test("Obtaining the mapping for a view that doesn't exist in the project should fail") {

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/IdResolutionSuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/IdResolutionSuite.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.IdResolutionResponse.{MultipleResults, SingleResult}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.IdResolutionSuite.searchResults
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultViewId, permissions}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.ElasticSearchQueryError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.{DefaultSearchRequest, DefaultViewsQuery}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
@@ -11,6 +10,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.DataResource
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.generators.ResourceGen
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{AggregationResult, SearchResults}
@@ -72,7 +72,7 @@ class IdResolutionSuite extends BioSuite with Fixtures {
     val noListingResults = defaultViewsQuery(searchResults(Seq.empty))
     new IdResolution(noListingResults, fetchResource)
       .resolve(iri)(alice)
-      .assertError(_ == AuthorizationFailed)
+      .terminated[AuthorizationFailed]
   }
 
   test("Single listing result leads to the resource being fetched") {

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsQuerySuite.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/query/DefaultViewsQuerySuite.scala
@@ -3,9 +3,9 @@ package ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query
 import ch.epfl.bluebrain.nexus.delta.kernel.search.Pagination
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{defaultViewId, permissions, ResourcesSearchParams}
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.DefaultSearchRequest.{OrgSearch, ProjectSearch, RootSearch}
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.ElasticSearchQueryError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.SortList
 import ch.epfl.bluebrain.nexus.delta.sdk.views.View.IndexingView
@@ -104,7 +104,7 @@ class DefaultViewsQuerySuite extends BioSuite {
   }
 
   test(s"Raise an error for $project2 for a user with limited access on '$project1'") {
-    defaultViewsQuery.list(project2Search)(charlie).error(AuthorizationFailed)
+    defaultViewsQuery.list(project2Search)(charlie).terminated[AuthorizationFailed]
   }
 
   test(s"List only '$project1' default view in '$org' for a user with limited access on '$project1'") {
@@ -116,14 +116,14 @@ class DefaultViewsQuerySuite extends BioSuite {
   }
 
   test(s"Raise an error for $project1 for Anonymous") {
-    defaultViewsQuery.list(project1Search)(anon).error(AuthorizationFailed)
+    defaultViewsQuery.list(project1Search)(anon).terminated[AuthorizationFailed]
   }
 
   test(s"Raise an error for $org for Anonymous") {
-    defaultViewsQuery.list(org1Search)(anon).error(AuthorizationFailed)
+    defaultViewsQuery.list(org1Search)(anon).terminated[AuthorizationFailed]
   }
 
   test(s"Raise an error for root for Anonymous") {
-    defaultViewsQuery.list(rootSearch)(anon).error(AuthorizationFailed)
+    defaultViewsQuery.list(rootSearch)(anon).terminated[AuthorizationFailed]
   }
 }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/DummyDefaultViewsQuery.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/DummyDefaultViewsQuery.scala
@@ -4,6 +4,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.query.{DefaultSearchR
 import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.routes.DummyDefaultViewsQuery._
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.kernel.search.Pagination.FromPagination
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.{AggregationResult, SearchResults}
 import ch.epfl.bluebrain.nexus.testkit.CirceLiteral.circeLiteralSyntax
 import io.circe.JsonObject
@@ -17,7 +18,7 @@ class DummyDefaultViewsQuery extends DefaultViewsQuery[Result, Aggregation] {
     if (searchRequest.pagination == allowedPage)
       IO.pure(SearchResults(1, List(listResponse)))
     else
-      IO.raiseError(ElasticSearchQueryError.AuthorizationFailed)
+      IO.terminate(AuthorizationFailed("Fail !!!!"))
 
   override def aggregate(searchRequest: DefaultSearchRequest)(implicit
       caller: Caller

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchIndexingRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchIndexingRoutesSpec.scala
@@ -132,8 +132,7 @@ class ElasticSearchIndexingRoutesSpec extends ElasticSearchViewsRoutesFixtures w
     )
     forAll(endpoints) { endpoint =>
       Get(endpoint) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
   }
@@ -180,8 +179,7 @@ class ElasticSearchIndexingRoutesSpec extends ElasticSearchViewsRoutesFixtures w
     aclCheck.subtract(AclAddress.Root, Anonymous -> Set(esPermissions.write)).accepted
 
     Delete(s"$viewEndpoint/offset") ~> routes ~> check {
-      response.status shouldEqual StatusCodes.Forbidden
-      response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+      response.shouldBeForbidden
     }
   }
 
@@ -204,8 +202,7 @@ class ElasticSearchIndexingRoutesSpec extends ElasticSearchViewsRoutesFixtures w
     )
     forAll(endpoints) { endpoint =>
       Get(endpoint) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
   }

--- a/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
+++ b/delta/plugins/elasticsearch/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/elasticsearch/routes/ElasticSearchViewsRoutesSpec.scala
@@ -98,8 +98,7 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures with
     "fail to create a view without views/write permission" in {
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       Post("/v1/views/myorg/myproject", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -153,8 +152,7 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures with
     "fail to update a view without views/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(esPermissions.write)).accepted
       Put(s"/v1/views/myorg/myproject/myid?rev=1", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -192,8 +190,7 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures with
     "fail to deprecate a view without views/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(esPermissions.write)).accepted
       Delete("/v1/views/myorg/myproject/myid?rev=3") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -243,8 +240,7 @@ class ElasticSearchViewsRoutesSpec extends ElasticSearchViewsRoutesFixtures with
       forAll(endpoints) { endpoint =>
         forAll(List("", "?rev=1", "?tags=mytag")) { suffix =>
           Get(s"$endpoint$suffix") ~> routes ~> check {
-            response.status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual jsonContentOf("/routes/errors/authorization-failed.json")
+            response.shouldBeForbidden
           }
         }
       }

--- a/delta/plugins/graph-analytics/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/routes/GraphAnalyticsRoutesSpec.scala
+++ b/delta/plugins/graph-analytics/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/graph/analytics/routes/GraphAnalyticsRoutesSpec.scala
@@ -98,8 +98,7 @@ class GraphAnalyticsRoutesSpec extends BaseRouteSpec with CancelAfterFailure {
       "fail to fetch without resources/read permission" in {
         aclCheck.append(AclAddress.Root, alice -> Set(resources.read)).accepted
         Get("/v1/graph-analytics/org/project/relationships") ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
 
@@ -115,8 +114,7 @@ class GraphAnalyticsRoutesSpec extends BaseRouteSpec with CancelAfterFailure {
 
       "fail to fetch without resources/read permission" in {
         Get("/v1/graph-analytics/org/project/properties/Person") ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
 
@@ -132,8 +130,7 @@ class GraphAnalyticsRoutesSpec extends BaseRouteSpec with CancelAfterFailure {
 
       "fail to fetch without resources/read permission" in {
         Get("/v1/graph-analytics/org/project/statistics") ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
 
@@ -151,8 +148,7 @@ class GraphAnalyticsRoutesSpec extends BaseRouteSpec with CancelAfterFailure {
 
       "fail without authorization" in {
         Post("/v1/graph-analytics/org/project/_search", query.toEntity) ~> asAlice ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
         }
       }
 

--- a/delta/plugins/jira/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/jira/routes/JiraRoutes.scala
+++ b/delta/plugins/jira/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/jira/routes/JiraRoutes.scala
@@ -44,7 +44,10 @@ class JiraRoutes(
   private def extractUser: Directive1[User] = extractCaller.flatMap {
     _.subject match {
       case u: User => provide(u)
-      case _       => failWith(AuthorizationFailed)
+      case _       =>
+        extractRequest.flatMap { request =>
+          failWith(AuthorizationFailed(request))
+        }
     }
   }
 

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/Files.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/Files.scala
@@ -31,6 +31,7 @@ import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.ContextValue
 import ch.epfl.bluebrain.nexus.delta.sdk.AkkaSource
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.FileResponse
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.IdSegmentRef.{Latest, Revision, Tag}

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutes.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutes.scala
@@ -22,6 +22,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.ce.DeltaDirectives._
 import ch.epfl.bluebrain.nexus.delta.sdk.circe.CirceUnmarshalling
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.DeltaDirectives.{baseUriPrefix, idSegment, indexingMode, noParameter, tagParam}
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.{AuthDirectives, DeltaSchemeDirectives}
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.fusion.FusionConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.Identities
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.Caller

--- a/delta/plugins/storage/src/test/resources/errors/authorization-failed.json
+++ b/delta/plugins/storage/src/test/resources/errors/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The supplied authentication is not authorized to access this resource."
-}

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FilesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/FilesSpec.scala
@@ -24,6 +24,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclSimpleCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.acls.model.AclAddress
 import ch.epfl.bluebrain.nexus.delta.sdk.auth.{AuthTokenProvider, Credentials}
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.FileResponse
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
 import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClient
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.model.{Caller, ServiceAccount}
 import ch.epfl.bluebrain.nexus.delta.sdk.implicits._

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutesSpec.scala
@@ -154,8 +154,7 @@ class FilesRoutesSpec
 
     "fail to create a file without disk/write permission" in {
       Post("/v1/files/org/proj", entity()) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -192,8 +191,7 @@ class FilesRoutesSpec
 
     "fail to create a file without s3/write permission" in {
       Put("/v1/files/org/proj/file1?storage=s3-storage", entity()) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -248,8 +246,7 @@ class FilesRoutesSpec
     "fail to update a file without disk/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(diskWrite)).accepted
       Put(s"/v1/files/org/proj/file1?rev=1", s3FieldsJson.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -305,8 +302,7 @@ class FilesRoutesSpec
 
     "fail to deprecate a file without files/write permission" in {
       Delete(s"/v1/files/org/proj/$uuid?rev=1") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -345,8 +341,7 @@ class FilesRoutesSpec
     "fail to fetch a file without s3/read permission" in {
       forAll(List("", "?rev=1", "?tags=mytag")) { suffix =>
         Get(s"/v1/files/org/proj/file1$suffix") ~> Accept(`*/*`) ~> routes ~> check {
-          response.status shouldEqual StatusCodes.Forbidden
-          response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+          response.shouldBeForbidden
           response.headers should not contain varyHeader
         }
       }
@@ -414,8 +409,7 @@ class FilesRoutesSpec
       forAll(endpoints) { endpoint =>
         forAll(List("", "?rev=1", "?tags=mytag")) { suffix =>
           Get(s"$endpoint$suffix") ~> Accept(`application/ld+json`) ~> routes ~> check {
-            response.status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+            response.shouldBeForbidden
             response.headers should not contain varyHeader
           }
         }

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/routes/StoragesRoutesSpec.scala
@@ -122,8 +122,7 @@ class StoragesRoutesSpec extends BaseRouteSpec with TryValues with StorageFixtur
       aclCheck.append(AclAddress.Root, Anonymous -> Set(events.read)).accepted
       val payload = s3FieldsJson deepMerge json"""{"@id": "$s3Id"}"""
       Post("/v1/storages/myorg/myproject", payload.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -159,8 +158,7 @@ class StoragesRoutesSpec extends BaseRouteSpec with TryValues with StorageFixtur
     "fail to update a storage without storages/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(permissions.write)).accepted
       Put(s"/v1/storages/myorg/myproject/s3-storage?rev=1", s3FieldsJson.toEntity) ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -198,8 +196,7 @@ class StoragesRoutesSpec extends BaseRouteSpec with TryValues with StorageFixtur
     "fail to deprecate a storage without storages/write permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(permissions.write)).accepted
       Delete("/v1/storages/myorg/myproject/s3-storage?rev=3") ~> routes ~> check {
-        response.status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 
@@ -245,8 +242,7 @@ class StoragesRoutesSpec extends BaseRouteSpec with TryValues with StorageFixtur
       forAll(endpoints) { endpoint =>
         forAll(List("", "?rev=1", "?tags=mytag")) { suffix =>
           Get(s"$endpoint$suffix") ~> routes ~> check {
-            response.status shouldEqual StatusCodes.Forbidden
-            response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+            response.shouldBeForbidden
           }
         }
       }
@@ -369,8 +365,7 @@ class StoragesRoutesSpec extends BaseRouteSpec with TryValues with StorageFixtur
     "fail to get storage statistics for an existing entry without resources/read permission" in {
       aclCheck.subtract(AclAddress.Root, Anonymous -> Set(permissions.read)).accepted
       Get("/v1/storages/myorg/myproject/remote-disk-storage/statistics") ~> routes ~> check {
-        status shouldEqual StatusCodes.Forbidden
-        response.asJson shouldEqual jsonContentOf("errors/authorization-failed.json")
+        response.shouldBeForbidden
       }
     }
 

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/marshalling/HttpResponseFields.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/marshalling/HttpResponseFields.scala
@@ -1,8 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.marshalling
 
 import akka.http.scaladsl.model.{HttpHeader, StatusCode, StatusCodes}
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError
-import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.{AuthorizationFailed, FetchContextFailed, IndexingFailed, ScopeInitializationFailed, UnknownSseLabel}
 
 /**
   * Typeclass definition for ''A''s from which the HttpHeaders and StatusCode can be ontained.
@@ -58,15 +56,6 @@ object HttpResponseFields {
     new HttpResponseFields[A] {
       override def statusFrom(value: A): StatusCode       = f(value)._1
       override def headersFrom(value: A): Seq[HttpHeader] = f(value)._2
-    }
-
-  implicit val responseFieldsServiceError: HttpResponseFields[ServiceError] =
-    HttpResponseFields {
-      case AuthorizationFailed          => StatusCodes.Forbidden
-      case FetchContextFailed(_)        => StatusCodes.InternalServerError
-      case ScopeInitializationFailed(_) => StatusCodes.InternalServerError
-      case IndexingFailed(_, _)         => StatusCodes.InternalServerError
-      case UnknownSseLabel(_)           => StatusCodes.InternalServerError
     }
 
   implicit val responseFieldsUnit: HttpResponseFields[Unit] =

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/marshalling/RdfExceptionHandler.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/marshalling/RdfExceptionHandler.scala
@@ -35,7 +35,7 @@ object RdfExceptionHandler {
       case err: IdentityError             => discardEntityAndForceEmit(err)
       case err: PermissionsRejection      => discardEntityAndForceEmit(err)
       case err: AuthTokenError            => discardEntityAndForceEmit(err)
-      case AuthorizationFailed            => discardEntityAndForceEmit(AuthorizationFailed: ServiceError)
+      case err: AuthorizationFailed       => discardEntityAndForceEmit(err: ServiceError)
       case err: RdfError                  => discardEntityAndForceEmit(err)
       case err: EntityStreamSizeException => discardEntityAndForceEmit(err)
       case err: Throwable                 =>

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/AuthDirectivesSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/AuthDirectivesSpec.scala
@@ -78,7 +78,7 @@ class AuthDirectivesSpec extends RouteHelpers with TestHelpers with Matchers wit
       }
     }
 
-  private val authExceptionHandler: ExceptionHandler = ExceptionHandler { case AuthorizationFailed =>
+  private val authExceptionHandler: ExceptionHandler = ExceptionHandler { case AuthorizationFailed(_) =>
     complete(StatusCodes.Forbidden)
   }
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/ServiceErrorSuite.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/error/ServiceErrorSuite.scala
@@ -1,0 +1,32 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.error
+
+import ch.epfl.bluebrain.nexus.testkit.CirceLiteral
+import ch.epfl.bluebrain.nexus.delta.sdk.syntax._
+import ch.epfl.bluebrain.nexus.testkit.mu.ce.CatsEffectSuite
+import ch.epfl.bluebrain.nexus.delta.sdk.error.ServiceError.AuthorizationFailed
+import ch.epfl.bluebrain.nexus.delta.sdk.model.BaseUri
+import ch.epfl.bluebrain.nexus.delta.sdk.utils.Fixtures
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.Label
+import ch.epfl.bluebrain.nexus.delta.kernel.effect.migration._
+
+class ServiceErrorSuite extends CatsEffectSuite with CirceLiteral with Fixtures {
+
+  implicit private val baseUri: BaseUri = BaseUri("http://localhost", Label.unsafe("v1"))
+
+  test("Serialize properly the `AuthorizationFailed`") {
+    val error: ServiceError = AuthorizationFailed("Some details")
+
+    val expected =
+      json"""
+        {
+          "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
+          "@type": "AuthorizationFailed",
+          "reason": "The supplied authentication is not authorized to access this resource.",
+          "details": "Some details"
+        }"""
+
+    error.toCompactedJsonLd.map(_.json).toCatsIO.assertEquals(expected)
+
+  }
+
+}

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/utils/RouteHelpers.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/utils/RouteHelpers.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.utils
 
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model.MediaTypes.`application/json`
-import akka.http.scaladsl.model.{HttpEntity, HttpResponse, RequestEntity}
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse, RequestEntity, StatusCodes}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
@@ -10,8 +10,10 @@ import akka.testkit.TestDuration
 import akka.util.ByteString
 import ch.epfl.bluebrain.nexus.testkit.scalatest.BaseSpec
 import io.circe.parser.parse
+import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Json, JsonObject, Printer}
-import org.scalatest.Suite
+import org.scalactic.source.Position
+import org.scalatest.{Assertion, Suite}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 
@@ -82,6 +84,12 @@ final class HttpResponseOps(private val http: HttpResponse) extends Consumer {
       case Left(err)    => fail(s"Error converting th json to '${A.runtimeClass.getName}'. Details: '${err.getMessage()}'")
       case Right(value) => value
     }
+
+  def shouldBeForbidden(implicit position: Position, materializer: Materializer): Assertion = {
+    http.status shouldEqual StatusCodes.Forbidden
+    asJsonObject(materializer)("@type") shouldEqual Some("AuthorizationFailed".asJson)
+  }
+
 }
 
 final class HttpChunksOps(private val chunks: Source[ChunkStreamPart, Any]) extends Consumer {

--- a/tests/src/test/resources/kg/archives/authorization-failed.json
+++ b/tests/src/test/resources/kg/archives/authorization-failed.json
@@ -1,5 +1,0 @@
-{
-  "@context": "https://bluebrain.github.io/nexus/contexts/error.json",
-  "@type": "AuthorizationFailed",
-  "reason": "The permission 'resources/read' required for accessing a resource at '/{{project}}' is missing."
-}

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/ExpectedResponse.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/ExpectedResponse.scala
@@ -1,6 +1,0 @@
-package ch.epfl.bluebrain.nexus.tests
-
-import akka.http.scaladsl.model.StatusCode
-import io.circe.Json
-
-final case class ExpectedResponse(statusCode: StatusCode, json: Json)

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ArchiveSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ArchiveSpec.scala
@@ -232,10 +232,7 @@ class ArchiveSpec extends BaseIntegrationSpec with ArchiveHelpers {
       )
 
     "fail when a resource in the archive cannot be fetched due to missing permissions" in {
-      deltaClient.get[Json](s"/archives/$fullId/test-resource:archive", Tweety, acceptAll) { (json, response) =>
-        json shouldEqual jsonContentOf("/kg/archives/authorization-failed.json", "project" -> fullId2)
-        response.status shouldEqual StatusCodes.Forbidden
-      }
+      deltaClient.get[Json](s"/archives/$fullId/test-resource:archive", Tweety, acceptAll) { expectForbidden }
     }
 
     "succeed getting archive using query param ignoreNotFound" in {

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ElasticSearchViewsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ElasticSearchViewsSpec.scala
@@ -437,10 +437,7 @@ class ElasticSearchViewsSpec extends BaseIntegrationSpec {
     }
 
     "fail to fetch mapping without permission" in {
-      deltaClient.get[Json](s"/views/$fullId/test-resource:cell-view/_mapping", Anonymous) { (json, response) =>
-        response.status shouldEqual StatusCodes.Forbidden
-        json shouldEqual jsonContentOf("/iam/errors/unauthorized-access.json")
-      }
+      deltaClient.get[Json](s"/views/$fullId/test-resource:cell-view/_mapping", Anonymous) { expectForbidden }
     }
 
     "fail to fetch mapping for view that doesn't exist" in {

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ErrorsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/ErrorsSpec.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.tests.kg
 
-import akka.http.scaladsl.model.StatusCodes
 import ch.epfl.bluebrain.nexus.tests.{BaseIntegrationSpec, Identity}
 import io.circe.Json
 
@@ -8,10 +7,7 @@ class ErrorsSpec extends BaseIntegrationSpec {
 
   "The /errors/invalid endpoint" should {
     s"return the proper error code" in {
-      deltaClient.get[Json]("/errors/invalid", Identity.Anonymous) { (json, response) =>
-        response.status shouldEqual StatusCodes.Forbidden
-        json shouldEqual jsonContentOf("/iam/errors/unauthorized-access.json")
-      }
+      deltaClient.get[Json]("/errors/invalid", Identity.Anonymous) { expectForbidden }
     }
   }
 

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/GraphAnalyticsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/GraphAnalyticsSpec.scala
@@ -85,10 +85,7 @@ final class GraphAnalyticsSpec extends BaseIntegrationSpec {
     }
 
     "fail to query when unauthorized" in {
-      deltaClient.post[Json](s"/graph-analytics/$ref/_search", matchPerson1, Anonymous) { (json, response) =>
-        response.status shouldEqual StatusCodes.Forbidden
-        json shouldEqual jsonContentOf("/iam/errors/unauthorized-access.json")
-      }
+      deltaClient.post[Json](s"/graph-analytics/$ref/_search", matchPerson1, Anonymous) { expectForbidden }
     }
 
     "query for person1" in eventually {

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/IdResolutionSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/IdResolutionSpec.scala
@@ -44,9 +44,6 @@ class IdResolutionSpec extends BaseIntegrationSpec {
   private val neurosciencegraphId        = s"$proxyIdBase/$neurosciencegraphSegment"
   private val encodedNeurosciencegraphId = UrlUtils.encode(neurosciencegraphId)
 
-  private val unauthorizedAccessErrorPayload =
-    jsonContentOf("iam/errors/unauthorized-access.json")
-
   override def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -69,17 +66,11 @@ class IdResolutionSpec extends BaseIntegrationSpec {
   "Id resolution" should {
 
     "lead to an authorization failure for a user without permission" in {
-      deltaClient.get[Json](s"/resolve/$encodedUniqueId", Alice) { (json, response) =>
-        response.status shouldEqual StatusCodes.Forbidden
-        json shouldEqual unauthorizedAccessErrorPayload
-      }
+      deltaClient.get[Json](s"/resolve/$encodedUniqueId", Alice) { expectForbidden }
     }
 
     "lead to an authorization failure when trying to resolve a resource that does not exist" in {
-      deltaClient.get[Json](s"/resolve/unknownId", Bob) { (json, response) =>
-        response.status shouldEqual StatusCodes.Forbidden
-        json shouldEqual unauthorizedAccessErrorPayload
-      }
+      deltaClient.get[Json](s"/resolve/unknownId", Bob) { expectForbidden }
     }
 
     "resolve a single resource" in {


### PR DESCRIPTION
Fixes #4384 

* Only one `AuthenticationFailed` remains
* Route tests now only check the error code and the type of the error with the same method
* The serialization of `AuthenticationFailed` is tested separately