### PR TITLE
Add synaptome properties, examples and tests

### DIFF
--- a/tests/docker/config/construct-query.sparql
+++ b/tests/docker/config/construct-query.sparql
@@ -152,7 +152,7 @@ CONSTRUCT {
   ?alias  :seed                 ?seed                     .
 
   # Single cell simulations
-  ?alias  :injectionLocation    ?injectionLocation        .
+  ?alias  :injectionLocation    ?injectionLocation        ;
           :recordingLocation    ?recordingLocation        .
 
   ## Bouton density

--- a/tests/docker/config/construct-query.sparql
+++ b/tests/docker/config/construct-query.sparql
@@ -143,16 +143,23 @@ CONSTRUCT {
 
 
   # Object of study
-  ?alias :objectOfStudy     ?objectOfStudyId        .
+  ?alias  :objectOfStudy    ?objectOfStudyId        .
                             ?objectOfStudyId        :identifier  ?objectOfStudyId      ;
                                                     :label       ?objectOfStudyLabel   .
   # Properties specific to types
 
+  # MEModels and Synaptome
+  ?alias  :seed                 ?seed                     .
+
+  # Single cell simulations
+  ?alias  :injectionLocation    ?injectionLocation        .
+          :recordingLocation    ?recordingLocation        .
+
   ## Bouton density
-  ?alias  :boutonDensity   ?boutonDensityBN          .
-                           ?boutonDensityBN          :value       ?boutonDensityValue  ;
-                                                     :unit        ?boutonDensityUnit   ;
-                                                     :label       ?boutonDensityLabel  .
+  ?alias  :boutonDensity        ?boutonDensityBN          .
+                                ?boutonDensityBN          :value       ?boutonDensityValue  ;
+                                                          :unit        ?boutonDensityUnit   ;
+                                                          :label       ?boutonDensityLabel  .
 
   ## Circuit
   ?alias  :circuitType          ?circuitType              ;
@@ -237,6 +244,19 @@ CONSTRUCT {
                                   ?singleNeuronSimulation  :recordingLocation                ?recordingLocation .
                                   ?singleNeuronSimulation  :emodel                           ?singleNeuronSimulationEmodelId .
                                                            ?singleNeuronSimulationEmodelId   :name ?singleNeuronSimulationEmodelName .
+  ## SingleNeuronSynaptome
+  ?alias :singleNeuronSynaptome   ?singleNeuronSynaptome   .
+                                  ?singleNeuronSynaptome   :seed                             ?seed .
+                                  ?singleNeuronSynaptome   :memodel                          ?singleNeuronSynaptomeMEModelId .
+                                                           ?singleNeuronSynaptomeMEModelId   :name ?singleNeuronSynaptomeMEModelName . 
+
+  ## SynaptomeSimulation
+  ?alias :synaptomeSimulation     ?synaptomeSimulation     .
+                                  ?synaptomeSimulation     :injectionLocation                ?injectionLocation .
+                                  ?synaptomeSimulation     :recordingLocation                ?recordingLocation .
+                                  ?synaptomeSimulation     :synaptome                        ?synaptomeId .
+                                                           ?synaptomeId                      :name ?synaptomeName . 
+
 } WHERE {
   VALUES ?id { {resource_id} } .
   BIND( IRI(concat(str(?id), '/', 'alias')) AS ?alias ) .
@@ -537,6 +557,13 @@ CONSTRUCT {
       ) .
   } .
 
+  # MEModels and Synaptome
+  OPTIONAL { ?id  bmo:seed ?seed . } .
+
+  # Simulations
+  OPTIONAL { ?id  bmo:injectionLocation ?injectionLocation  . } .
+  OPTIONAL { ?id  nsg:recordingLocation ?recordingLocation  . } .
+
   # Bouton density
   OPTIONAL {
     ?id  a             nsg:BoutonDensity   ;
@@ -788,18 +815,39 @@ CONSTRUCT {
        OPTIONAL { ?id  bmo:validated ?memodelValidated   . } .
    }
 
-   # SingleNeuronSimulation
+  # SingleNeuronSimulation
   OPTIONAL {
       ?id a bmo:SingleNeuronSimulation .
 
       BIND(BNODE(CONCAT(STR(?id), '/singleNeuronSimulation')) as ?singleNeuronSimulation ) .
 
-      OPTIONAL { ?id  bmo:injectionLocation ?injectionLocation  . } .
-      OPTIONAL { ?id  nsg:recordingLocation ?recordingLocation  . } .
-
       OPTIONAL {
         ?id                                 prov:used    ?singleNeuronSimulationEmodelId .
         ?singleNeuronSimulationEmodelId     schema:name  ?singleNeuronSimulationEmodelName .
+      } .
+  }
+
+  # SingleNeuronSynaptome
+  OPTIONAL {
+      ?id a bmo:SingleNeuronSynaptome.
+
+      BIND(BNODE(CONCAT(STR(?id), '/singleNeuronSynaptome')) as ?singleNeuronSynaptome ) .
+
+      OPTIONAL {
+        ?id                          prov:used    ?singleNeuronSynaptomeMEModelId   .
+        ?singleNeuronSynaptome       schema:name  ?singleNeuronSynaptomeMEModelName .
+      } .
+  }
+
+  # SynaptomeSimulation
+  OPTIONAL {
+      ?id a bmo:SynaptomeSimulation .
+
+      BIND(BNODE(CONCAT(STR(?id), '/synaptomeSimulation')) as ?synaptomeSimulation ) .
+
+      OPTIONAL {
+        ?id                prov:used    ?synaptomeId   .
+        ?synaptomeId       schema:name  ?synaptomeName .
       } .
   }
 }

--- a/tests/docker/config/construct-query.sparql
+++ b/tests/docker/config/construct-query.sparql
@@ -829,13 +829,13 @@ CONSTRUCT {
 
   # SingleNeuronSynaptome
   OPTIONAL {
-      ?id a bmo:SingleNeuronSynaptome.
+      ?id a bmo:SingleNeuronSynaptome .
 
       BIND(BNODE(CONCAT(STR(?id), '/singleNeuronSynaptome')) as ?singleNeuronSynaptome ) .
 
       OPTIONAL {
-        ?id                          prov:used    ?singleNeuronSynaptomeMEModelId   .
-        ?singleNeuronSynaptome       schema:name  ?singleNeuronSynaptomeMEModelName .
+        ?id                                   prov:used    ?singleNeuronSynaptomeMEModelId   .
+        ?singleNeuronSynaptomeMEModelId       schema:name  ?singleNeuronSynaptomeMEModelName .
       } .
   }
 

--- a/tests/src/test/resources/kg/search/data/single-neuron-synaptome.json
+++ b/tests/src/test/resources/kg/search/data/single-neuron-synaptome.json
@@ -30,7 +30,7 @@
         "name": "synaptome_config.json"
       }
     ],
-    "name": "syanptome-model-04",
+    "name": "synaptome-model-04",
     "objectOfStudy": {
       "@id": "http://bbp.epfl.ch/neurosciencegraph/taxonomies/objectsofstudy/singlecells",
       "@type": "nsg:ObjectOfStudy",

--- a/tests/src/test/resources/kg/search/data/single-neuron-synaptome.json
+++ b/tests/src/test/resources/kg/search/data/single-neuron-synaptome.json
@@ -1,0 +1,47 @@
+{
+    "@context": "https://bbp.neuroshapes.org",
+    "@type": "SingleNeuronSynaptome",
+    "@id": "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome",
+    "brainLocation": {
+      "@type": "BrainLocation",
+      "brainRegion": {
+        "@id": "mba:322",
+        "label": "Primary somatosensory area"
+      },
+      "layer": {
+        "@id": "uberon:0005394",
+        "label": "layer 5"
+      }
+    },
+    "description": "desc",
+    "distribution": [
+      {
+        "@type": "DataDownload",
+        "contentSize": {
+          "unitCode": "bytes",
+          "value": 837
+        },
+        "contentUrl": "https://openbluebrain.com/api/nexus/v1/files/7fa6efce-8809-407f-b4a2-ff8b67e24c59/e582af75-0778-4970-b5a7-1b5bfa30448c/https:%2F%2Fopenbluebrain.com%2Fdata%2F7fa6efce-8809-407f-b4a2-ff8b67e24c59%2Fe582af75-0778-4970-b5a7-1b5bfa30448c%2F1fb96ceb-315a-4e40-ab06-3f689aaf824c",
+        "digest": {
+          "algorithm": "SHA-256",
+          "value": "2420a0025da673991ada98fe6f12bd74d51d77aa4720ea1d1f869f49a582a030"
+        },
+        "encodingFormat": "application/json",
+        "name": "synaptome_config.json"
+      }
+    ],
+    "name": "syanptome-model-04",
+    "objectOfStudy": {
+      "@id": "http://bbp.epfl.ch/neurosciencegraph/taxonomies/objectsofstudy/singlecells",
+      "@type": "nsg:ObjectOfStudy",
+      "label": "Single Cell"
+    },
+    "seed": 100,
+    "used": {
+      "@id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/eeeeac3c-6bf1-47ed-ab97-460668eba2d2",
+      "@type": [
+        "Entity",
+        "MEModel"
+      ]
+    }
+  }

--- a/tests/src/test/resources/kg/search/data/single-neuron-synaptome.json
+++ b/tests/src/test/resources/kg/search/data/single-neuron-synaptome.json
@@ -38,7 +38,7 @@
     },
     "seed": 100,
     "used": {
-      "@id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/eeeeac3c-6bf1-47ed-ab97-460668eba2d2",
+      "@id": "https://bbp.epfl.ch/data/memodel",
       "@type": [
         "Entity",
         "MEModel"

--- a/tests/src/test/resources/kg/search/data/synaptome-simulation.json
+++ b/tests/src/test/resources/kg/search/data/synaptome-simulation.json
@@ -1,0 +1,48 @@
+{
+    "@context": "https://bbp.neuroshapes.org",
+    "@id": "https://bbp.epfl.ch/data/synapse/synaptome-simulation",
+    "@type": [
+      "Entity",
+      "SynaptomeSimulation"
+    ],
+    "brainLocation": {
+      "@type": "BrainLocation",
+      "brainRegion": {
+        "@id": "mba:322",
+        "label": "Primary somatosensory area"
+      },
+      "layer": {
+        "@id": "uberon:0005394",
+        "label": "layer 5"
+      }
+    },
+    "description": "sim",
+    "distribution": [
+      {
+        "@type": "DataDownload",
+        "contentSize": {
+          "unitCode": "bytes",
+          "value": 15776294
+        },
+        "contentUrl": "https://openbluebrain.com/api/nexus/v1/files/7fa6efce-8809-407f-b4a2-ff8b67e24c59/e582af75-0778-4970-b5a7-1b5bfa30448c/https%3A%2F%2Fopenbluebrain.com%2Fdata%2F7fa6efce-8809-407f-b4a2-ff8b67e24c59%2Fe582af75-0778-4970-b5a7-1b5bfa30448c%2F9af6a672-aa28-4caa-9c20-9e09410e5800?rev=1",
+        "digest": {
+          "algorithm": "SHA-256",
+          "value": "09a2e5708c7f053b1f36584c5555920e5def11b0753f87cc7690445e36bafd79"
+        },
+        "encodingFormat": "application/json",
+        "name": "simulation-config-synaptome.json"
+      }
+    ],
+    "injectionLocation": "soma[0]",
+    "name": "synatome-sim-05",
+    "recordingLocation": [
+      "soma[0]_0.5",
+      "dend[38]_0.5",
+      "dend[1]_0.4",
+      "apic[53]_0.3"
+    ],
+    "used": {
+      "@id": "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome",
+      "@type": "SingleNeuronSynaptome"
+    }
+  }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
@@ -1144,8 +1144,8 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
       json"""{
                  "synaptomeSimulation": {
                     "injectionLocation": "soma[0]",
-                    "recordingLocation": ["soma[0]_0.5", "dend[38]_0.5", "dend[1]_0.4", "apic[53]_0.3"dendrite.01A", "dendrite.01B"],
-                    "synaptome": { "@id" : "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome", "name" : "syanptome-model-04"}
+                    "recordingLocation": ["soma[0]_0.5", "dend[38]_0.5", "dend[1]_0.4", "apic[53]_0.3", "dendrite.01A", "dendrite.01B"],
+                    "synaptome": { "@id" : "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome", "name" : "synaptome-model-04"}
                   }
                 }"""
 

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
@@ -39,6 +39,8 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
   private val memodelId                         = "https://bbp.epfl.ch/data/memodel"
   private val analysisSuitablememodelId         = "https://bbp.epfl.ch/data/analysis-suitable-memodel"
   private val singleNeuronSimulationId          = "https://bbp.epfl.ch/data/synapse/single-neuron-simulation"
+  private val singleNeuronSynaptomeId           = "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome"
+  private val synaptomeSimulationId             = "https://bbp.epfl.ch/data/synapse/synaptome-simulation"
 
   // the resources that should appear in the search index
   private val mainResources  = List(
@@ -67,7 +69,9 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
     "simulations/simulation-campaign.json",
     "simulations/simulation.json",
     "simulations/analysis-report-simulation.json",
-    "single-neuron-simulation.json"
+    "single-neuron-simulation.json",
+    "single-neuron-synaptome.json",
+    "synaptome-simulation.json"
   )
   private val otherResources = List(
     "article.json",
@@ -1117,6 +1121,35 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
                 }"""
 
     assertOneSource(queryField(singleNeuronSimulationId, "singleNeuronSimulation")) { json =>
+      json should equalIgnoreArrayOrder(expected)
+    }
+  }
+
+  "have the correct single neuron synaptome information" in {
+    val expected =
+      json"""{
+                 "singleNeuronSynaptome": {
+                    "seed": 100,
+                    "memodel": { "@id" : "https://bbp.epfl.ch/data/memodel", "name" : "me-model with status"}
+                  }
+                }"""
+
+    assertOneSource(queryField(singleNeuronSynaptomeId, "singleNeuronSynaptome")) { json =>
+      json should equalIgnoreArrayOrder(expected)
+    }
+  }
+
+  "have the correct synaptome simulation information" in {
+    val expected =
+      json"""{
+                 "synaptomeSimulation": {
+                    "injectionLocation": "soma[0]",
+                    "recordingLocation": ["soma[0]_0.5", "dend[38]_0.5", "dend[1]_0.4", "apic[53]_0.3"dendrite.01A", "dendrite.01B"],
+                    "synaptome": { "@id" : "https://bbp.epfl.ch/data/single-neuron-synaptome", "name" : "syanptome-model-04"}
+                  }
+                }"""
+
+    assertOneSource(queryField(synaptomeSimulationId, "singleNeuronSimulation")) { json =>
       json should equalIgnoreArrayOrder(expected)
     }
   }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
@@ -1144,7 +1144,7 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
       json"""{
                  "synaptomeSimulation": {
                     "injectionLocation": "soma[0]",
-                    "recordingLocation": ["soma[0]_0.5", "dend[38]_0.5", "dend[1]_0.4", "apic[53]_0.3", "dendrite.01A", "dendrite.01B"],
+                    "recordingLocation": ["soma[0]_0.5", "dend[38]_0.5", "dend[1]_0.4", "apic[53]_0.3"],
                     "synaptome": { "@id" : "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome", "name" : "synaptome-model-04"}
                   }
                 }"""

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
@@ -1149,7 +1149,7 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
                   }
                 }"""
 
-    assertOneSource(queryField(synaptomeSimulationId, "singleNeuronSimulation")) { json =>
+    assertOneSource(queryField(synaptomeSimulationId, "synaptomeSimulation")) { json =>
       json should equalIgnoreArrayOrder(expected)
     }
   }

--- a/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
+++ b/tests/src/test/scala/ch/epfl/bluebrain/nexus/tests/kg/SearchConfigIndexingSpec.scala
@@ -1145,7 +1145,7 @@ class SearchConfigIndexingSpec extends BaseIntegrationSpec {
                  "synaptomeSimulation": {
                     "injectionLocation": "soma[0]",
                     "recordingLocation": ["soma[0]_0.5", "dend[38]_0.5", "dend[1]_0.4", "apic[53]_0.3"dendrite.01A", "dendrite.01B"],
-                    "synaptome": { "@id" : "https://bbp.epfl.ch/data/single-neuron-synaptome", "name" : "syanptome-model-04"}
+                    "synaptome": { "@id" : "https://bbp.epfl.ch/data/synapse/single-neuron-synaptome", "name" : "syanptome-model-04"}
                   }
                 }"""
 


### PR DESCRIPTION
I added the properties requested, just be aware that they are indexed with different names:
    SingleNeuronSynaptome:
        used -> .singleNeuronSynaptome.memodel, 
        seed -> .singleNeuronSynaptome.seed
    SynaptomeSimulation:
        used -> synaptomeSimulation.synaptome
        injectionLocation -> synaptomeSimulation.injectionLocation
        recordingLocation  -> synaptomeSimulation.recordingLocation
