### PR TITLE
Deduplicating shapes before Shacl validation

### DIFF
--- a/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/Graph.scala
+++ b/delta/rdf/src/main/scala/ch/epfl/bluebrain/nexus/delta/rdf/graph/Graph.scala
@@ -60,6 +60,8 @@ final case class Graph private (rootNode: IriOrBNode, value: DatasetGraph) { sel
     */
   def isEmpty: Boolean = value.isEmpty
 
+  def getDefaultGraphSize: Int = value.getDefaultGraph.size()
+
   /**
     * Returns a subgraph retaining all the triples that satisfy the provided predicate.
     */

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/schemas/model/SchemaSuite.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/schemas/model/SchemaSuite.scala
@@ -11,21 +11,21 @@ import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite
 
 class SchemaSuite extends NexusSuite with Fixtures {
 
-  private  val project                = ProjectRef.unsafe("org", "proj")
+  private val project = ProjectRef.unsafe("org", "proj")
 
   test("Extract as a graph the content of the schema, removing the duplicates") {
     for {
-      entitySource <- loader.jsonContentOf("schemas/entity.json")
-      entityExpanded  <- ExpandedJsonLd(jsonContentOf("schemas/entity-expanded.json"))
-      entityExpandedGraphSize <- IO.fromEither(entityExpanded.toGraph.map(_.getDefaultGraphSize))
-      entityCompacted <- entityExpanded.toCompacted(entitySource.topContextValueOrEmpty)
-      licenseExpanded <- ExpandedJsonLd(jsonContentOf("schemas/license-expanded.json"))
+      entitySource             <- loader.jsonContentOf("schemas/entity.json")
+      entityExpanded           <- ExpandedJsonLd(jsonContentOf("schemas/entity-expanded.json"))
+      entityExpandedGraphSize  <- IO.fromEither(entityExpanded.toGraph.map(_.getDefaultGraphSize))
+      entityCompacted          <- entityExpanded.toCompacted(entitySource.topContextValueOrEmpty)
+      licenseExpanded          <- ExpandedJsonLd(jsonContentOf("schemas/license-expanded.json"))
       licenseExpandedGraphSize <- IO.fromEither(licenseExpanded.toGraph.map(_.getDefaultGraphSize))
     } yield {
-      val id = iri"https://neuroshapes.org/commons/entity"
+      val id        = iri"https://neuroshapes.org/commons/entity"
       val expandeds = NonEmptyList.of(entityExpanded, licenseExpanded, entityExpanded)
-      val schema = Schema(id, project, Tags.empty, entitySource, entityCompacted, expandeds)
-      assertEquals(schema.shapes.getDefaultGraphSize , entityExpandedGraphSize + licenseExpandedGraphSize)
+      val schema    = Schema(id, project, Tags.empty, entitySource, entityCompacted, expandeds)
+      assertEquals(schema.shapes.getDefaultGraphSize, entityExpandedGraphSize + licenseExpandedGraphSize)
     }
   }
 

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/schemas/model/SchemaSuite.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/schemas/model/SchemaSuite.scala
@@ -1,0 +1,32 @@
+package ch.epfl.bluebrain.nexus.delta.sdk.schemas.model
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.ExpandedJsonLd
+import ch.epfl.bluebrain.nexus.delta.rdf.syntax._
+import ch.epfl.bluebrain.nexus.delta.sdk.model.Tags
+import ch.epfl.bluebrain.nexus.delta.sdk.utils.Fixtures
+import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
+import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite
+
+class SchemaSuite extends NexusSuite with Fixtures {
+
+  private  val project                = ProjectRef.unsafe("org", "proj")
+
+  test("Extract as a graph the content of the schema, removing the duplicates") {
+    for {
+      entitySource <- loader.jsonContentOf("schemas/entity.json")
+      entityExpanded  <- ExpandedJsonLd(jsonContentOf("schemas/entity-expanded.json"))
+      entityExpandedGraphSize <- IO.fromEither(entityExpanded.toGraph.map(_.getDefaultGraphSize))
+      entityCompacted <- entityExpanded.toCompacted(entitySource.topContextValueOrEmpty)
+      licenseExpanded <- ExpandedJsonLd(jsonContentOf("schemas/license-expanded.json"))
+      licenseExpandedGraphSize <- IO.fromEither(licenseExpanded.toGraph.map(_.getDefaultGraphSize))
+    } yield {
+      val id = iri"https://neuroshapes.org/commons/entity"
+      val expandeds = NonEmptyList.of(entityExpanded, licenseExpanded, entityExpanded)
+      val schema = Schema(id, project, Tags.empty, entitySource, entityCompacted, expandeds)
+      assertEquals(schema.shapes.getDefaultGraphSize , entityExpandedGraphSize + licenseExpandedGraphSize)
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #5020

Before:
```
[info] NeuroMorphologySampleSpec:
[info] Creating a morphology
[info] - should succeed provisionning the mandatory schemas (2 seconds, 980 milliseconds)
[info] - should succeed creating the neuronmorphology-entity without a schema (121 milliseconds)
[info] - should succeed creating the neuronmorphology-entity with a schema (2 seconds, 352 milliseconds)
[info] - should succeed updating the neuronmorphology-entity with a schema (2 seconds, 336 milliseconds)
[info] - should succeed generating the neuronmorphology-entity with the trial endpoint (2 seconds, 252 milliseconds)
[info] - should succeed creating the neuronmorphology-dataset without a schema (57 milliseconds)
[info] - should succeed creating the neuronmorphology-dataset with a schema (1 second, 771 milliseconds)
[info] - should succeed updating the neuronmorphology-dataset with a schema (1 second, 711 milliseconds)
[info] - should succeed generating the neuronmorphology-dataset with the trial endpoint (1 second, 515 milliseconds)
```

After:
```
[info] NeuroMorphologySampleSpec:
[info] Creating a morphology
[info] - should succeed provisionning the mandatory schemas (2 seconds, 619 milliseconds)
[info] - should succeed creating the neuronmorphology-entity without a schema (73 milliseconds)
[info] - should succeed creating the neuronmorphology-entity with a schema (71 milliseconds)
[info] - should succeed updating the neuronmorphology-entity with a schema (79 milliseconds)
[info] - should succeed generating the neuronmorphology-entity with the trial endpoint (66 milliseconds)
[info] - should succeed creating the neuronmorphology-dataset without a schema (48 milliseconds)
[info] - should succeed creating the neuronmorphology-dataset with a schema (81 milliseconds)
[info] - should succeed updating the neuronmorphology-dataset with a schema (51 milliseconds)
[info] - should succeed generating the neuronmorphology-dataset with the trial endpoint (52 milliseconds)
```