### PR TITLE
Remove explicit content length header

### DIFF
--- a/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutesSpec.scala
+++ b/delta/plugins/storage/src/test/scala/ch/epfl/bluebrain/nexus/delta/plugins/storage/files/routes/FilesRoutesSpec.scala
@@ -658,8 +658,6 @@ class FilesRoutesSpec
               header("Content-Disposition").value.value() shouldEqual
                 s"""attachment; filename="=?UTF-8?B?${base64encode(id)}?=""""
               response.asString shouldEqual content
-              val attr = attributes(id)
-              response.header[`Content-Length`].value shouldEqual `Content-Length`(attr.bytes)
               response.expectConditionalCacheHeaders
               response.headers should contain(varyHeader)
             }

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/FileResponse.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/FileResponse.scala
@@ -1,6 +1,5 @@
 package ch.epfl.bluebrain.nexus.delta.sdk.directives
 
-import akka.http.scaladsl.model.headers.`Content-Length`
 import akka.http.scaladsl.model.{ContentType, HttpHeader, StatusCode, StatusCodes}
 import cats.effect.IO
 import cats.syntax.all._

--- a/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/FileResponse.scala
+++ b/delta/sdk/src/main/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/FileResponse.scala
@@ -45,8 +45,7 @@ object FileResponse {
     implicit def fileResponseMetadataHttpResponseFields: HttpResponseFields[Metadata] =
       new HttpResponseFields[Metadata] {
         override def statusFrom(value: Metadata): StatusCode       = StatusCodes.OK
-        override def headersFrom(value: Metadata): Seq[HttpHeader] =
-          value.bytes.map { bytes => `Content-Length`(bytes) }.toSeq
+        override def headersFrom(value: Metadata): Seq[HttpHeader] = Seq.empty
 
         override def entityTag(value: Metadata): Option[String] = value.etag
       }

--- a/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToJsonLdSpec.scala
+++ b/delta/sdk/src/test/scala/ch/epfl/bluebrain/nexus/delta/sdk/directives/ResponseToJsonLdSpec.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.delta.sdk.directives
 
 import akka.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
 import akka.http.scaladsl.model.MediaRanges.`*/*`
-import akka.http.scaladsl.model.headers.{`Content-Length`, Accept}
+import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.model.{ContentType, StatusCodes}
 import akka.http.scaladsl.server.RouteConcatenation
 import akka.stream.scaladsl.Source
@@ -73,7 +73,6 @@ class ResponseToJsonLdSpec extends CatsEffectSpec with RouteHelpers with JsonSyn
         status shouldEqual StatusCodes.OK
         contentType shouldEqual `text/plain(UTF-8)`
         response.asString shouldEqual FileContents
-        response.header[`Content-Length`].value shouldEqual `Content-Length`(1024L)
         response.expectConditionalCacheHeaders
       }
     }


### PR DESCRIPTION
The explicit header is ignored by Akka and trigger warnings:
```
Explicitly set HTTP header 'Content-Length: 4394' is ignored, explicit `Content-Length` header is not allowed. Use the appropriate HttpEntity subtype.
```