### PR TITLE
Edit constraint on trace's encoding format

### DIFF
--- a/tests/docker/config/construct-query.sparql
+++ b/tests/docker/config/construct-query.sparql
@@ -268,11 +268,12 @@ CONSTRUCT {
   FILTER (?type != prov:Entity)
 
   # for Traces, only consider ones that have the nwb encoding format
-  FILTER NOT EXISTS {
-    ?id   a                                            nsg:Trace       ;
-          schema:distribution / schema:encodingFormat  ?encodingFormat .
-    FILTER (?encodingFormat != "application/nwb")
-  }
+  OPTIONAL {
+        ?id a bmo:ExperimentalTrace ;
+        schema:distribution/schema:encodingFormat ?encodingFormat .
+  } .
+
+  FILTER(!bound(?encodingFormat) || ?encodingFormat = "application/nwb") .
 
   ?id  nxv:createdAt   ?createdAt      ;
        nxv:createdBy   ?createdByNode  ;


### PR DESCRIPTION
The current filter will filter out any ExperimentalTrace that has one of its distribution of encoding format something other than `application/nwb`.
In other words, if an ExperimentalTrace has multiple distributions, one being `application/nwb` and another being `application/abf`, the ExperimentalTrace would be filtered out, which is not what we want. The goal is to ensure there is at least one distribution of encoding format `application/nwb`