### PR TITLE
Remove ship dependency on acls

### DIFF
--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/ContextWiring.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/ContextWiring.scala
@@ -2,21 +2,19 @@ package ch.epfl.bluebrain.nexus.ship
 
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.ClasspathResourceLoader
+import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.{contexts => bgContexts}
+import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.{contexts => compositeViewContexts}
+import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts => esContexts}
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.contexts
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.{ContextValue, RemoteContextResolution}
-import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContext
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.ResolverContextResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.resources.FetchResource
 import ch.epfl.bluebrain.nexus.delta.sourcing.Transactors
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.EventLogConfig
-import ch.epfl.bluebrain.nexus.ship.acls.AclWiring
+import ch.epfl.bluebrain.nexus.ship.acls.AclWiring.alwaysAuthorize
 import ch.epfl.bluebrain.nexus.ship.resolvers.ResolverWiring
-
-import ch.epfl.bluebrain.nexus.delta.plugins.elasticsearch.model.{contexts => esContexts}
-import ch.epfl.bluebrain.nexus.delta.plugins.blazegraph.model.{contexts => bgContexts}
-import ch.epfl.bluebrain.nexus.delta.plugins.compositeviews.model.{contexts => compositeViewContexts}
 
 object ContextWiring {
 
@@ -53,12 +51,11 @@ object ContextWiring {
       clock: EventClock,
       xas: Transactors
   )(implicit jsonLdApi: JsonLdApi): IO[ResolverContextResolution] = {
-    val aclCheck  = AclCheck(AclWiring.acls(config, clock, xas))
     val resolvers = ResolverWiring.resolvers(fetchContext, config, clock, xas)
 
     for {
       rcr <- remoteContextResolution
-    } yield ResolverContextResolution(aclCheck, resolvers, rcr, fetchResource)
+    } yield ResolverContextResolution(alwaysAuthorize, resolvers, rcr, fetchResource)
   }
 
 }

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/ResourceWiring.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/ResourceWiring.scala
@@ -12,6 +12,7 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.config.EventLogConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.{ScopedEventLog, Transactors}
 import ch.epfl.bluebrain.nexus.ship.EventClock
 import ch.epfl.bluebrain.nexus.ship.acls.AclWiring
+import ch.epfl.bluebrain.nexus.ship.acls.AclWiring.alwaysAuthorize
 import ch.epfl.bluebrain.nexus.ship.resolvers.ResolverWiring
 
 object ResourceWiring {
@@ -27,10 +28,9 @@ object ResourceWiring {
   ): (ResourceLog, FetchResource) = {
     val rcr                = RemoteContextResolution.never // TODO: Use correct RemoteContextResolution
     val detectChange       = DetectChange(false)
-    val aclCheck           = AclCheck(AclWiring.acls(config, clock, xas))
     val resolvers          = ResolverWiring.resolvers(fetchContext, config, clock, xas)
     val resourceResolution =
-      ResourceResolution.schemaResource(aclCheck, resolvers, fetchSchema, excludeDeprecated = false)
+      ResourceResolution.schemaResource(alwaysAuthorize, resolvers, fetchSchema, excludeDeprecated = false)
     val validate           = ValidateResource(resourceResolution)(rcr)
     val resourceDef        = Resources.definition(validate, detectChange, clock)
 

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/ResourceWiring.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/ResourceWiring.scala
@@ -2,7 +2,6 @@ package ch.epfl.bluebrain.nexus.ship.resources
 
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
-import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContext
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.ResourceResolution
 import ch.epfl.bluebrain.nexus.delta.sdk.resources.Resources.ResourceLog
@@ -11,7 +10,6 @@ import ch.epfl.bluebrain.nexus.delta.sdk.schemas.FetchSchema
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.EventLogConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.{ScopedEventLog, Transactors}
 import ch.epfl.bluebrain.nexus.ship.EventClock
-import ch.epfl.bluebrain.nexus.ship.acls.AclWiring
 import ch.epfl.bluebrain.nexus.ship.acls.AclWiring.alwaysAuthorize
 import ch.epfl.bluebrain.nexus.ship.resolvers.ResolverWiring
 

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/schemas/SchemaWiring.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/schemas/SchemaWiring.scala
@@ -3,14 +3,13 @@ package ch.epfl.bluebrain.nexus.ship.schemas
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.api.JsonLdApi
 import ch.epfl.bluebrain.nexus.delta.rdf.shacl.ShaclShapesGraph
-import ch.epfl.bluebrain.nexus.delta.sdk.acls.AclCheck
 import ch.epfl.bluebrain.nexus.delta.sdk.projects.FetchContext
 import ch.epfl.bluebrain.nexus.delta.sdk.resources.FetchResource
 import ch.epfl.bluebrain.nexus.delta.sdk.schemas.Schemas.SchemaLog
 import ch.epfl.bluebrain.nexus.delta.sdk.schemas.{FetchSchema, SchemaImports, Schemas, ValidateSchema}
 import ch.epfl.bluebrain.nexus.delta.sourcing.config.EventLogConfig
 import ch.epfl.bluebrain.nexus.delta.sourcing.{ScopedEventLog, Transactors}
-import ch.epfl.bluebrain.nexus.ship.acls.AclWiring
+import ch.epfl.bluebrain.nexus.ship.acls.AclWiring.alwaysAuthorize
 import ch.epfl.bluebrain.nexus.ship.resolvers.ResolverWiring
 import ch.epfl.bluebrain.nexus.ship.{ContextWiring, EventClock}
 
@@ -31,9 +30,8 @@ object SchemaWiring {
   )(implicit
       jsonLdApi: JsonLdApi
   ): SchemaImports = {
-    val aclCheck  = AclCheck(AclWiring.acls(config, clock, xas))
     val resolvers = ResolverWiring.resolvers(fetchContext, config, clock, xas)
-    SchemaImports(aclCheck, resolvers, fetchSchema, fetchResource)
+    SchemaImports(alwaysAuthorize, resolvers, fetchSchema, fetchResource)
   }
 
   private def validateSchema(implicit api: JsonLdApi): IO[ValidateSchema] =


### PR DESCRIPTION
Adds an `AclCheck` implementation that always authorizes without needing `acls` around