### PR TITLE
Sync projects in sbo suite with k8s deployment

### DIFF
--- a/infra/aws.conf
+++ b/infra/aws.conf
@@ -130,20 +130,17 @@ plugins {
       sbo = [
         "public/forge",
         "public/hippocampus",
-        "public/hippocampus-hub",
         "public/multi-vesicular-release",
         "public/ngv",
         "public/ngv-anatomy",
-        "public/nvg",
         "public/sscx",
         "public/thalamus",
         "public/topological-sampling",
         "bbp/lnmce",
         "bbp/mmb-point-neuron-framework-model",
-        "bbp/ncmv3",
-        "bbp/hippocampus",
         "bbp-external/seu",
-        "bbp/mouselight"
+        "bbp/mouselight",
+        "neurosciencegraph/datamodels",
       ]
     }
   }

--- a/infra/delta-aws.conf
+++ b/infra/delta-aws.conf
@@ -135,20 +135,17 @@ plugins {
       sbo = [
         "public/forge",
         "public/hippocampus",
-        "public/hippocampus-hub",
         "public/multi-vesicular-release",
         "public/ngv",
         "public/ngv-anatomy",
-        "public/nvg",
         "public/sscx",
         "public/thalamus",
         "public/topological-sampling",
         "bbp/lnmce",
         "bbp/mmb-point-neuron-framework-model",
-        "bbp/ncmv3",
-        "bbp/hippocampus",
         "bbp-external/seu",
-        "bbp/mouselight"
+        "bbp/mouselight",
+        "neurosciencegraph/datamodels",
       ]
     }
   }


### PR DESCRIPTION
### Problem

To implement [this ticket](https://bbpteam.epfl.ch/project/issues/browse/BBPP134-1735) the virtual lab client needs to create an aggregate view for every project in sbo suite. Right now, the creation of aggregate view fails because of error `At least one view reference does not exist or is deprecated.`. These are the projects in aws for which views couldn't be found:

- public/multi-vesicular-release 
- bbp/ncmv3 
- public/nvg 
- bbp/hippocampus 

According to @crisely09 the last 3 projects shouldn't be in the suite. The projects in the suite should be the same as the [ones in the k8s deployment](https://bbp.epfl.ch/nexus/v1/search/suites/sbo).