### PR TITLE
Publish Nexus Storage Service as a fat jar

### DIFF
--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -45,7 +45,8 @@ jobs:
           echo ${{ secrets.DOCKER_PASS }} | docker login --username ${{ secrets.DOCKER_USER }} --password-stdin
           sbt -Dsbt.color=always -Dsbt.supershell=false \
             app/Docker/publish \
-            storage/Docker/publish
+            storage/Docker/publish \
+            storage/Universal/publish
       - name: Publish to Github Packages
         run: |
           sbt -Dsbt.color=always -Dsbt.supershell=false publish

--- a/build.sbt
+++ b/build.sbt
@@ -891,12 +891,13 @@ lazy val storageFatJar = Seq(
       case (_, name)                                  => !name.endsWith(".jar")
     }
     filteredMappings :+ (fatJar -> ("lib/" + fatJar.getName))
-  }
+  },
+  scriptClasspath      := Seq((assembly / assemblyJarName).value)
 )
 
 lazy val storageAssemblySettings = Seq(
+  assembly / assemblyJarName       := "nexus-storage.jar",
   assembly / test                  := {},
-  assembly / assemblyOutputPath    := baseDirectory.value / "nexus-storage.jar",
   assembly / assemblyMergeStrategy := {
     case PathList("org", "apache", "commons", "logging", xs @ _*)        => MergeStrategy.last
     case PathList("org", "apache", "commons", "codec", xs @ _*)          => MergeStrategy.last


### PR DESCRIPTION
* The Nexus Storage Service can be published locally as a fat jar by running `sbt storage/Universal/publishLocal`. The content of the archive contains the Nexus Storage Service as a far jar, the nexus-fixer, and the kanela agent. This should be all that is required to run the service (provided a JVM).
* The ci-snapshot pipeline is update to publish the snapshot version of the Storage Service. TBD whether we need this or not.
* The `ci-release` _should_ publish the universal package (with the fat jar) upon a release; this needs to be confirmed when the next release is made.