### PR TITLE
Use EXISTS instead for equality for traces encoding format

### DIFF
--- a/tests/docker/config/construct-query.sparql
+++ b/tests/docker/config/construct-query.sparql
@@ -270,10 +270,8 @@ CONSTRUCT {
   # for Traces, only consider ones that have the nwb encoding format
   OPTIONAL {
         ?id a bmo:ExperimentalTrace ;
-        schema:distribution/schema:encodingFormat ?encodingFormat .
+        FILTER EXISTS {schema:distribution/schema:encodingFormat "application/nwb"}
   } .
-
-  FILTER(!bound(?encodingFormat) || ?encodingFormat = "application/nwb") .
 
   ?id  nxv:createdAt   ?createdAt      ;
        nxv:createdBy   ?createdByNode  ;


### PR DESCRIPTION
Replace equality check to an "EXISTS" check, in order to allow more than one encodingFormat value.