### PR TITLE
Changing the patching strategy for contentUrl, atLocation.location and url

### DIFF
--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/config/FileProcessingConfig.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/config/FileProcessingConfig.scala
@@ -11,7 +11,7 @@ final case class FileProcessingConfig(
     importBucket: String,
     targetBucket: String,
     prefix: Option[Path],
-    locationPrefixToStripOpt: Option[Uri],
+    locationPrefixToStrip: Option[Uri],
     skipFileEvents: Boolean,
     mediaTypeDetector: MediaTypeDetectorConfig
 )

--- a/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/SourcePatcher.scala
+++ b/ship/src/main/scala/ch/epfl/bluebrain/nexus/ship/resources/SourcePatcher.scala
@@ -64,7 +64,7 @@ object SourcePatcher {
         projectMapper,
         iriPatcher,
         targetBase,
-        config.files.locationPrefixToStripOpt,
+        config.files.locationPrefixToStrip,
         fetchFileAttributes
       )
     new SourcePatcher(distributionPatcher, iriPatcher)

--- a/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/DistributionPatcherSuite.scala
+++ b/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/DistributionPatcherSuite.scala
@@ -260,7 +260,7 @@ class DistributionPatcherSuite extends NexusSuite {
       .map(distrubutionDigest)
       .assertEquals(jobj"""{
                             "algorithm": "SHA-256",
-                            "value": "${digest}"
+                            "value": "$digest"
                           }""")
   }
 
@@ -279,7 +279,7 @@ class DistributionPatcherSuite extends NexusSuite {
     patcher.patchAll(input).assertEquals(expected)
   }
 
-  test("Patch and strip the distribution location when it matches the given prefix") {
+  test("Patch and strip the distribution location when it matches the given prefix leaving the url undefined ") {
     val input =
       json"""{
         "distribution": {
@@ -289,10 +289,40 @@ class DistributionPatcherSuite extends NexusSuite {
         }
       }"""
 
-    patcher
-      .patchAll(input)
-      .map(distributionLocation)
-      .assertEquals("file:///project/a/b/c/d/file.txt")
+    val expected = json"""{
+        "distribution": {
+          "atLocation": {
+            "location": "file:///project/a/b/c/d/file.txt"
+          }
+        }
+      }"""
+
+    patcher.patchAll(input).assertEquals(expected)
+  }
+
+  test(
+    "Patch and strip the distribution location when it matches the given prefix, setting the url to the same value"
+  ) {
+    val input =
+      json"""{
+        "distribution": {
+          "url": "XXX",
+          "atLocation": {
+            "location": "file:///location_to_strip/project/a/b/c/d/file.txt"
+          }
+        }
+      }"""
+
+    val expected = json"""{
+        "distribution": {
+          "url": "file:///project/a/b/c/d/file.txt",
+          "atLocation": {
+            "location": "file:///project/a/b/c/d/file.txt"
+          }
+        }
+      }"""
+
+    patcher.patchAll(input).assertEquals(expected)
   }
 
   private def distributionContentSize(json: Json): JsonObject = {

--- a/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/DistributionPatcherSuite.scala
+++ b/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/DistributionPatcherSuite.scala
@@ -279,7 +279,7 @@ class DistributionPatcherSuite extends NexusSuite {
     patcher.patchAll(input).assertEquals(expected)
   }
 
-  test("Patch and strip the distribution location when it matches the given prefix leaving the url undefined ") {
+  test("Patch and strip the distribution location when it matches the prefix leaving the url undefined ") {
     val input =
       json"""{
         "distribution": {
@@ -301,7 +301,7 @@ class DistributionPatcherSuite extends NexusSuite {
   }
 
   test(
-    "Patch and strip the distribution location when it matches the given prefix, setting the url to the same value"
+    "Patch and strip the distribution location when it matches the prefix, setting the url to the same value"
   ) {
     val input =
       json"""{
@@ -323,6 +323,19 @@ class DistributionPatcherSuite extends NexusSuite {
       }"""
 
     patcher.patchAll(input).assertEquals(expected)
+  }
+
+  test("Do not patch the location or the url if the distribution location when it does not match the prefix") {
+    val input =
+      json"""{
+        "distribution": {
+          "atLocation": {
+            "location": "file:///some/other/location/project/a/b/c/d/file.txt"
+          }
+        }
+      }"""
+
+    patcher.patchAll(input).assertEquals(input)
   }
 
   private def distributionContentSize(json: Json): JsonObject = {

--- a/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/DistributionPatcherSuite.scala
+++ b/ship/src/test/scala/ch/epfl/bluebrain/nexus/ship/resources/DistributionPatcherSuite.scala
@@ -279,13 +279,11 @@ class DistributionPatcherSuite extends NexusSuite {
     patcher.patchAll(input).assertEquals(expected)
   }
 
-  test("Patch and strip the distribution location when it matches the prefix leaving the url undefined ") {
+  test("Patch and strip the distribution contentUrl when it matches the prefix and set the value to location and url") {
     val input =
       json"""{
         "distribution": {
-          "atLocation": {
-            "location": "file:///location_to_strip/project/a/b/c/d/file.txt"
-          }
+          "contentUrl": "file:///location_to_strip/project/a/b/c/d/file.txt"
         }
       }"""
 
@@ -293,16 +291,27 @@ class DistributionPatcherSuite extends NexusSuite {
         "distribution": {
           "atLocation": {
             "location": "file:///project/a/b/c/d/file.txt"
-          }
+          },
+          "contentUrl": "file:///project/a/b/c/d/file.txt",
+          "url": "file:///project/a/b/c/d/file.txt"
         }
       }"""
 
     patcher.patchAll(input).assertEquals(expected)
   }
 
-  test(
-    "Patch and strip the distribution location when it matches the prefix, setting the url to the same value"
-  ) {
+  test("Do not patch the distribution contentUrl when it does not match the prefix") {
+    val input =
+      json"""{
+        "distribution": {
+          "contentUrl": "file:///some/other/location/project/a/b/c/d/file.txt"
+        }
+      }"""
+
+    patcher.patchAll(input).assertEquals(input)
+  }
+
+  test("Patch and strip the distribution location when it matches the prefix, setting the url to the same value") {
     val input =
       json"""{
         "distribution": {


### PR DESCRIPTION
When `contentUrl` matches the defined prefix
* Strip the prefix from its value
* Apply the patched value to `contentUrl`, `atLocation.location` and `url`

If not. fallback to `atLocation.location`:
* Strip the prefix from its value
* Apply the patched value to `atLocation.location` and `url`
