### PR TITLE
Configure docker compose to run Delta in clustered node

### DIFF
--- a/tests/docker/.env
+++ b/tests/docker/.env
@@ -1,0 +1,4 @@
+CLUSTER_SIZE=1
+DELTA_PLUGINS=/opt/docker/plugins/
+DELTA_EXTERNAL_CONF=/config/delta-postgres.conf
+KAMON_ENABLED=false

--- a/tests/docker/.env.cluster
+++ b/tests/docker/.env.cluster
@@ -1,0 +1,4 @@
+CLUSTER_SIZE=3
+DELTA_PLUGINS=/opt/docker/plugins/
+DELTA_EXTERNAL_CONF=/config/delta-postgres.conf
+KAMON_ENABLED=false

--- a/tests/docker/config/delta-postgres.conf
+++ b/tests/docker/config/delta-postgres.conf
@@ -5,14 +5,20 @@ app {
   }
 
   database {
+    tables-autocreate = true
+
+    cache {
+      expire-after = 1s
+    }
+
     read = ${app.defaults.database.access} {
-      pool-size = 15
+      pool-size = 10
     }
     write = ${app.defaults.database.access} {
-      pool-size = 15
+      pool-size = 10
     }
     streaming = ${app.defaults.database.access} {
-      pool-size = 50
+      pool-size = 10
     }
   }
 
@@ -25,14 +31,6 @@ app {
 
     query {
       refresh-strategy = 1s
-    }
-  }
-
-  database {
-    tables-autocreate = true
-
-    cache {
-      expire-after = 1s
     }
   }
 

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -15,53 +15,65 @@ services:
       minio:
         condition: service_started
     environment:
-      DELTA_PLUGINS: "/opt/docker/plugins/"
-      DELTA_EXTERNAL_CONF: "/config/delta-postgres.conf"
-      KAMON_ENABLED: "false"
+      - DELTA_PLUGINS
+      - DELTA_EXTERNAL_CONF
+      - KAMON_ENABLED
     image: bluebrain/nexus-delta:latest
     entrypoint:
       - '/bin/bash'
       - '-c'
       - |
         ln -sf /opt/docker/plugins/disabled/project-deletion.jar /opt/docker/plugins/project-deletion.jar &&
-        /opt/docker/bin/delta-app -Xmx4G
+        /opt/docker/bin/delta-app -Xmx4G -Dapp.projections.cluster.size=${CLUSTER_SIZE}
     ports:
       - 8080:8080
     volumes:
       - ./config:/config
       - /tmp:/default-volume
 
-#  delta2:
-#    depends_on:
-#      - delta
-#    environment:
-#      DELTA_PLUGINS: "/opt/docker/plugins/"
-#      DELTA_EXTERNAL_CONF: "/config/delta-postgres.conf"
-#      KAMON_ENABLED: "false"
-#    image: bluebrain/nexus-delta:latest
-#    entrypoint: ["bin/wait-for-it.sh", "-s", "-t", "0", "delta:8080", "--", "./bin/delta-app",
-#                 "-Xmx4G" ]
-#    ports:
-#      - 8081:8080
-#    volumes:
-#      - ./config:/config
-#      - /tmp:/default-volume
-#
-#  delta3:
-#    depends_on:
-#      - delta2
-#    environment:
-#      DELTA_PLUGINS: "/opt/docker/plugins/"
-#      DELTA_EXTERNAL_CONF: "/config/delta-postgres.conf"
-#      KAMON_ENABLED: "false"
-#    image: bluebrain/nexus-delta:latest
-#    entrypoint: ["bin/wait-for-it.sh", "-s", "-t", "0", "delta2:8080", "--", "./bin/delta-app",
-#                 "-Xmx4G" ]
-#    ports:
-#      - 8082:8080
-#    volumes:
-#      - ./config:/config
-#      - /tmp:/default-volume
+  delta2:
+    depends_on:
+      - delta
+    environment:
+      DELTA_PLUGINS: "/opt/docker/plugins/"
+      DELTA_EXTERNAL_CONF: "/config/delta-postgres.conf"
+      KAMON_ENABLED: "false"
+    image: bluebrain/nexus-delta:latest
+    profiles:
+      - "cluster"
+    entrypoint:
+      - '/bin/bash'
+      - '-c'
+      - |
+        ln -sf /opt/docker/plugins/disabled/project-deletion.jar /opt/docker/plugins/project-deletion.jar &&
+        /opt/docker/bin/delta-app -Xmx4G -Dapp.projections.cluster.size=${CLUSTER_SIZE} -Dapp.projections.cluster.node-index=1 -Dapp.database.tables-autocreate=false
+    ports:
+      - 8081:8080
+    volumes:
+      - ./config:/config
+      - /tmp:/default-volume
+
+  delta3:
+    depends_on:
+      - delta2
+    environment:
+      DELTA_PLUGINS: "/opt/docker/plugins/"
+      DELTA_EXTERNAL_CONF: "/config/delta-postgres.conf"
+      KAMON_ENABLED: "false"
+    image: bluebrain/nexus-delta:latest
+    profiles:
+      - "cluster"
+    entrypoint:
+      - '/bin/bash'
+      - '-c'
+      - |
+        ln -sf /opt/docker/plugins/disabled/project-deletion.jar /opt/docker/plugins/project-deletion.jar &&
+        /opt/docker/bin/delta-app -Xmx4G -Dapp.projections.cluster.size=${CLUSTER_SIZE} -Dapp.projections.cluster.node-index=2 -Dapp.database.tables-autocreate=false
+    ports:
+      - 8082:8080
+    volumes:
+      - ./config:/config
+      - /tmp:/default-volume
 
   keycloak:
     image: quay.io/keycloak/keycloak:22.0.5


### PR DESCRIPTION
Using env files and profiles from docker compose to run Delta in standalone or clustered nodes

The docker command looks like this:
```
# Standalone
docker compose -f tests/docker/docker-compose.yml up -d

# Clustered mode
docker compose -f tests/docker/docker-compose.yml --env-file tests/docker/.env.cluster --profile cluster up -d
```