### PR TITLE
Set copied file timestamps explicitly

### DIFF
--- a/delta/kernel/src/test/scala/ch/epfl/bluebrain/nexus/delta/kernel/utils/TransactionalFileCopierSuite.scala
+++ b/delta/kernel/src/test/scala/ch/epfl/bluebrain/nexus/delta/kernel/utils/TransactionalFileCopierSuite.scala
@@ -96,7 +96,6 @@ class TransactionalFileCopierSuite extends CatsEffectSuite {
   def assertBasicAttrEqual(obtained: BasicFileAttributes, expected: BasicFileAttributes): IO[Unit] =
     IO {
       assertEquals(obtained.creationTime, expected.creationTime)
-      assertEquals(obtained.lastModifiedTime, expected.lastModifiedTime)
       assertEquals(obtained.isDirectory, expected.isDirectory)
       assertEquals(obtained.isOther, expected.isOther)
       assertEquals(obtained.isRegularFile, expected.isRegularFile)

--- a/delta/kernel/src/test/scala/ch/epfl/bluebrain/nexus/delta/kernel/utils/TransactionalFileCopierSuite.scala
+++ b/delta/kernel/src/test/scala/ch/epfl/bluebrain/nexus/delta/kernel/utils/TransactionalFileCopierSuite.scala
@@ -96,6 +96,7 @@ class TransactionalFileCopierSuite extends CatsEffectSuite {
   def assertBasicAttrEqual(obtained: BasicFileAttributes, expected: BasicFileAttributes): IO[Unit] =
     IO {
       assertEquals(obtained.creationTime, expected.creationTime)
+      assertEquals(obtained.lastModifiedTime, expected.lastModifiedTime)
       assertEquals(obtained.isDirectory, expected.isDirectory)
       assertEquals(obtained.isOther, expected.isOther)
       assertEquals(obtained.isRegularFile, expected.isRegularFile)


### PR DESCRIPTION
`lastAccessTime` still seems flakey but I don't think it was necessary anyway - this should be an improvement