### PR TITLE
Improve message for 'ResourceShaclEngineRejection'

### DIFF
--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/resources/ValidateResource.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/resources/ValidateResource.scala
@@ -84,7 +84,7 @@ object ValidateResource {
           schema.value.shapes,
           reportDetails = true
         ).adaptError { e =>
-          ResourceShaclEngineRejection(jsonld.id, schemaRef, e.getMessage)
+          ResourceShaclEngineRejection(jsonld.id, schemaRef, e)
         }.span("validateShacl")
 
       private def assertNotDeprecated(schema: ResourceF[Schema]) = {


### PR DESCRIPTION
Fixes #4830 

In the end, the problem was not related to a resource not found but to a static remote context (the shacl one provided by Nexus) required to generate the compacted representation of the validation report.
In the end, the problem happened because the import batch did not inject this static context so this PR is:
- Enriching the error message to make it clearer
- Giving it a 5xx status as it is a problem of the application