### PR TITLE
Patch resource types in resolver events in the import batch

### DIFF
--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/RunShip.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/RunShip.scala
@@ -63,7 +63,7 @@ object RunShip {
           fileSelf                     = FileSelf(originalProjectContext)(originalBaseUri)
           sourcePatcher                = SourcePatcher(fileSelf, projectMapper, iriPatcher, targetBaseUri, eventClock, xas, config)
           projectProcessor            <- ProjectProcessor(fetchActiveOrg, fetchContext, rcr, originalProjectContext, projectMapper, iriPatcher, config, eventClock, xas)(targetBaseUri, jsonLdApi)
-          resolverProcessor            = ResolverProcessor(fetchContext, projectMapper, eventLogConfig, eventClock, xas)
+          resolverProcessor            = ResolverProcessor(fetchContext, projectMapper, iriPatcher, eventLogConfig, eventClock, xas)
           schemaProcessor              = SchemaProcessor(schemaLog, fetchContext, schemaImports, rcr, projectMapper, sourcePatcher, eventClock)
                     resourceProcessor            = ResourceProcessor(resourceLog, rcr, projectMapper, fetchContext, sourcePatcher, iriPatcher, config.resourceTypesToIgnore, eventClock)
                     viewPatcher                  = new ViewPatcher(projectMapper, iriPatcher)

--- a/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resolvers/ResolverProcessorSuite.scala
+++ b/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resolvers/ResolverProcessorSuite.scala
@@ -2,10 +2,11 @@ package ch.epfl.bluebrain.nexus.ship.resolvers
 
 import cats.data.NonEmptyList
 import ch.epfl.bluebrain.nexus.delta.rdf.Vocabulary.nxv
+import ch.epfl.bluebrain.nexus.delta.rdf.syntax.iriStringContextSyntax
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.model.ResolverValue.{CrossProjectValue, InProjectValue}
 import ch.epfl.bluebrain.nexus.delta.sdk.resolvers.model.{IdentityResolution, Priority}
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.ProjectRef
-import ch.epfl.bluebrain.nexus.ship.ProjectMapper
+import ch.epfl.bluebrain.nexus.ship.{IriPatcher, ProjectMapper}
 import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite
 
 class ResolverProcessorSuite extends NexusSuite {
@@ -15,29 +16,39 @@ class ResolverProcessorSuite extends NexusSuite {
 
   private val projectMapper = ProjectMapper(Map(originalProject -> targetProject))
 
+  private val originalPrefix = iri"https://bbp.epfl.ch/"
+  private val targetPrefix   = iri"https:/openbrainplatform.com/"
+
+  private val iriPatcher = IriPatcher(originalPrefix, targetPrefix, Map(originalProject -> targetProject))
+
   private val priority = Priority.unsafe(42)
 
   test("Patching does not affect in project resolvers") {
     val original = InProjectValue(priority)
 
-    val obtained = ResolverProcessor.patchValue(original, projectMapper)
+    val obtained = ResolverProcessor.patchValue(original, projectMapper, iriPatcher)
     assertEquals(obtained, original)
   }
 
   test("Patching a cross project resolver") {
     val unpatchedProject = ProjectRef.unsafe("neurosciencegraph", "datamodels")
     val originalProjects = NonEmptyList.of(unpatchedProject, originalProject)
+    val originalType     = originalPrefix / originalProject.organization.value / originalProject.project.value / "Type"
     val original         = CrossProjectValue(
       Some("My resolver"),
       Some("My description"),
       priority,
-      Set(nxv + "Schema"),
+      Set(nxv + "Schema", originalType),
       originalProjects,
       IdentityResolution.UseCurrentCaller
     )
 
-    val expected = original.copy(projects = NonEmptyList.of(unpatchedProject, targetProject))
-    val obtained = ResolverProcessor.patchValue(original, projectMapper)
+    val expected = original.copy(
+      projects = NonEmptyList.of(unpatchedProject, targetProject),
+      resourceTypes =
+        Set(nxv + "Schema", targetPrefix / targetProject.organization.value / targetProject.project.value / "Type")
+    )
+    val obtained = ResolverProcessor.patchValue(original, projectMapper, iriPatcher)
     assertEquals(obtained, expected)
   }
 


### PR DESCRIPTION
Resolvers can be conditionally applied to a subset of types. When those types start by a prefix, those should be patched