### PR TITLE
Make S3 file location relative within bucket + path independent of the prefix

### DIFF
--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3FileOperations.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3FileOperations.scala
@@ -17,7 +17,6 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.Storage
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.S3FileOperations.S3FileMetadata
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient.HeadObject
-import ch.epfl.bluebrain.nexus.delta.rdf.syntax.uriSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.AkkaSource
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.StreamConverter
 import org.apache.commons.codec.binary.Hex
@@ -75,7 +74,7 @@ object S3FileOperations {
       }
 
     override def save(storage: S3Storage, filename: String, entity: BodyPartEntity): IO[FileStorageMetadata] =
-      saveFile.apply(storage, filename, entity)
+      saveFile.save(storage, filename, entity)
 
     override def register(bucket: String, path: Uri.Path): IO[S3FileMetadata] =
       registerInternal(client, bucket, path)
@@ -88,7 +87,7 @@ object S3FileOperations {
     for {
       _        <- log.info(s"Fetching attributes for S3 file. Bucket $bucket at path $path")
       resp     <- client.headObject(bucket, path.toString())
-      metadata <- mkS3Metadata(client, bucket, path, resp)
+      metadata <- mkS3Metadata(path, resp)
     } yield metadata
   }
     .onError { e =>
@@ -106,9 +105,9 @@ object S3FileOperations {
     }
   }
 
-  private def mkS3Metadata(client: S3StorageClient, bucket: String, path: Uri.Path, resp: HeadObject)(implicit
+  private def mkS3Metadata(path: Uri.Path, resp: HeadObject)(implicit
       uuidf: UUIDF
-  ) = {
+  ) =
     for {
       uuid        <- uuidf()
       contentType <- parseContentType(resp.contentType)
@@ -120,11 +119,10 @@ object S3FileOperations {
         resp.fileSize,
         checksum,
         FileAttributesOrigin.External,
-        client.baseEndpoint / bucket / path,
+        Uri(path.toString()),
         path
       )
     )
-  }
 
   private def checksumFrom(response: HeadObject) = IO.fromOption {
     response.sha256Checksum

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageSaveFile.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/S3StorageSaveFile.scala
@@ -17,7 +17,6 @@ import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.FileOpe
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.StorageFileRejection.SaveFileRejection._
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient.UploadMetadata
-import ch.epfl.bluebrain.nexus.delta.rdf.syntax.uriSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.stream.StreamConverter
 import fs2.Stream
 
@@ -30,7 +29,7 @@ final class S3StorageSaveFile(s3StorageClient: S3StorageClient)(implicit
 
   private val logger = Logger[S3StorageSaveFile]
 
-  def apply(
+  def save(
       storage: S3Storage,
       filename: String,
       entity: BodyPartEntity
@@ -38,7 +37,7 @@ final class S3StorageSaveFile(s3StorageClient: S3StorageClient)(implicit
 
     for {
       uuid   <- uuidf()
-      path    = s3StorageClient.prefix / Uri.Path(intermediateFolders(storage.project, uuid, filename))
+      path    = Uri.Path(intermediateFolders(storage.project, uuid, filename))
       result <- storeFile(storage.value.bucket, path.toString(), uuid, entity, storage.value.algorithm)
     } yield result
   }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/S3StorageClientImpl.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/s3/client/S3StorageClientImpl.scala
@@ -103,7 +103,7 @@ final private[client] class S3StorageClientImpl(client: S3AsyncClientOp[IO], val
                        .compile
                        .onlyOrError
       fileSize    <- fileSizeAcc.get
-      location     = baseEndpoint / bucket / Uri.Path(key)
+      location     = prefix / Uri.Path(key)
     } yield UploadMetadata(digest, fileSize, location)
   }
 

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/SourcePatcher.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/SourcePatcher.scala
@@ -22,7 +22,7 @@ object SourcePatcher {
   // Resources will be keep their ids as we explicitly pass them along the source payload
   val removeEmptyIds: Json => Json = root.obj.modify {
     case obj if obj("@id").contains(emptyString) => obj.remove("@id")
-    case obj => obj
+    case obj                                     => obj
   }
 
   def apply(fileSelfParser: FileSelf, projectMapper: ProjectMapper, targetBase: BaseUri): SourcePatcher =

--- a/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/SourcePatcherSuite.scala
+++ b/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/SourcePatcherSuite.scala
@@ -15,7 +15,7 @@ class SourcePatcherSuite extends NexusSuite {
   }
 
   test("Removing empty ids removes the @id field when it is empty") {
-    val source = json"""{ "@id": "", "name": "Bob" }"""
+    val source   = json"""{ "@id": "", "name": "Bob" }"""
     val expected = json"""{ "name": "Bob" }"""
     assertEquals(SourcePatcher.removeEmptyIds(source), expected)
   }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/files/S3StorageSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/files/S3StorageSpec.scala
@@ -39,7 +39,7 @@ class S3StorageSpec extends StorageSpec {
 
   override def storageId: String = "mys3storage"
 
-  override def locationPrefix: Option[String] = Some(s"$s3BucketEndpoint/${s3Config.prefix}")
+  override def locationPrefix: Option[String] = Some(s3Config.prefix)
 
   val s3Config: S3Config = storageConfig.s3
 
@@ -244,10 +244,13 @@ class S3StorageSpec extends StorageSpec {
                        (_, response) => response.status shouldEqual StatusCodes.Created
                      }
         fullId     = s"$attachmentPrefix$id"
-        location   = s"$s3BucketEndpoint/$path"
         assertion <- deltaClient.get[Json](s"/files/$projectRef/$id", Coyote) { (json, response) =>
                        response.status shouldEqual StatusCodes.OK
-                       filterMetadataKeys(json) shouldEqual registrationResponse(fullId, logoSha256HexDigest, location)
+                       filterMetadataKeys(json) shouldEqual registrationResponse(
+                         fullId,
+                         logoSha256HexDigest,
+                         location = path
+                       )
                      }
       } yield assertion
     }


### PR DESCRIPTION
Fixes #4888, the two cases are:

1. Saving files
   a)  Location goes from `base / bucket / prefix / key` to `prefix / key`
   b) Path goes from `prefix / key` to `key`
2. Registering files
   a) Location goes from `base / bucket / key` to `key` (this was not specified in the ticket and is an assumption; the prefix was never used because the user provides the path)
   b) Path is the same as before, just the key. So location and path are equal

If I've misunderstood the reqs please LMK which one of these is wrong @imsdu 