### PR TITLE
Handle S3 access error gracefully with 403

### DIFF
--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileRejection.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/model/FileRejection.scala
@@ -269,20 +269,21 @@ object FileRejection {
 
   implicit final val fileRejectionHttpResponseFields: HttpResponseFields[FileRejection] =
     HttpResponseFields.fromStatusAndHeaders {
-      case RevisionNotFound(_, _)                                          => (StatusCodes.NotFound, Seq.empty)
-      case TagNotFound(_)                                                  => (StatusCodes.NotFound, Seq.empty)
-      case FileNotFound(_, _)                                              => (StatusCodes.NotFound, Seq.empty)
-      case ResourceAlreadyExists(_, _)                                     => (StatusCodes.Conflict, Seq.empty)
-      case IncorrectRev(_, _)                                              => (StatusCodes.Conflict, Seq.empty)
-      case FileTooLarge(_)                                                 => (StatusCodes.PayloadTooLarge, Seq.empty)
-      case WrappedAkkaRejection(rej)                                       => (rej.status, rej.headers)
-      case WrappedStorageRejection(rej)                                    => (rej.status, rej.headers)
+      case RevisionNotFound(_, _)                                             => (StatusCodes.NotFound, Seq.empty)
+      case TagNotFound(_)                                                     => (StatusCodes.NotFound, Seq.empty)
+      case FileNotFound(_, _)                                                 => (StatusCodes.NotFound, Seq.empty)
+      case ResourceAlreadyExists(_, _)                                        => (StatusCodes.Conflict, Seq.empty)
+      case IncorrectRev(_, _)                                                 => (StatusCodes.Conflict, Seq.empty)
+      case FileTooLarge(_)                                                    => (StatusCodes.PayloadTooLarge, Seq.empty)
+      case WrappedAkkaRejection(rej)                                          => (rej.status, rej.headers)
+      case WrappedStorageRejection(rej)                                       => (rej.status, rej.headers)
       // If this happens it signifies a system problem rather than the user having made a mistake
-      case FetchRejection(_, _, FetchFileRejection.FileNotFound(_))        => (StatusCodes.InternalServerError, Seq.empty)
-      case SaveRejection(_, _, SaveFileRejection.ResourceAlreadyExists(_)) => (StatusCodes.Conflict, Seq.empty)
-      case CopyRejection(_, _, _, rejection)                               => (rejection.status, Seq.empty)
-      case FetchRejection(_, _, _)                                         => (StatusCodes.InternalServerError, Seq.empty)
-      case SaveRejection(_, _, _)                                          => (StatusCodes.InternalServerError, Seq.empty)
-      case _                                                               => (StatusCodes.BadRequest, Seq.empty)
+      case FetchRejection(_, _, FetchFileRejection.FileNotFound(_))           => (StatusCodes.InternalServerError, Seq.empty)
+      case SaveRejection(_, _, SaveFileRejection.ResourceAlreadyExists(_))    => (StatusCodes.Conflict, Seq.empty)
+      case SaveRejection(_, _, SaveFileRejection.BucketAccessDenied(_, _, _)) => (StatusCodes.Forbidden, Seq.empty)
+      case CopyRejection(_, _, _, rejection)                                  => (rejection.status, Seq.empty)
+      case FetchRejection(_, _, _)                                            => (StatusCodes.InternalServerError, Seq.empty)
+      case SaveRejection(_, _, _)                                             => (StatusCodes.InternalServerError, Seq.empty)
+      case _                                                                  => (StatusCodes.BadRequest, Seq.empty)
     }
 }

--- a/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/StorageFileRejection.scala
+++ b/delta/plugins/storage/src/main/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/storages/operations/StorageFileRejection.scala
@@ -1,7 +1,6 @@
 package ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations
 
 import akka.http.scaladsl.model.{StatusCodes, Uri}
-import cats.data.NonEmptyList
 import ch.epfl.bluebrain.nexus.delta.kernel.error.Rejection
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.model.StorageType
 import ch.epfl.bluebrain.nexus.delta.rdf.IriOrBNode.Iri
@@ -146,6 +145,8 @@ object StorageFileRejection {
           s"File cannot be saved on path '$path' for unexpected reasons. Details '$details'"
         )
 
+    final case class BucketAccessDenied(bucket: String, key: String, details: String)
+        extends SaveFileRejection(s"Access denied to bucket $bucket at key $key")
   }
 
   /**
@@ -196,9 +197,6 @@ object StorageFileRejection {
   sealed abstract class RegisterFileRejection(loggedDetails: String) extends StorageFileRejection(loggedDetails)
 
   object RegisterFileRejection {
-    final case class MissingS3Attributes(missingAttributes: NonEmptyList[String])
-        extends RegisterFileRejection(s"Missing attributes from S3: ${missingAttributes.toList.mkString(", ")}")
-
     final case class InvalidContentType(received: String)
         extends RegisterFileRejection(s"Invalid content type returned from S3: $received")
 


### PR DESCRIPTION
Fixes #4887 

To test this using localstack would require adding IAM to our container setup, then creating and setting up users with the desired permissions via the SDK. With all that setup, it might be inconsistent with the real S3 anyway. I thought it best to test manually instead by:
1. Creating user in sandbox with S3 read permissions
2. Pointing integration tests to sandbox S3 with access keys from my admin user
3. Pointing the dockerised delta to sandbox S3 with access keys from the restricted user
4. Run `S3StorageSpec`, see what file upload failures look like

In the end we now return 403 with
```json
   {
     "@context" : "https://bluebrain.github.io/nexus/contexts/error.json",
     "@type" : "BucketAccessDenied",
     "reason" : "File 'http://delta:8080/v1/resources/6k0mab3nc23xhan/ykab7aepbgphlt0/_/attachment.json' could not be saved using storage 'https://bluebrain.github.io/nexus/vocabulary/mys3storage'",
     "details" : "Access denied to bucket da7goncyy5irq8u at key myprefix/6k0mab3nc23xhan/ykab7aepbgphlt0/files/6/1/6/a/d/7/0/a/attachment.json"
   }
```