### PR TITLE
Add endpoint to update previously registered S3 files

### DIFF
--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutes.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutes.scala
@@ -290,6 +290,32 @@ final class FilesRoutes(
                     }
                   }
                 }
+              },
+              pathPrefix("register-update") {
+                (idSegment & indexingMode) { (id, mode) =>
+                  pathEndOrSingleSlash {
+                    operationName(s"$prefixSegment/files/{org}/{project}/register-update/{id}") {
+                      parameters("rev".as[Int], "storage".as[IdSegment].?, "tag".as[UserTag].?) { (rev, storage, tag) =>
+                        (requestEntityPresent & extractRequestEntity & extractFileMetadata) { (entity, metadata) =>
+                          val fileId = FileId(id, project)
+                          emit(
+                            files
+                              .updateRegisteredFile(
+                                fileId,
+                                storage,
+                                rev,
+                                entity,
+                                tag,
+                                metadata
+                              )
+                              .index(mode)
+                              .attemptNarrow[FileRejection]
+                          )
+                        }
+                      }
+                    }
+                  }
+                }
               }
             )
           }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/FileOperations.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/FileOperations.scala
@@ -25,6 +25,8 @@ trait FileOperations extends StorageAccess {
 
   def register(storage: Storage, path: Uri.Path): IO[S3FileMetadata]
 
+  def registerUpdate(storage: Storage, path: Uri.Path, entity: BodyPartEntity): IO[FileStorageMetadata]
+
   def fetchAttributes(storage: Storage, attributes: FileAttributes): IO[ComputedFileAttributes]
 }
 
@@ -69,6 +71,12 @@ object FileOperations {
     override def register(storage: Storage, path: Uri.Path): IO[S3FileMetadata] =
       storage match {
         case s: S3Storage => s3FileOps.register(s.value.bucket, path)
+        case s            => IO.raiseError(RegisterFileRejection.UnsupportedOperation(s.tpe))
+      }
+
+    override def registerUpdate(storage: Storage, path: Uri.Path, entity: BodyPartEntity): IO[FileStorageMetadata] =
+      storage match {
+        case s: S3Storage => s3FileOps.registerUpdate(s, path, entity)
         case s            => IO.raiseError(RegisterFileRejection.UnsupportedOperation(s.tpe))
       }
   }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/StorageFileRejection.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/StorageFileRejection.scala
@@ -1,7 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations
 
 import akka.http.scaladsl.model.{StatusCodes, Uri}
-import cats.data.NonEmptyList
 import ch.epfl.bluebrain.nexus.delta.kernel.error.Rejection
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageType
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
@@ -138,6 +137,9 @@ object StorageFileRejection {
           s"File cannot be saved because it already exists on path '$path'."
         )
 
+    final case class FileNotFound(path: String)
+        extends SaveFileRejection(s"File could not be retrieved from expected path '$path'.")
+
     /**
       * Rejection returned when a storage cannot save a file due to an unexpected reason
       */
@@ -196,11 +198,11 @@ object StorageFileRejection {
   sealed abstract class RegisterFileRejection(loggedDetails: String) extends StorageFileRejection(loggedDetails)
 
   object RegisterFileRejection {
-    final case class MissingS3Attributes(missingAttributes: NonEmptyList[String])
-        extends RegisterFileRejection(s"Missing attributes from S3: ${missingAttributes.toList.mkString(", ")}")
-
     final case class InvalidContentType(received: String)
         extends RegisterFileRejection(s"Invalid content type returned from S3: $received")
+
+    final case class MissingChecksum(key: String)
+        extends RegisterFileRejection(s"Missing SHA-256 checksum for S3 object at key: ")
 
     final case class InvalidPath(path: Uri.Path)
         extends RegisterFileRejection(s"An S3 path must contain at least the filename. Path was $path")

--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/mocks/FileOperationsMock.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/mocks/FileOperationsMock.scala
@@ -31,12 +31,13 @@ object FileOperationsMock {
     )
 
   def unimplemented: FileOperations = new FileOperations {
-    def validateStorageAccess(storage: StorageValue): IO[Unit]                                    = ???
-    def save(storage: Storage, filename: String, entity: BodyPartEntity): IO[FileStorageMetadata] = ???
-    def link(storage: Storage, sourcePath: Uri.Path, filename: String): IO[FileStorageMetadata]   = ???
-    def fetch(storage: Storage, attributes: FileAttributes): IO[AkkaSource]                       = ???
-    def fetchAttributes(storage: Storage, attributes: FileAttributes): IO[ComputedFileAttributes] = ???
-    def register(storage: Storage, path: Uri.Path): IO[S3FileOperations.S3FileMetadata]           = ???
+    def validateStorageAccess(storage: StorageValue): IO[Unit]                                            = ???
+    def save(storage: Storage, filename: String, entity: BodyPartEntity): IO[FileStorageMetadata]         = ???
+    def link(storage: Storage, sourcePath: Uri.Path, filename: String): IO[FileStorageMetadata]           = ???
+    def fetch(storage: Storage, attributes: FileAttributes): IO[AkkaSource]                               = ???
+    def fetchAttributes(storage: Storage, attributes: FileAttributes): IO[ComputedFileAttributes]         = ???
+    def register(storage: Storage, path: Uri.Path): IO[S3FileOperations.S3FileMetadata]                   = ???
+    def registerUpdate(storage: Storage, path: Uri.Path, entity: BodyPartEntity): IO[FileStorageMetadata] = ???
   }
 
   def diskUnimplemented: DiskFileOperations = new DiskFileOperations {
@@ -46,9 +47,11 @@ object FileOperationsMock {
   }
 
   def s3Unimplemented: S3FileOperations = new S3FileOperations {
-    def checkBucketExists(bucket: String): IO[Unit]                                                         = ???
-    def fetch(bucket: String, path: Uri.Path): IO[AkkaSource]                                               = ???
-    def save(storage: Storage.S3Storage, filename: String, entity: BodyPartEntity): IO[FileStorageMetadata] = ???
-    def register(bucket: String, path: Uri.Path): IO[S3FileOperations.S3FileMetadata]                       = ???
+    def checkBucketExists(bucket: String): IO[Unit]                                                                 = ???
+    def fetch(bucket: String, path: Uri.Path): IO[AkkaSource]                                                       = ???
+    def save(storage: Storage.S3Storage, filename: String, entity: BodyPartEntity): IO[FileStorageMetadata]         = ???
+    def register(bucket: String, path: Uri.Path): IO[S3FileOperations.S3FileMetadata]                               = ???
+    def registerUpdate(storage: Storage.S3Storage, path: Uri.Path, entity: BodyPartEntity): IO[FileStorageMetadata] =
+      ???
   }
 }


### PR DESCRIPTION
@olivergrabinski is this enough to unblock you? Still need to verify all the file attribute fields in the E2E test response and the API design could be better.

Some points of note
1. We change the `FileAttributesOrigin` from `External` to `Client`.
2. The S3 path isn't provided by the client - it comes from the file state.
3. Generate another UUID that's stored in the event but isn't used.
4. Content type and filename now come from the request, other attributes are populated in the S3 client (same as for an initial save).