### PR TITLE
Use GitHub cloud runners for more workflows

### DIFF
--- a/.github/workflows/ci-delta-app.yml
+++ b/.github/workflows/ci-delta-app.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run:
     if: github.event_name == 'pull_request'
-    runs-on: it
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-delta-core.yml
+++ b/.github/workflows/ci-delta-core.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   run:
     if: github.event_name == 'pull_request'
-    runs-on: it
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-delta-ship.yml
+++ b/.github/workflows/ci-delta-ship.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run:
     if: github.event_name == 'pull_request'
-    runs-on: it
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/MainSuite.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/MainSuite.scala
@@ -18,6 +18,7 @@ import munit.catseffect.IOFixture
 import munit.{AnyFixture, CatsEffectSuite}
 
 import java.nio.file.{Files, Paths}
+import scala.concurrent.duration.Duration
 
 /**
   * Test class that allows to check that across core and plugins:
@@ -26,6 +27,9 @@ import java.nio.file.{Files, Paths}
   *   - Distage wiring is valid
   */
 class MainSuite extends NexusSuite with MainSuite.Fixture {
+
+  // The default timeout of 30s is slightly too short for the GitHub free runners
+  override val munitIOTimeout: Duration = Duration(60, "s")
 
   private val pluginsParentPath  = Paths.get("target/plugins").toAbsolutePath
   private val pluginLoaderConfig = PluginLoaderConfig(pluginsParentPath.toString)


### PR DESCRIPTION
The workflows that are moved from self-hosted to the basic cloud runners now run faster; this frees up the self-hosted runners for integration tests.

The plugin workflow is almost ready to run on the cloud runners as well, only #4790 needs to be dealt with first.