### PR TITLE
Fix external doc link validation workflow

### DIFF
--- a/.github/workflows/ci-docs-ext-links.yml
+++ b/.github/workflows/ci-docs-ext-links.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -16,7 +18,5 @@ jobs:
           java-version: '21'
           cache: 'sbt'
           check-latest: true
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Review
         run: sbt "project docs" clean scalafmtCheck scalafmtSbtCheck paradox paradoxValidateLinks


### PR DESCRIPTION
The JDK steps needs to be run only after the checkout if caching is enabled.