### PR TITLE
Fix hostname validation on remote sources for composite views

### DIFF
--- a/delta/plugins/composite-views/src/main/resources/composite-views.conf
+++ b/delta/plugins/composite-views/src/main/resources/composite-views.conf
@@ -27,7 +27,6 @@ plugins.composite-views {
   pagination = ${app.defaults.pagination}
   # the HTTP client configuration for a remote source
   remote-source-client {
-    http = ${app.defaults.http-client-compression}
     retry-delay = 1 minute
     # the maximum batching size, corresponding to the maximum number of Blazegraph documents uploaded on a bulk request.
     # in this window, duplicated persistence ids are discarded

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsPluginModule.scala
@@ -25,7 +25,7 @@ import ch.epfl.bluebrain.nexus.delta.sdk.auth.AuthTokenProvider
 import ch.epfl.bluebrain.nexus.delta.sdk.deletion.ProjectDeletionTask
 import ch.epfl.bluebrain.nexus.delta.sdk.directives.DeltaSchemeDirectives
 import ch.epfl.bluebrain.nexus.delta.sdk.fusion.FusionConfig
-import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClient
+import ch.epfl.bluebrain.nexus.delta.sdk.http.{HttpClient, HttpClientConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.identities.Identities
 import ch.epfl.bluebrain.nexus.delta.sdk.model._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.metrics.ScopedEventMetricEncoder
@@ -53,7 +53,8 @@ class CompositeViewsPluginModule(priority: Int) extends ModuleDef {
         as: ActorSystem[Nothing],
         authTokenProvider: AuthTokenProvider
     ) =>
-      val httpClient = HttpClient()(cfg.remoteSourceClient.http, as.classicSystem)
+      val httpConfig = HttpClientConfig.noRetry(true)
+      val httpClient = HttpClient()(httpConfig, as.classicSystem)
       DeltaClient(httpClient, authTokenProvider, cfg.remoteSourceCredentials, cfg.remoteSourceClient.retryDelay)(
         as
       )

--- a/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
+++ b/delta/plugins/composite-views/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/config/CompositeViewsConfig.scala
@@ -6,7 +6,6 @@ import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.config.BlazegraphViewsCo
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.SinkConfig.SinkConfig
 import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.config.CompositeViewsConfig.{BlazegraphAccess, RemoteSourceClientConfig, SourcesConfig}
 import ch.epfl.bluebrain.nexus.delta.sdk.auth
-import ch.epfl.bluebrain.nexus.delta.sdk.http.HttpClientConfig
 import ch.epfl.bluebrain.nexus.delta.sdk.instances._
 import ch.epfl.bluebrain.nexus.delta.sdk.model.search.PaginationConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.{BatchConfig, EventLogConfig}
@@ -96,8 +95,6 @@ object CompositeViewsConfig {
 
   /**
     * Remote source client configuration
-    * @param http
-    *   http client configuration
     * @param retryDelay
     *   SSE client retry delay
     * @param maxBatchSize
@@ -107,7 +104,6 @@ object CompositeViewsConfig {
     *   the maximum batching duration. In this window, duplicated persistence ids are discarded
     */
   final case class RemoteSourceClientConfig(
-      http: HttpClientConfig,
       retryDelay: FiniteDuration,
       maxBatchSize: Int,
       maxTimeWindow: FiniteDuration

--- a/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
+++ b/delta/plugins/composite-views/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/compositeviews/CompositeViewsFixture.scala
@@ -168,7 +168,7 @@ trait CompositeViewsFixture extends ConfigFixtures {
     3,
     eventLogConfig,
     pagination,
-    RemoteSourceClientConfig(httpClientConfig, 1.second, 1, 500.milliseconds),
+    RemoteSourceClientConfig(1.second, 1, 500.milliseconds),
     1.minute,
     batchConfig,
     batchConfig,


### PR DESCRIPTION
Also removing the retry strategy for the http client for composite views as it only brings more problems in the end