### PR TITLE
Partition export file to have a maximum number of events

### DIFF
--- a/delta/app/src/main/resources/app.conf
+++ b/delta/app/src/main/resources/app.conf
@@ -49,6 +49,8 @@ app {
   # Database export configuration
   export {
     batch-size = 30
+    # Limit number of events per files (this default value should give ~1GB files)
+    limit-per-file = 32000
     # Max number of concurrent exports
     permits = 1
     # Target directory for exports

--- a/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ExportModule.scala
+++ b/delta/app/src/main/scala/ch/epfl/bluebrain/nexus/delta/wiring/ExportModule.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.delta.wiring
 
-import cats.effect.{Clock, IO}
 import ch.epfl.bluebrain.nexus.delta.Main.pluginsMaxPriority
 import ch.epfl.bluebrain.nexus.delta.config.AppConfig
 import ch.epfl.bluebrain.nexus.delta.rdf.jsonld.context.RemoteContextResolution
@@ -16,8 +15,8 @@ import izumi.distage.model.definition.{Id, ModuleDef}
 // $COVERAGE-OFF$
 object ExportModule extends ModuleDef {
 
-  make[Exporter].fromEffect { (config: AppConfig, clock: Clock[IO], xas: Transactors) =>
-    Exporter(config.`export`, clock, xas)
+  make[Exporter].fromEffect { (config: AppConfig, xas: Transactors) =>
+    Exporter(config.`export`, xas)
   }
 
   make[ExportRoutes].from {

--- a/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ExportRoutesSpec.scala
+++ b/delta/app/src/test/scala/ch/epfl/bluebrain/nexus/delta/routes/ExportRoutesSpec.scala
@@ -15,8 +15,6 @@ import ch.epfl.bluebrain.nexus.delta.sourcing.exporter.{ExportEventQuery, Export
 import ch.epfl.bluebrain.nexus.delta.sourcing.model.Identity.{Anonymous, Authenticated, Group}
 import fs2.io.file.Path
 
-import java.time.Instant
-
 class ExportRoutesSpec extends BaseRouteSpec {
 
   private val caller = Caller(alice, Set(alice, Anonymous, Authenticated(realm), Group("group", realm)))
@@ -31,7 +29,7 @@ class ExportRoutesSpec extends BaseRouteSpec {
 
   private val exporter = new Exporter {
     override def events(query: ExportEventQuery): IO[ExportResult] =
-      exportTrigger.set(true).as(ExportResult(Path("json"), Path("Success"), Instant.EPOCH, Instant.EPOCH))
+      exportTrigger.set(true).as(ExportResult(Path("target"), Path("success")))
   }
 
   private lazy val routes = Route.seal(

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/exporter/ExportConfig.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/exporter/ExportConfig.scala
@@ -5,7 +5,7 @@ import pureconfig.ConfigConvert.catchReadError
 import pureconfig.generic.semiauto.deriveReader
 import pureconfig.{ConfigConvert, ConfigReader}
 
-final case class ExportConfig(batchSize: Int, permits: Int, target: Path)
+final case class ExportConfig(batchSize: Int, limitPerFile: Int, permits: Int, target: Path)
 
 object ExportConfig {
 

--- a/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/utils/StreamingUtils.scala
+++ b/delta/sourcing-psql/src/main/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/utils/StreamingUtils.scala
@@ -1,0 +1,75 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing.stream.utils
+
+import cats.effect.{IO, Resource}
+import cats.effect.std.Hotswap
+import fs2.io.file.{FileHandle, Files, Flag, Flags, Path, WriteCursor}
+import fs2.{text, Pipe, Pull, Stream}
+
+object StreamingUtils {
+
+  private val flags = Flags.Write
+
+  private val lineSeparator = "\n"
+
+  private val newLine = Stream.emit(lineSeparator)
+
+  def readLines(path: Path) =
+    Files[IO].readUtf8Lines(path).filter(_.nonEmpty)
+
+  /**
+    * Writes all data to a sequence of files, each limited to a maximum number of lines
+    *
+    * Adapted from fs2.io.file.Files.writeRotate (which is not preserving lines)
+    *
+    * @param computePath
+    *   to compute the path of the first file and the subsequent ones
+    * @param limit
+    *   maximum number of lines
+    */
+  def writeRotate(computePath: IO[Path], limit: Int): Pipe[IO, String, Nothing] = {
+    def openNewFile: Resource[IO, FileHandle[IO]] =
+      Resource
+        .eval(computePath)
+        .flatMap(p => Files[IO].open(p, flags.addIfAbsent(Flag.Write)))
+
+    def newCursor(file: FileHandle[IO]): IO[WriteCursor[IO]] =
+      Files[IO].writeCursorFromFileHandle(file, flags.contains(Flag.Append))
+
+    def go(
+        fileHotswap: Hotswap[IO, FileHandle[IO]],
+        cursor: WriteCursor[IO],
+        acc: Int,
+        s: Stream[IO, String]
+    ): Pull[IO, Unit, Unit] = {
+      s.pull.unconsLimit(limit - acc).flatMap {
+        case Some((hd, tl)) =>
+          val newAcc    = acc + hd.size
+          val hdAsBytes =
+            Stream.chunk(hd).intersperse(lineSeparator).append(newLine).through(text.utf8.encode)
+          cursor.writeAll(hdAsBytes).flatMap { nc =>
+            if (newAcc >= limit)
+              Pull
+                .eval {
+                  fileHotswap
+                    .swap(openNewFile)
+                    .flatMap(newCursor)
+                }
+                .flatMap(nc => go(fileHotswap, nc, 0, tl))
+            else
+              go(fileHotswap, nc, newAcc, tl)
+          }
+        case None           => Pull.done
+      }
+    }
+
+    in =>
+      Stream
+        .resource(Hotswap(openNewFile))
+        .flatMap { case (fileHotswap, fileHandle) =>
+          Stream.eval(newCursor(fileHandle)).flatMap { cursor =>
+            go(fileHotswap, cursor, 0, in).stream.drain
+          }
+        }
+  }
+
+}

--- a/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/utils/StreamingUtilsSuite.scala
+++ b/delta/sourcing-psql/src/test/scala/ch/epfl/bluebrain/nexus/delta/sourcing/stream/utils/StreamingUtilsSuite.scala
@@ -1,0 +1,34 @@
+package ch.epfl.bluebrain.nexus.delta.sourcing.stream.utils
+
+import cats.effect.IO
+import ch.epfl.bluebrain.nexus.testkit.file.TempDirectory
+import ch.epfl.bluebrain.nexus.testkit.mu.NexusSuite
+import fs2.Stream
+import fs2.io.file.Files
+import munit.AnyFixture
+
+class StreamingUtilsSuite extends NexusSuite with TempDirectory.Fixture {
+
+  override def munitFixtures: Seq[AnyFixture[_]] = List(tempDirectory)
+
+  private lazy val exportDirectory = tempDirectory()
+
+  private val limitPerFile = 3
+  private val lines        = Stream.emits(List("A", "B", "C", "D", "E"))
+
+  test(s"Write stream of lines in a file rotating every $limitPerFile lines") {
+    for {
+      refCompute <- IO.ref(0)
+      computePath = refCompute
+                      .updateAndGet(_ + 1)
+                      .map { counter => exportDirectory / s"part-$counter.txt" }
+      _          <- lines.through(StreamingUtils.writeRotate(computePath, limitPerFile)).compile.drain
+      _          <- Files[IO].list(exportDirectory).assertSize(2)
+      firstFile   = exportDirectory / "part-1.txt"
+      _          <- Files[IO].readUtf8Lines(firstFile).assert("A", "B", "C")
+      secondFile  = exportDirectory / "part-2.txt"
+      _          <- Files[IO].readUtf8Lines(secondFile).assert("D", "E")
+    } yield ()
+  }
+
+}

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/file/TempDirectory.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/file/TempDirectory.scala
@@ -12,7 +12,7 @@ object TempDirectory {
     val tempDirectory: IOFixture[Path] =
       ResourceSuiteLocalFixture(
         "tempDirectory",
-        Resource.make(Files[IO].createTempDirectory)(Files[IO].deleteRecursively)
+        Resource.make(Files[IO].createTempDirectory)(_ => IO.unit)
       )
   }
 

--- a/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/file/TempDirectory.scala
+++ b/delta/testkit/src/main/scala/ch/epfl/bluebrain/nexus/testkit/file/TempDirectory.scala
@@ -12,7 +12,7 @@ object TempDirectory {
     val tempDirectory: IOFixture[Path] =
       ResourceSuiteLocalFixture(
         "tempDirectory",
-        Resource.make(Files[IO].createTempDirectory)(_ => IO.unit)
+        Resource.make(Files[IO].createTempDirectory)(Files[IO].deleteRecursively)
       )
   }
 

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/EventStreamer.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/EventStreamer.scala
@@ -6,6 +6,7 @@ import ch.epfl.bluebrain.nexus.delta.kernel.Logger
 import ch.epfl.bluebrain.nexus.delta.plugins.storage.storages.operations.s3.client.S3StorageClient
 import ch.epfl.bluebrain.nexus.delta.sourcing.exporter.RowEvent
 import ch.epfl.bluebrain.nexus.delta.sourcing.offset.Offset
+import ch.epfl.bluebrain.nexus.delta.sourcing.stream.utils.StreamingUtils
 import ch.epfl.bluebrain.nexus.ship.EventStreamer.logger
 import fs2.io.file.{Files, Path}
 import fs2.{text, Stream}
@@ -57,6 +58,7 @@ object EventStreamer {
                    .readFileMultipart(bucket, path.toString)
                    .through(text.utf8.decode)
                    .through(text.lines)
+                   .filter(_.nonEmpty)
       } yield lines
 
     override def fileList(path: Path): IO[List[Path]] =
@@ -73,7 +75,7 @@ object EventStreamer {
   def localStreamer: EventStreamer = new EventStreamer {
 
     override def streamLines(path: Path): Stream[IO, String] =
-      Files[IO].readUtf8Lines(path)
+      StreamingUtils.readLines(path)
 
     override def fileList(path: Path): IO[List[Path]] =
       Files[IO].list(path).compile.toList


### PR DESCRIPTION
* Partitoning export to files with a maximum number of lines to limit the file size
* Using the start offset as the name of the export file