### PR TITLE
Add slow query logger based on Doobie

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -912,7 +912,6 @@ lazy val kamonSettings = Seq(
     "io.kamon" %% "kamon-core"           % kamonVersion,
     "io.kamon" %% "kamon-executors"      % kamonVersion,
     "io.kamon" %% "kamon-jaeger"         % kamonVersion,
-    "io.kamon" %% "kamon-jdbc"           % kamonVersion,
     "io.kamon" %% "kamon-logback"        % kamonVersion,
     "io.kamon" %% "kamon-prometheus"     % kamonVersion,
     "io.kamon" %% "kamon-scala-future"   % kamonVersion,

--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -41,6 +41,9 @@ app {
       # The duration after an entry in the cache expires
       expire-after = 10 minutes
     }
+
+    # Threshold from which a query is considered slow and will be logged
+    slow-query-threshold = 2 seconds
   }
 
   # Database export configuration

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/QueryLogHandler.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/QueryLogHandler.scala
@@ -1,0 +1,69 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing
+
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.delta.kernel.Logger
+import ch.epfl.bluebrain.nexus.delta.sourcing.event.Event
+import ch.epfl.bluebrain.nexus.delta.sourcing.state.State
+import doobie.util.log
+import doobie.util.log.{LogEvent, LogHandler}
+import io.circe.Json
+
+import scala.concurrent.duration.FiniteDuration
+
+object QueryLogHandler {
+
+  private val logger = Logger[QueryLogHandler.type]
+
+  def apply(poolName: String, slowQueryThreshold: FiniteDuration): LogHandler[IO] = new LogHandler[IO] {
+    override def run(logEvent: LogEvent): IO[Unit] = logEvent match {
+      case log.Success(sql, args, label, exec, processing) if exec > slowQueryThreshold =>
+        logger.warn(s"""[$poolName] Slow Statement Execution:
+             |
+             | ${formatQuery(sql)}
+             |
+             | arguments = ${formatArguments(args)}
+             | label     = $label
+             | elapsed = ${exec.toMillis} ms exec + ${processing.toMillis} ms processing (${(exec + processing).toMillis} ms total)
+          """.stripMargin)
+      case log.Success(sql, args, label, exec, processing)                              =>
+        logger.debug(s"""[$poolName] Successful Statement Execution:
+             |
+             | ${formatQuery(sql)}
+             |
+             | arguments = ${formatArguments(args)}
+             | label     = $label
+             | elapsed = ${exec.toMillis} ms exec + ${processing.toMillis} ms processing (${(exec + processing).toMillis} ms total)
+          """.stripMargin)
+      case log.ProcessingFailure(sql, args, label, exec, processing, failure)           =>
+        logger.error(failure)(s"""[$poolName] Failed Resultset Processing:
+             |
+             | ${formatQuery(sql)}
+             |
+             | arguments = ${formatArguments(args)}
+             | label     = $label
+             | elapsed = ${exec.toMillis} ms exec + ${processing.toMillis} ms processing (failed) (${(exec + processing).toMillis.toString} ms total)
+          """.stripMargin)
+      case log.ExecFailure(sql, args, label, exec, failure)                             =>
+        logger.error(failure)(s"""[$poolName] Failed Statement Execution:
+             |
+             | ${formatQuery(sql)}
+             |
+             | arguments = ${formatArguments(args)}
+             | label     = $label
+             | elapsed = ${exec.toMillis} ms exec (failed)
+          """.stripMargin)
+    }
+
+    private def formatQuery(sql: String) = sql.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")
+
+    private def formatArguments(args: List[Any]) = args
+      .map {
+        case _: Json  => "{json blob}"
+        case e: Event => s"{event ${e.getClass.getSimpleName}}"
+        case s: State => s"{state ${s.getClass.getSimpleName}}"
+        case other    => other.toString
+      }
+      .mkString("[", ", ", "]")
+  }
+
+}

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/config/DatabaseConfig.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/config/DatabaseConfig.scala
@@ -6,6 +6,8 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.config.DatabaseConfig.DatabaseAcce
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
+import scala.concurrent.duration.FiniteDuration
+
 /**
   * Database configuration
   * @param read
@@ -22,6 +24,8 @@ import pureconfig.generic.semiauto.deriveReader
   *   The database password
   * @param tablesAutocreate
   *   When true it creates the tables on service boot
+  * @param slowQueryThreshold
+  *   Threshold allowing to trigger a warning log when a query execution time reaches this limit
   * @param cache
   *   The cache configuration for the partitions cache
   */
@@ -33,6 +37,7 @@ final case class DatabaseConfig(
     username: String,
     password: Secret[String],
     tablesAutocreate: Boolean,
+    slowQueryThreshold: FiniteDuration,
     cache: CacheConfig
 )
 

--- a/ship/src/main/resources/ship-default.conf
+++ b/ship/src/main/resources/ship-default.conf
@@ -17,6 +17,9 @@ ship {
       expire-after = 10 minutes
     }
 
+    # Threshold from which a query is considered slow and will be logged
+    slow-query-threshold = 2 seconds
+
     access {
       # the database host
       host = 127.0.0.1


### PR DESCRIPTION
Example of log:
```
2024-05-22 09:48:14 WARN  c.e.b.n.d.sourcing.QueryLogHandler - [StreamingPool] Slow Statement Execution:

 ((SELECT 'newState', type, id, org, project, value, instant, ordering, rev
  FROM public.scoped_states
  WHERE org = ? and project = ?  AND ordering > ?  AND tag = ? 
  ORDER BY ordering
  LIMIT ?)
  UNION ALL
  (SELECT 'tombstone', type, id, org, project, null, instant, ordering, -1
  FROM public.scoped_tombstones
  WHERE org = ? and project = ?  AND ordering > ?  AND tag = ?  AND (cause->>'deleted' = 'true' ) 
  ORDER BY ordering
  LIMIT ?)
  ORDER BY ordering)
  LIMIT ?

 arguments = [mbodytmoxbxk0do, n5rspxio3rlet3w, 184, latest, 30, mbodytmoxbxk0do, n5rspxio3rlet3w, 184, latest, 30, 30]
 label     = unlabeled
 elapsed = 11 ms exec + 0 ms processing (11 ms total)
```
So we have the arguments now to make it easier