### PR TITLE
Fix resource wiring in ship

### DIFF
--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/RunShip.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/RunShip.scala
@@ -58,7 +58,7 @@ class RunShip {
                     projectProcessor            <- ProjectProcessor(fetchActiveOrg, projectMapper, eventLogConfig, eventClock, xas)(baseUri)
                     resolverProcessor            = ResolverProcessor(fetchContext, projectMapper, eventLogConfig, eventClock, xas)
                     schemaProcessor              = SchemaProcessor(schemaLog, fetchContext, schemaImports, rcr, projectMapper, eventClock)
-                    resourceProcessor            = ResourceProcessor(resourceLog, projectMapper, fetchContext, eventClock)
+                    resourceProcessor            = ResourceProcessor(resourceLog, rcr, projectMapper, fetchContext, eventClock)
                     esViewsProcessor            <- ElasticSearchViewProcessor(fetchContext, rcr, projectMapper, eventLogConfig, eventClock, xas)
                     bgViewsProcessor             = BlazegraphViewProcessor(fetchContext, rcr, projectMapper, eventLogConfig, eventClock, xas)
                     compositeViewsProcessor      = CompositeViewProcessor(fetchContext, rcr, projectMapper, eventLogConfig, eventClock, xas)

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/ResourceProcessor.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/ResourceProcessor.scala
@@ -77,11 +77,11 @@ object ResourceProcessor {
 
   def apply(
       log: ResourceLog,
+      rcr: ResolverContextResolution,
       projectMapper: ProjectMapper,
       fetchContext: FetchContext,
       clock: EventClock
   )(implicit jsonLdApi: JsonLdApi): ResourceProcessor = {
-    val rcr       = ResolverContextResolution.never // TODO: Pass correct ResolverContextResolution
     val resources = ResourcesImpl(log, fetchContext, rcr)
     new ResourceProcessor(resources, projectMapper, clock)
   }


### PR DESCRIPTION
The proper `ResolverContextResolution` needs to be passed to `Resources` in order for its internal source parser to work correctly