### PR TITLE
Reduce library S3 client usage

### DIFF
--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/S3StorageClient.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/S3StorageClient.scala
@@ -22,7 +22,7 @@ trait S3StorageClient {
   def listObjectsV2(bucket: BucketName, prefix: String): IO[ListObjectsV2Response]
 
   final def readFile(bucket: String, fileKey: String): Stream[IO, Byte] =
-    (parseBucket[StreamIO](bucket), parseFileKey[StreamIO](fileKey)).flatMapN(readFile)
+    (Stream.eval(parseBucket(bucket)), Stream.eval(parseFileKey(fileKey))).flatMapN(readFile)
 
   def readFile(bucket: BucketName, fileKey: FileKey): Stream[IO, Byte]
 

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/package.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/package.scala
@@ -1,0 +1,22 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3
+
+import cats.MonadThrow
+import cats.effect.IO
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.refineV
+import cats.syntax.all._
+import fs2.Stream
+import fs2.aws.s3.models.Models.{BucketName, FileKey}
+
+package object client {
+
+  type StreamIO[A] = Stream[IO, A]
+
+  def parseNonEmptyString[F[_]: MonadThrow](s: String): F[String Refined NonEmpty] =
+    MonadThrow[F].fromEither(refineV[NonEmpty](s).leftMap(e => new IllegalArgumentException(e)))
+
+  def parseBucket[F[_]: MonadThrow](bucket: String): F[BucketName] = parseNonEmptyString(bucket).map(BucketName)
+
+  def parseFileKey[F[_]: MonadThrow](fileKey: String): F[FileKey] = parseNonEmptyString(fileKey).map(FileKey)
+}

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/package.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/package.scala
@@ -1,22 +1,12 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3
 
-import cats.MonadThrow
 import cats.effect.IO
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.NonEmpty
-import eu.timepit.refined.refineV
-import cats.syntax.all._
-import fs2.Stream
+import eu.timepit.refined.types.string.NonEmptyString
 import fs2.aws.s3.models.Models.{BucketName, FileKey}
 
 package object client {
 
-  type StreamIO[A] = Stream[IO, A]
+  def parseBucket(bucket: String): IO[BucketName] = IO(BucketName(NonEmptyString.unsafeFrom(bucket)))
 
-  def parseNonEmptyString[F[_]: MonadThrow](s: String): F[String Refined NonEmpty] =
-    MonadThrow[F].fromEither(refineV[NonEmpty](s).leftMap(e => new IllegalArgumentException(e)))
-
-  def parseBucket[F[_]: MonadThrow](bucket: String): F[BucketName] = parseNonEmptyString(bucket).map(BucketName)
-
-  def parseFileKey[F[_]: MonadThrow](fileKey: String): F[FileKey] = parseNonEmptyString(fileKey).map(FileKey)
+  def parseFileKey(fileKey: String): IO[FileKey] = IO(FileKey(NonEmptyString.unsafeFrom(fileKey)))
 }

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3Helpers.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3Helpers.scala
@@ -1,4 +1,4 @@
-package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations
+package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3
 
 import cats.effect.IO
 import cats.syntax.all._

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageAccessSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageAccessSpec.scala
@@ -3,11 +3,12 @@ package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.StorageFixtures
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageRejection.StorageNotAccessible
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.S3Helpers
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
 import ch.epfl.bluebrain.nexus.delta.sdk.actor.ActorSystemSetup
 import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite
+import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
 import munit.AnyFixture
-import software.amazon.awssdk.services.s3.model.{CreateBucketRequest, DeleteBucketRequest}
 
 import scala.concurrent.duration.{Duration, DurationInt}
 
@@ -15,14 +16,15 @@ class S3StorageAccessSpec
     extends NexusSuite
     with StorageFixtures
     with LocalStackS3StorageClient.Fixture
-    with ActorSystemSetup.Fixture {
+    with ActorSystemSetup.Fixture
+    with S3Helpers {
 
   override def munitIOTimeout: Duration = 60.seconds
 
   override def munitFixtures: Seq[AnyFixture[_]] = List(localStackS3Client)
 
-  private lazy val (s3Client: S3StorageClient, _) = localStackS3Client()
-  private lazy val s3Access                       = new S3StorageAccess(s3Client)
+  implicit private lazy val (s3Client: S3StorageClient, underlying: S3AsyncClientOp[IO], _) = localStackS3Client()
+  private lazy val s3Access                                                                 = new S3StorageAccess(s3Client)
 
   test("List objects in an existing bucket") {
     givenAnS3Bucket { bucket =>
@@ -32,12 +34,5 @@ class S3StorageAccessSpec
 
   test("Fail to list objects when bucket doesn't exist") {
     s3Access.apply(genString()).intercept[StorageNotAccessible]
-  }
-
-  def givenAnS3Bucket(test: String => IO[Unit]): IO[Unit] = {
-    val bucket = genString()
-    s3Client.underlyingClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build) >>
-      test(bucket) >>
-      s3Client.underlyingClient.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build).void
   }
 }

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageAccessSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageAccessSpec.scala
@@ -3,7 +3,6 @@ package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3
 import cats.effect.IO
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.StorageFixtures
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageRejection.StorageNotAccessible
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.S3Helpers
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
 import ch.epfl.bluebrain.nexus.delta.sdk.actor.ActorSystemSetup
 import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageFetchSaveSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageFetchSaveSpec.scala
@@ -9,7 +9,7 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.DigestAlgori
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.Storage.S3Storage
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageValue.S3StorageValue
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.{AkkaSourceHelpers, S3Helpers}
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.AkkaSourceHelpers
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.permissions.{read, write}
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.actor.ActorSystemSetup

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageFetchSaveSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageFetchSaveSpec.scala
@@ -3,33 +3,32 @@ package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpEntity
 import cats.effect.IO
-import cats.syntax.all._
 import ch.epfl.bluebrain.nexus.delta.kernel.utils.UUIDF
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.StorageFixtures
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.DigestAlgorithm
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.Storage.S3Storage
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageValue.S3StorageValue
-import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.AkkaSourceHelpers
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.{AkkaSourceHelpers, S3Helpers}
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.permissions.{read, write}
 import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.actor.ActorSystemSetup
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
 import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite
 import io.circe.Json
+import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
 import munit.AnyFixture
-import software.amazon.awssdk.services.s3.model.{CreateBucketRequest, DeleteBucketRequest, DeleteObjectRequest}
 
 import java.util.UUID
 import scala.concurrent.duration.{Duration, DurationInt}
-import scala.jdk.CollectionConverters.ListHasAsScala
 
 class S3StorageFetchSaveSpec
     extends NexusSuite
     with StorageFixtures
     with ActorSystemSetup.Fixture
     with LocalStackS3StorageClient.Fixture
-    with AkkaSourceHelpers {
+    with AkkaSourceHelpers
+    with S3Helpers {
 
   override def munitIOTimeout: Duration = 120.seconds
 
@@ -38,8 +37,9 @@ class S3StorageFetchSaveSpec
   private val uuid                  = UUID.fromString("8049ba90-7cc6-4de5-93a1-802c04200dcc")
   implicit private val uuidf: UUIDF = UUIDF.fixed(uuid)
 
-  private lazy val (s3StorageClient: S3StorageClient, _) = localStackS3Client()
-  implicit private lazy val as: ActorSystem              = actorSystem()
+  implicit private lazy val (s3StorageClient: S3StorageClient, underlying: S3AsyncClientOp[IO], _) =
+    localStackS3Client()
+  implicit private lazy val as: ActorSystem                                                        = actorSystem()
 
   test("Save and fetch an object in a bucket") {
     givenAnS3Bucket { bucket =>
@@ -69,24 +69,4 @@ class S3StorageFetchSaveSpec
       assertIO(result, content)
     }
   }
-
-  def givenAnS3Bucket(test: String => IO[Unit]): IO[Unit] = {
-    val bucket = genString()
-    s3StorageClient.underlyingClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build) >>
-      test(bucket) >>
-      emptyBucket(bucket) >>
-      s3StorageClient.underlyingClient.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build).void
-  }
-
-  def emptyBucket(bucket: String): IO[Unit] =
-    s3StorageClient
-      .listObjectsV2(bucket)
-      .flatMap { resp =>
-        val keys: List[String] = resp.contents.asScala.map(_.key()).toList
-        keys.traverse(deleteObject(bucket, _))
-      }
-      .void
-
-  def deleteObject(bucket: String, key: String): IO[Unit] =
-    s3StorageClient.underlyingClient.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build()).void
 }

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/package.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/package.scala
@@ -1,0 +1,36 @@
+package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations
+
+import cats.effect.IO
+import cats.syntax.all._
+import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
+import ch.epfl.bluebrain.nexus.testkit.Generators
+import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
+import software.amazon.awssdk.services.s3.model.{CreateBucketRequest, DeleteBucketRequest, DeleteObjectRequest}
+
+import scala.jdk.CollectionConverters.ListHasAsScala
+
+trait S3Helpers { self: Generators =>
+
+  def givenAnS3Bucket(
+      test: String => IO[Unit]
+  )(implicit client: S3StorageClient, fs2Client: S3AsyncClientOp[IO]): IO[Unit] = {
+    val bucket = genString()
+    fs2Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build) >>
+      test(bucket) >>
+      emptyBucket(bucket) >>
+      fs2Client.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build).void
+  }
+
+  def emptyBucket(bucket: String)(implicit client: S3StorageClient, fs2Client: S3AsyncClientOp[IO]): IO[Unit] =
+    client
+      .listObjectsV2(bucket)
+      .flatMap { resp =>
+        val keys: List[String] = resp.contents.asScala.map(_.key()).toList
+        keys.traverse(deleteObject(bucket, _))
+      }
+      .void
+
+  def deleteObject(bucket: String, key: String)(implicit client: S3AsyncClientOp[IO]): IO[Unit] =
+    client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build()).void
+
+}


### PR DESCRIPTION
Small changes to get closer to abstracting all S3 interactions behind our own client (I don't want to conflict too much with @shinyhappydan ). Most usages of the exposed client were in tests - easy enough to pass that client out of the localstack setup